### PR TITLE
fix: add exit-on-error for dnsmasq and hostapd startup

### DIFF
--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -137,10 +137,26 @@ dhcp-option=option:router,${AP_ADDR}
 dhcp-option=option:dns-server,${PRI_DNS},${SEC_DNS}
 EOF
 
+echo "Starting dnsmasq daemon ..."
+dnsmasq --no-daemon &
+DNSMASQ_PID=$!
+
+if ! kill -0 "${DNSMASQ_PID}" 2>/dev/null ; then
+    echo "[Error] dnsmasq failed to start."
+    exit 1
+fi
+
 echo "Starting HostAP daemon ..."
 /usr/sbin/hostapd /etc/hostapd.conf &
+HOSTAPD_PID=$!
 
-wait $!
+if ! kill -0 "${HOSTAPD_PID}" 2>/dev/null ; then
+    echo "[Error] hostapd failed to start."
+    kill "${DNSMASQ_PID}" 2>/dev/null
+    exit 1
+fi
+
+wait "${DNSMASQ_PID}" "${HOSTAPD_PID}"
 
 echo "Removing iptables rules..."
 


### PR DESCRIPTION
## Summary

This PR fixes the issue where  and  could fail silently without any error reporting.

## Changes

- Start  daemon before  with PID tracking
- Add error checking via  for both daemons
- Wait for both  and 
- Kill  if  fails to start (cleanup orphaned process)
- Properly quote shell variables

## Issue

Closes #30