### PR TITLE
Fixed AP_ADDR typo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,20 +2,20 @@ IMGNAME = rpi-hostap
 VERSION = $(shell grep "ENV VERSION" Dockerfile| awk 'NF>1{print $$NF}')
 SUBNET  = 192.168.254.0
 APADDR  = 192.168.254.1
-.PHONY: all build test taglatest  
+.PHONY: all build test taglatest
 
 all: build test
 
 build:
 	@docker build -t $(IMGNAME):$(VERSION) --rm . && echo Buildname: $(IMGNAME):$(VERSION)
 test:
-	@sudo /sbin/ifconfig wlan0 $(APADDR)/24 down 
-	@sudo /sbin/ifconfig wlan0 $(APADDR)/24 up 
+	@sudo /sbin/ifconfig wlan0 $(APADDR)/24 down
+	@sudo /sbin/ifconfig wlan0 $(APADDR)/24 up
 	sudo docker run -t \
         --name $(IMGNAME)_test \
 	-e INTERFACE=wlan0 \
 	-e SSID=testssid \
-	-e APADDR=$(APADDR) \
+	-e AP_ADDR=$(APADDR) \
 	-e SUBNET=$(SUBNET) \
 	-e SSID=testssid \
 	-e CHANNEL=6 \
@@ -27,32 +27,32 @@ test:
 	--rm \
 	$(IMGNAME):$(VERSION) \
         /bin/test.sh || sudo docker stop $(IMGNAME)_test && docker rm $(IMGNAME)_test
-run: 
-	@sudo /sbin/ifconfig wlan0 $(APADDR)/24 down 
-	@sudo /sbin/ifconfig wlan0 $(APADDR)/24 up 
+run:
+	@sudo /sbin/ifconfig wlan0 $(APADDR)/24 down
+	@sudo /sbin/ifconfig wlan0 $(APADDR)/24 up
 	sudo docker run -d -t \
         --name $(IMGNAME)_run \
 	-e INTERFACE=wlan0 \
 	-e CHANNEL=6 \
 	-e SSID=runssid \
-	-e APADDR=$(APADDR) \
+	-e AP_ADDR=$(APADDR) \
 	-e SUBNET=$(SUBNET) \
 	-e WPA_PASSPHRASE=passw0rd \
 	-e OUTGOINGS=eth0 \
 	--privileged \
 	--net host \
-	$(IMGNAME):$(VERSION) 
+	$(IMGNAME):$(VERSION)
 stop:
 	@docker stop $(IMGNAME)_test || docker stop $(IMGNAME)_run || docker stop $(IMGNAME)_shell
 	@docker rm $(IMGNAME)_test || docker rm $(IMGNAME)_run || docker rm $(IMGNAME)_shell
 shell:
-	@sudo /sbin/ifconfig wlan0 $(APADDR)/24 down 
-	@sudo /sbin/ifconfig wlan0 $(APADDR)/24 up 
+	@sudo /sbin/ifconfig wlan0 $(APADDR)/24 down
+	@sudo /sbin/ifconfig wlan0 $(APADDR)/24 up
 	@sudo docker run -t \
         --name $(IMGNAME)_shell \
 	-e INTERFACE=wlan0 \
 	-e SSID=shellssid \
-	-e APADDR=$(APADDR) \
+	-e AP_ADDR=$(APADDR) \
 	-e SUBNET=$(SUBNET) \
 	-e WPA_PASSPHRASE=passw0rd \
 	-e OUTGOINGS=eth0 \

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-# Docker container stack: hostap + dhcp server 
+# Docker container stack: hostap + dhcp server
 
 Designed to work on **Raspberry Pi** (arm) using as base image alpine linux (very little size).
 
 # Idea
 
 
-Since my last change on ISP, they put a cable modem with a horrible Wireless, it drops lots of packets, and I didn't want to put an extra AP or wireless router. 
+Since my last change on ISP, they put a cable modem with a horrible Wireless, it drops lots of packets, and I didn't want to put an extra AP or wireless router.
 
 Most of the time use wireless devices on same room so I decided to try to convert my current Pi on a small Access Point using a small USB dongle.
 
@@ -57,7 +57,7 @@ sudo docker run -d -t \
   -e INTERFACE=wlan0 \
   -e CHANNEL=6 \
   -e SSID=runssid \
-  -e APADDR=192.168.254.1 \
+  -e AP_ADDR=192.168.254.1 \
   -e SUBNET=192.168.254.0 \
   -e WPA_PASSPHRASE=passw0rd \
   -e OUTGOINGS=eth0 \
@@ -86,7 +86,6 @@ Make sure you are not runing `wpa_supplicant` on your host machine or docker con
 root     22619  0.0  0.4   6616  3700 ?        Ss   22:04   0:00 /sbin/wpa_supplicant -s -B -P /run/wpa_supplicant.wlan0.pid -i wlan0 -D nl80211,wext -C /run/wpa_supplicant
 ```
 
-# Todo 
+# Todo
 
 Improve README.md
-


### PR DESCRIPTION
In Readme and Makefile the ENVVAR is APADDR, in the .sh the expected ENVVAR is AP_ADDR, i've fixed the typo in the Readme and Makefile.