### PR TITLE
feat: add AP_ISOLATION env var to isolate wireless clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ docker run -d \
 | `DHCP_LEASE` | No | DHCP lease time (used with default range) | `12h` |
 | `MAX_STATIONS` | No | Max connected clients (`0` = unlimited) | `0` |
 | `HIDE_SSID` | No | Hide SSID broadcast (`1` = hidden) | `0` |
+| `AP_ISOLATION` | No | Isolate clients from each other (`1` = enabled) | `0` |
 
 ### Build from Source
 

--- a/tests/ap_isolation.bats
+++ b/tests/ap_isolation.bats
@@ -1,0 +1,41 @@
+#!/usr/bin/env bats
+
+# Helper to extract AP_ISOLATION logic from wlanstart.sh
+# Tests the bash parameter expansion: ${AP_ISOLATION+"ap_isolate=${AP_ISOLATION}"}
+
+setup() {
+    unset AP_ISOLATION
+}
+
+compute_ap_isolation_line() {
+    # Replicate the bash expansion from wlanstart.sh
+    local result="${AP_ISOLATION+"ap_isolate=${AP_ISOLATION}"}"
+    echo "${result}"
+}
+
+@test "AP_ISOLATION not set produces no config line" {
+    run compute_ap_isolation_line
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "AP_ISOLATION=1 produces ap_isolate=1" {
+    AP_ISOLATION=1
+    run compute_ap_isolation_line
+    [ "$status" -eq 0 ]
+    [ "$output" = "ap_isolate=1" ]
+}
+
+@test "AP_ISOLATION=0 produces ap_isolate=0" {
+    AP_ISOLATION=0
+    run compute_ap_isolation_line
+    [ "$status" -eq 0 ]
+    [ "$output" = "ap_isolate=0" ]
+}
+
+@test "AP_ISOLATION empty string produces ap_isolate with empty value" {
+    AP_ISOLATION=""
+    run compute_ap_isolation_line
+    [ "$status" -eq 0 ]
+    [ "$output" = "ap_isolate=" ]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -58,6 +58,7 @@ rsn_pairwise=CCMP
 wpa_ptk_rekey=600
 wmm_enabled=1
 ${_MAX_STA_CONF}
+${AP_ISOLATION+"ap_isolate=${AP_ISOLATION}"}
 
 # Activate channel selection for HT High Througput (802.11an)
 


### PR DESCRIPTION
## Why

Public and guest networks should prevent connected clients from communicating
with each other. Without AP isolation, any device on the network can scan and
reach other devices — a security risk in open or semi-trusted environments.

This addresses **#33**.

## What

Adds an optional `AP_ISOLATION` environment variable that controls the hostapd
`ap_isolate` directive. When set to `1`, connected clients are isolated from
each other at the AP layer (no client-to-client frames are forwarded).

### Changes

| File | Change |
|------|--------|
| `wlanstart.sh` | Added `AP_ISOLATION` to hostapd config generation |
| `README.md` | Documented new env var in the configuration table |
| `tests/ap_isolation.bats` | Added 4 bats tests covering all expansion cases |

### Implementation detail

Uses `+` expansion (not `:+`) so `ap_isolate` is only written to hostapd.conf
when the variable is **explicitly set** — consistent with how `HIDE_SSID` works.
When unset, hostapd defaults to `ap_isolate=0` (clients can communicate).

```bash
# hostapd.conf generation
${AP_ISOLATION+"ap_isolate=${AP_ISOLATION}"}
```

### Usage

```bash
docker run -d \
  --privileged \
  --net host \
  -e INTERFACE=wlan0 \
  -e SSID=MyGuestNetwork \
  -e WPA_PASSPHRASE=changeme \
  -e AP_ISOLATION=1 \
  sdelrio/rpi-hostap:latest
```

### Checklist

- [x] All 31 bats tests pass
- [x] Follows existing patterns (HIDE_SSID, MAX_STATIONS)
- [x] No config noise when env var is unset
- [x] Documentation updated
- [x] Closes #33