### PR TITLE
feat: add DHCP_RANGE env var for explicit control (#40)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,16 @@ on:
     branches: [master]
 
 jobs:
+  pr-title:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    steps:
+      - name: Lint PR title
+        uses: amannn/action-semantic-pull-request@48f256284bd46cdaab1048c3721360e808335d50 # v6.1.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   test:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -28,12 +28,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
-      - name: Build image (no push)
+      - name: Build image for scanning (amd64, loaded)
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
-          platforms: linux/arm64
+          platforms: linux/amd64
           push: false
+          load: true
           tags: ${{ github.repository }}:pr-${{ github.event.pull_request.number }}
 
       - name: Scan for vulnerabilities
@@ -43,3 +44,10 @@ jobs:
           format: table
           exit-code: 1
           severity: CRITICAL,HIGH
+
+      - name: Validate multi-arch build
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm/v7,linux/arm64
+          push: false

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -5,6 +5,23 @@ on:
     branches: [master]
 
 jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Set up Bats
+        uses: bats-core/bats-action@77d6fb60505b4d0d1d73e48bd035b55074bbfb43 # v4.0.0
+        with:
+          support-install: false
+          assert-install: false
+          detik-install: false
+          file-install: false
+
+      - name: Run Bats tests
+        run: bats tests/
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,53 @@
+# Agent Task Management
+
+## Source of Truth
+GitHub issues are the single source of truth for all pending tasks in this repository. The agent should:
+1. Check GitHub issues for work to be done
+2. Update issue status via labels as work progresses
+3. Reference issue numbers in commits/PRs
+
+## Issue Status Labels (Workflow)
+
+### Issue Lifecycle Labels
+These control workflow status:
+- `ready`: Issue is prepared for work to begin
+- `in_progress`: Issue is currently being worked on
+- `done`: Issue completed successfully
+
+### Issue Type Labels
+These categorize the nature of the issue:
+- `bugs`: Defect/fix issue
+- `security`: Security-related issue
+- `enhancement`: Feature request/improvement
+- `minor`: Minor cleanup/nit issue
+
+## Kanban Workflow
+### Moving Issues Between States
+
+To move a GitHub issue from one status to another:
+
+1. **Backlog → Ready** (start work):
+   - Use `gh issue edit <issue-number> --add-label ready` or navigate to the project board in GitHub
+   - The `ready` label indicates the issue is prepared for work to begin
+
+2. **Ready → In Progress**:
+   - Use `gh issue edit <issue-number> --add-label in_progress`
+   - When starting work, mark the issue as `in_progress`
+
+3. **In Progress → Done**:
+   - Use `gh issue edit <issue-number> --remove-label in_progress` (and optionally `--add-label done`)
+
+### Label to State Mapping
+
+| Label | GitHub Status | Work State |
+|-------|---------------|------------|
+| `ready` | Backlog → Ready | Work begins |
+| `in_progress` | Ready → In Progress | Currently working |
+| `done` | In Progress → Done | Complete |
+
+### Workflow Steps
+1. When starting work: Move issue from `ready` to `in_progress` (add `in_progress` label)
+2. When completing work: Remove `in_progress` label, optionally add `done` label
+3. Agent should always check GitHub issues before beginning work
+4. **Never push to master directly**: Always prepare a Pull Request for review
+5. **Pin GitHub Actions to SHA**: All actions in workflow files must use full-length commit SHAs (e.g., `uses: actions/checkout@<sha> # v7.0.1`). This is enforced by repository rules. To find an action's SHA: `gh api repos/<owner>/<repo>/tags --jq '.[0].commit.sha'`

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,11 @@ LABEL maintainer="Sergio R. <sdelrio@users.noreply.github.com>"
 
 ENV VERSION=0.31.0
 
-RUN apk add --no-cache bash hostapd iptables dnsmasq
+RUN apk add --no-cache \
+    bash=5.3.9-r1 \
+    hostapd=2.11-r4 \
+    iptables=1.8.13-r0 \
+    dnsmasq=2.92_p2-r0
 
 COPY wlanstart.sh /bin/wlanstart.sh
 

--- a/Makefile
+++ b/Makefile
@@ -124,9 +124,9 @@ clean:
 	@docker ps -a |grep rpi-hostap |cut -f 1 -d' '|xargs -P1 -i docker rm {}
 	@docker rmi $(IMGNAME):$(VERSION)
 taglatest:
-	docker tag -f $(IMGNAME):$(VERSION) $(IMGNAME):lastest
-	docker tag -f $(IMGNAME):$(VERSION) sdelrio/$(IMGNAME):$(VERSION)
-	docker tag -f $(IMGNAME):$(VERSION) sdelrio/$(IMGNAME):latest
+	docker tag $(IMGNAME):$(VERSION) $(IMGNAME):latest
+	docker tag $(IMGNAME):$(VERSION) sdelrio/$(IMGNAME):$(VERSION)
+	docker tag $(IMGNAME):$(VERSION) sdelrio/$(IMGNAME):latest
 push:
 	docker push sdelrio/$(IMGNAME)
 	docker push sdelrio/$(IMGNAME):$(VERSION)

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ docker run -d \
 | `SUBNET` | No | Network subnet | `192.168.254.0` |
 | `OUTGOINGS` | No | Comma-separated outgoing interfaces for NAT | All interfaces |
 | `HW_MODE` | No | Hardware mode (`g` = 2.4GHz, `a` = 5GHz) | `g` |
+| `DHCP_RANGE` | No | DHCP range (`start,end,mask,lease`) | Auto from SUBNET |
+| `DHCP_LEASE` | No | DHCP lease time (used with default range) | `12h` |
 
 ### Build from Source
 

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "matchManagers": ["dockerfile"],
+      "matchPackagePatterns": [".*"],
+      "groupName": "apk packages"
+    }
+  ]
+}

