### PR TITLE
DHCP daemon should start on specified interface

### DIFF
--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -111,7 +111,7 @@ subnet ${SUBNET} netmask 255.255.255.0 {
 EOF
 
 echo "Starting DHCP server .."
-dhcpd wlan0
+dhcpd ${INTERFACE}
 
 # Capture external docker signals
 trap 'true' SIGINT


### PR DESCRIPTION
Fix to ensure that dhcpd starts on the interface specified by the
docker environment vars