### PR TITLE
feat: add MAX_STATIONS env var to limit connected clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ docker run -d \
 | `HW_MODE` | No | Hardware mode (`g` = 2.4GHz, `a` = 5GHz) | `g` |
 | `DHCP_RANGE` | No | DHCP range (`start,end,mask,lease`) | Auto from SUBNET |
 | `DHCP_LEASE` | No | DHCP lease time (used with default range) | `12h` |
+| `MAX_STATIONS` | No | Max connected clients (`0` = unlimited) | `0` |
 
 ### Build from Source
 

--- a/tests/max_stations.bats
+++ b/tests/max_stations.bats
@@ -9,6 +9,9 @@ setup() {
 
 compute_max_sta_conf() {
     true ${MAX_STATIONS:=0}
+    if [ "${MAX_STATIONS}" != "0" ] && ! [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
+        echo "[Warning] Invalid MAX_STATIONS '${MAX_STATIONS}'. Must be a non-negative integer. Ignoring."
+    fi
     _MAX_STA_CONF=""
     if [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
         _MAX_STA_CONF="max_num_sta=${MAX_STATIONS}"
@@ -43,16 +46,32 @@ compute_max_sta_conf() {
     [ "$output" = "" ]
 }
 
-@test "negative MAX_STATIONS produces no config line" {
+@test "negative MAX_STATIONS produces warning and no config line" {
     MAX_STATIONS=-5
     run compute_max_sta_conf
     [ "$status" -eq 0 ]
-    [ "$output" = "" ]
+    [[ "$output" == *"Invalid MAX_STATIONS"* ]]
+    [[ "$output" != *"max_num_sta"* ]]
 }
 
-@test "non-numeric MAX_STATIONS produces no config line" {
+@test "non-numeric MAX_STATIONS produces warning and no config line" {
     MAX_STATIONS="abc"
     run compute_max_sta_conf
     [ "$status" -eq 0 ]
-    [ "$output" = "" ]
+    [[ "$output" == *"Invalid MAX_STATIONS"* ]]
+    [[ "$output" != *"max_num_sta"* ]]
+}
+
+@test "MAX_STATIONS=0 does not produce warning" {
+    MAX_STATIONS=0
+    run compute_max_sta_conf
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Invalid"* ]]
+}
+
+@test "MAX_STATIONS=10 does not produce warning" {
+    MAX_STATIONS=10
+    run compute_max_sta_conf
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"Invalid"* ]]
 }

--- a/tests/max_stations.bats
+++ b/tests/max_stations.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+# Helper to extract MAX_STATIONS logic from wlanstart.sh
+
+setup() {
+    unset MAX_STATIONS
+    unset _MAX_STA_CONF
+}
+
+compute_max_sta_conf() {
+    true ${MAX_STATIONS:=0}
+    _MAX_STA_CONF=""
+    if [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
+        _MAX_STA_CONF="max_num_sta=${MAX_STATIONS}"
+    fi
+    echo "${_MAX_STA_CONF}"
+}
+
+@test "default MAX_STATIONS=0 produces no config line" {
+    run compute_max_sta_conf
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "MAX_STATIONS=1 produces max_num_sta=1" {
+    MAX_STATIONS=1
+    run compute_max_sta_conf
+    [ "$status" -eq 0 ]
+    [ "$output" = "max_num_sta=1" ]
+}
+
+@test "MAX_STATIONS=10 produces max_num_sta=10" {
+    MAX_STATIONS=10
+    run compute_max_sta_conf
+    [ "$status" -eq 0 ]
+    [ "$output" = "max_num_sta=10" ]
+}
+
+@test "MAX_STATIONS=0 produces no config line" {
+    MAX_STATIONS=0
+    run compute_max_sta_conf
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "negative MAX_STATIONS produces no config line" {
+    MAX_STATIONS=-5
+    run compute_max_sta_conf
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "non-numeric MAX_STATIONS produces no config line" {
+    MAX_STATIONS="abc"
+    run compute_max_sta_conf
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -31,6 +31,9 @@ fi
 if [ "${WPA_PASSPHRASE}" = "passw0rd" ] ; then
     echo "[Warning] Using default WPA passphrase. Set WPA_PASSPHRASE env var for production."
 fi
+if [ "${MAX_STATIONS}" != "0" ] && ! [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
+    echo "[Warning] Invalid MAX_STATIONS '${MAX_STATIONS}'. Must be a non-negative integer. Ignoring."
+fi
 
 _MAX_STA_CONF=""
 if [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -22,6 +22,7 @@ true ${SSID:=raspberry}
 true ${CHANNEL:=11}
 true ${WPA_PASSPHRASE:=passw0rd}
 true ${HW_MODE:=g}
+true ${MAX_STATIONS:=0}
 
 # Startup warnings for default credentials
 if [ "${SSID}" = "raspberry" ] ; then
@@ -29,6 +30,11 @@ if [ "${SSID}" = "raspberry" ] ; then
 fi
 if [ "${WPA_PASSPHRASE}" = "passw0rd" ] ; then
     echo "[Warning] Using default WPA passphrase. Set WPA_PASSPHRASE env var for production."
+fi
+
+_MAX_STA_CONF=""
+if [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
+    _MAX_STA_CONF="max_num_sta=${MAX_STATIONS}"
 fi
 
 if [ ! -f "/etc/hostapd.conf" ] ; then
@@ -47,6 +53,7 @@ wpa_pairwise=CCMP
 rsn_pairwise=CCMP
 wpa_ptk_rekey=600
 wmm_enabled=1
+${_MAX_STA_CONF}
 
 # Activate channel selection for HT High Througput (802.11an)
 


### PR DESCRIPTION
## Why

Resource-constrained Raspberry Pi devices running this AP container have no way to limit how many clients can associate. An unbounded number of stations can degrade wireless performance, exhaust memory, or cause denial-of-service — especially in public or untrusted environments.

**Issue:** #34

## What

Adds a new `MAX_STATIONS` environment variable that caps the number of clients allowed to connect to the access point.

| Variable | Default | Description |
|:--------:|:-------:|:-----------:|
| `MAX_STATIONS` | `0` | Max connected clients (`0` = unlimited) |

### Behavior

- **`0` (default):** No limit — current behavior preserved.
- **Positive integer:** Injects `max_num_sta=<value>` into `hostapd.conf`, enforcing a hard client cap at the driver level.

### Changes

| File | Change |
|------|--------|
| `wlanstart.sh` | Default `MAX_STATIONS=0`, compute `max_num_sta` config line when > 0 |
| `README.md` | Document `MAX_STATIONS` in Environment Variables table |

### Usage

```bash
# Limit to 10 clients
docker run -e MAX_STATIONS=10 ...

# Unlimited (default, no config needed)
docker run ...
```