### PR TITLE
feat: add HIDE_SSID env var to suppress SSID broadcast

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ docker run -d \
 | `DHCP_RANGE` | No | DHCP range (`start,end,mask,lease`) | Auto from SUBNET |
 | `DHCP_LEASE` | No | DHCP lease time (used with default range) | `12h` |
 | `MAX_STATIONS` | No | Max connected clients (`0` = unlimited) | `0` |
+| `HIDE_SSID` | No | Hide SSID broadcast (`1` = hidden) | `0` |
 
 ### Build from Source
 

--- a/tests/hide_ssid.bats
+++ b/tests/hide_ssid.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+# Helper to extract HIDE_SSID logic from wlanstart.sh
+# Tests the bash parameter expansion: ${HIDE_SSID+"ssid_hidden=${HIDE_SSID}"}
+
+setup() {
+    unset HIDE_SSID
+}
+
+compute_ssid_hidden_line() {
+    # Replicate the bash expansion from wlanstart.sh
+    local result="${HIDE_SSID+"ssid_hidden=${HIDE_SSID}"}"
+    echo "${result}"
+}
+
+@test "HIDE_SSID not set produces no config line" {
+    run compute_ssid_hidden_line
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "HIDE_SSID=1 produces ssid_hidden=1" {
+    HIDE_SSID=1
+    run compute_ssid_hidden_line
+    [ "$status" -eq 0 ]
+    [ "$output" = "ssid_hidden=1" ]
+}
+
+@test "HIDE_SSID=0 produces ssid_hidden=0" {
+    HIDE_SSID=0
+    run compute_ssid_hidden_line
+    [ "$status" -eq 0 ]
+    [ "$output" = "ssid_hidden=0" ]
+}
+
+@test "HIDE_SSID empty string produces ssid_hidden with empty value" {
+    HIDE_SSID=""
+    run compute_ssid_hidden_line
+    [ "$status" -eq 0 ]
+    [ "$output" = "ssid_hidden=" ]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -45,6 +45,7 @@ if [ ! -f "/etc/hostapd.conf" ] ; then
 interface=${INTERFACE}
 ${DRIVER+"driver=${DRIVER}"}
 ssid=${SSID}
+${HIDE_SSID+"ssid_hidden=${HIDE_SSID}"}
 hw_mode=${HW_MODE}
 channel=${CHANNEL}
 wpa=2


### PR DESCRIPTION
## Why

Closes #32

There is no option to hide the SSID broadcast. While not a strong security measure, SSID hiding prevents casual discovery and is a common requirement for private/lab networks.

## What

- Add `HIDE_SSID` environment variable to `wlanstart.sh`
  - When set to `1`, adds `ssid_hidden=1` to hostapd.conf
  - Default behavior (broadcast SSID) preserved when unset
- Document `HIDE_SSID` in README.md environment variables table
- Add bats tests for HIDE_SSID feature (`tests/hide_ssid.bats`)
  - Tests for: unset, set to 1, set to 0, empty string

## Testing

All 27 bats tests pass:

```bash
$ bats tests/*.bats
1..27
ok 1 default DHCP_RANGE computed from SUBNET 192.168.254.0
...
ok 27 both custom values trigger no warnings
```