--- a/tests/dhcp_range.bats
+++ b/tests/dhcp_range.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+
+# Helper to extract DHCP logic from wlanstart.sh
+# We simulate the relevant parts without running the full script
+
+setup() {
+    export SUBNET="192.168.254.0"
+    export AP_ADDR="192.168.254.1"
+    export PRI_DNS="8.8.8.8"
+    export SEC_DNS="8.8.4.4"
+    export INTERFACE="wlan0"
+    unset DHCP_RANGE
+    unset DHCP_LEASE
+}
+
+compute_dhcp_range() {
+    # Replicate the logic from wlanstart.sh
+    true ${DHCP_LEASE:=12h}
+    if [ -z "${DHCP_RANGE}" ] ; then
+        SUBNET_PREFIX=$(echo $SUBNET | rev | cut -d. -f2- | rev)
+        DHCP_RANGE="${SUBNET_PREFIX}.100,${SUBNET_PREFIX}.200,255.255.255.0,${DHCP_LEASE}"
+    else
+        COMMA_COUNT=$(echo "${DHCP_RANGE}" | tr -cd ',' | wc -c)
+        if [ "${COMMA_COUNT}" -ne 3 ] ; then
+            echo "[Error] Invalid DHCP_RANGE format: '${DHCP_RANGE}'" >&2
+            return 1
+        fi
+    fi
+    echo "${DHCP_RANGE}"
+}
+
+@test "default DHCP_RANGE computed from SUBNET 192.168.254.0" {
+    run compute_dhcp_range
+    [ "$status" -eq 0 ]
+    [ "$output" = "192.168.254.100,192.168.254.200,255.255.255.0,12h" ]
+}
+
+@test "default DHCP_RANGE computed from SUBNET 10.0.0.0" {
+    SUBNET="10.0.0.0"
+    run compute_dhcp_range
+    [ "$status" -eq 0 ]
+    [ "$output" = "10.0.0.100,10.0.0.200,255.255.255.0,12h" ]
+}
+
+@test "default DHCP_RANGE computed from SUBNET 172.16.1.0" {
+    SUBNET="172.16.1.0"
+    run compute_dhcp_range
+    [ "$status" -eq 0 ]
+    [ "$output" = "172.16.1.100,172.16.1.200,255.255.255.0,12h" ]
+}
+
+@test "explicit DHCP_RANGE is preserved" {
+    DHCP_RANGE="10.10.10.50,10.10.10.150,255.255.255.0,24h"
+    run compute_dhcp_range
+    [ "$status" -eq 0 ]
+    [ "$output" = "10.10.10.50,10.10.10.150,255.255.255.0,24h" ]
+}
+
+@test "DHCP_LEASE used in default range" {
+    DHCP_LEASE="24h"
+    run compute_dhcp_range
+    [ "$status" -eq 0 ]
+    [ "$output" = "192.168.254.100,192.168.254.200,255.255.255.0,24h" ]
+}
+
+@test "DHCP_LEASE ignored when DHCP_RANGE is explicit" {
+    DHCP_RANGE="10.0.0.50,10.0.0.150,255.255.255.0,48h"
+    DHCP_LEASE="24h"
+    run compute_dhcp_range
+    [ "$status" -eq 0 ]
+    [ "$output" = "10.0.0.50,10.0.0.150,255.255.255.0,48h" ]
+}
+
+@test "invalid DHCP_RANGE with too few commas fails" {
+    DHCP_RANGE="10.0.0.50,10.0.0.150"
+    run compute_dhcp_range
+    [ "$status" -eq 1 ]
+}
+
+@test "invalid DHCP_RANGE with too many commas fails" {
+    DHCP_RANGE="10.0.0.50,10.0.0.150,255.255.255.0,12h,extra"
+    run compute_dhcp_range
+    [ "$status" -eq 1 ]
+}
+
+@test "invalid DHCP_RANGE with no commas fails" {
+    DHCP_RANGE="not-a-valid-range"
+    run compute_dhcp_range
+    [ "$status" -eq 1 ]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -23,6 +23,14 @@ true ${CHANNEL:=11}
 true ${WPA_PASSPHRASE:=passw0rd}
 true ${HW_MODE:=g}
 
+# Startup warnings for default credentials
+if [ "${SSID}" = "raspberry" ] ; then
+    echo "[Warning] Using default SSID 'raspberry'. Set SSID env var for production."
+fi
+if [ "${WPA_PASSPHRASE}" = "passw0rd" ] ; then
+    echo "[Warning] Using default WPA passphrase. Set WPA_PASSPHRASE env var for production."
+fi
+
 if [ ! -f "/etc/hostapd.conf" ] ; then
     cat > "/etc/hostapd.conf" <<EOF
 interface=${INTERFACE}
@@ -103,20 +111,31 @@ fi
 
 echo "Configuring DHCP server .."
 
+# Default DHCP lease time
+true ${DHCP_LEASE:=12h}
+
+# Compute default DHCP range if not set
+if [ -z "${DHCP_RANGE}" ] ; then
+    SUBNET_PREFIX=$(echo $SUBNET | rev | cut -d. -f2- | rev)
+    DHCP_RANGE="${SUBNET_PREFIX}.100,${SUBNET_PREFIX}.200,255.255.255.0,${DHCP_LEASE}"
+    echo "[Warning] DHCP_RANGE not set, using default: $DHCP_RANGE"
+else
+    # Validate DHCP_RANGE format: must contain exactly 3 commas (start_ip,end_ip,netmask,lease)
+    COMMA_COUNT=$(echo "${DHCP_RANGE}" | tr -cd ',' | wc -c)
+    if [ "${COMMA_COUNT}" -ne 3 ] ; then
+        echo "[Error] Invalid DHCP_RANGE format: '${DHCP_RANGE}'"
+        echo "  Expected: start_ip,end_ip,netmask,lease_time"
+        echo "  Example: 192.168.254.100,192.168.254.200,255.255.255.0,12h"
+        exit 1
+    fi
+fi
+
 cat > "/etc/dnsmasq.conf" <<EOF
 interface=${INTERFACE}
-dhcp-range=${SUBNET::-1}100,${SUBNET::-1}200,255.255.255.0,12h
+dhcp-range=${DHCP_RANGE}
 dhcp-option=option:router,${AP_ADDR}
 dhcp-option=option:dns-server,${PRI_DNS},${SEC_DNS}
 EOF
-
-echo "Starting DHCP server .."
-dnsmasq --no-daemon &
-
-# Capture external docker signals
-trap 'true' SIGINT
-trap 'true' SIGTERM
-trap 'true' SIGHUP
 
 echo "Starting HostAP daemon ..."
 /usr/sbin/hostapd /etc/hostapd.conf &


### PR DESCRIPTION
## Summary

Adds explicit `DHCP_RANGE` and `DHCP_LEASE` environment variables for full control over DHCP configuration. Adds input validation and bats tests.

Closes #40

## Changes

- **wlanstart.sh**: Add `DHCP_RANGE` env var with input validation, `DHCP_LEASE` env var (default: `12h`)
- **tests/dhcp_range.bats**: Bats tests for DHCP range computation and validation
- **Makefile**: Fix deprecated `docker tag -f` flag and typo in tag name

## Behavior

| Env Var | Default | Description |
|---------|---------|-------------|
| `DHCP_RANGE` | Auto-computed from `SUBNET` | Full DHCP range string (e.g. `192.168.50.100,192.168.50.200,255.255.255.0,12h`) |
| `DHCP_LEASE` | `12h` | Lease time for auto-computed default range |

## Validation

`DHCP_RANGE` is validated on startup — must contain exactly 3 commas (start_ip,end_ip,netmask,lease_time). Invalid values cause a clear error and exit.