### PR TITLE
Add iptables FORWARD rules

### DIFF
--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -75,14 +75,29 @@ if [ "${OUTGOINGS}" ] ; then
    for int in ${ints}
    do
       echo "Setting iptables for outgoing traffics on ${int}..."
+
       iptables -t nat -D POSTROUTING -s ${SUBNET}/24 -o ${int} -j MASQUERADE > /dev/null 2>&1 || true
       iptables -t nat -A POSTROUTING -s ${SUBNET}/24 -o ${int} -j MASQUERADE
+
+      iptables -D FORWARD -i ${int} -o ${INTERFACE} -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+      iptables -A FORWARD -i ${int} -o ${INTERFACE} -m state --state RELATED,ESTABLISHED -j ACCEPT
+
+      iptables -D FORWARD -i ${INTERFACE} -o ${int} -j ACCEPT > /dev/null 2>&1 || true
+      iptables -A FORWARD -i ${INTERFACE} -o ${int} -j ACCEPT
    done
 else
    echo "Setting iptables for outgoing traffics on all interfaces..."
+
    iptables -t nat -D POSTROUTING -s ${SUBNET}/24 -j MASQUERADE > /dev/null 2>&1 || true
    iptables -t nat -A POSTROUTING -s ${SUBNET}/24 -j MASQUERADE
+
+   iptables -D FORWARD -o ${INTERFACE} -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+   iptables -A FORWARD -o ${INTERFACE} -m state --state RELATED,ESTABLISHED -j ACCEPT
+
+   iptables -D FORWARD -i ${INTERFACE} -j ACCEPT > /dev/null 2>&1 || true
+   iptables -A FORWARD -i ${INTERFACE} -j ACCEPT
 fi
+
 echo "Configuring DHCP server .."
 
 cat > "/etc/dhcpd.conf" <<EOF

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -60,7 +60,7 @@ echo "NAT settings ip_dynaddr, ip_forward"
 
 
 for i in ip_dynaddr ip_forward ; do
-  if [ $(cat /proc/sys/net/ipv4/$i) ]; then
+  if [ $(cat /proc/sys/net/ipv4/$i) -eq 1 ] ; then
     echo $i already 1
   else
     echo "1" > /proc/sys/net/ipv4/$i


### PR DESCRIPTION
In some cases, iptables `FORWARD` chain has `DROP` policy, and any packets from WiFi interface will never get to outgoing interface and vice versa. Adding `FORWARD` rules explicitly should fix this issue.