### PR TITLE
feat: add HEALTHCHECK to Dockerfile (#36)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,8 @@ RUN apk add --no-cache \
 
 COPY wlanstart.sh /bin/wlanstart.sh
 
+# hadolint ignore=DL3025
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD pidof hostapd > /dev/null && pidof dnsmasq > /dev/null || exit 1
+
 ENTRYPOINT [ "/bin/wlanstart.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,10 +10,13 @@ RUN apk add --no-cache \
     iptables=1.8.13-r0 \
     dnsmasq=2.92_p2-r0
 
-COPY wlanstart.sh /bin/wlanstart.sh
+ENV HEALTHCHECK_START_PERIOD=15
 
-# hadolint ignore=DL3025
+COPY wlanstart.sh /bin/wlanstart.sh
+COPY healthcheck.sh /bin/healthcheck.sh
+RUN chmod +x /bin/healthcheck.sh
+
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-  CMD pidof hostapd > /dev/null && pidof dnsmasq > /dev/null || exit 1
+  CMD ["/bin/healthcheck.sh"]
 
 ENTRYPOINT [ "/bin/wlanstart.sh" ]

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+
+# Health check script for rpi-hostap container
+# Checks if hostapd, dnsmasq are running and the interface is up
+
+# Configurable start period via environment variable (default: 15s)
+START_PERIOD=${HEALTHCHECK_START_PERIOD:-15}
+
+# Get container uptime in seconds
+UPTIME_FILE=${HEALTHCHECK_UPTIME_FILE:-/proc/uptime}
+UPTIME=$(awk '{print int($1)}' "$UPTIME_FILE")
+
+# During start period, return success to give daemons time to initialize
+if [ "$UPTIME" -lt "$START_PERIOD" ]; then
+    exit 0
+fi
+
+# Check if hostapd is running
+if ! pidof hostapd > /dev/null 2>&1; then
+    echo "hostapd is not running" >&2
+    exit 1
+fi
+
+# Check if dnsmasq is running
+if ! pidof dnsmasq > /dev/null 2>&1; then
+    echo "dnsmasq is not running" >&2
+    exit 1
+fi
+
+# Check if the wireless interface is up (if INTERFACE is set)
+if [ -n "$INTERFACE" ]; then
+    if ! ip link show "$INTERFACE" > /dev/null 2>&1; then
+        echo "interface $INTERFACE is not up" >&2
+        exit 1
+    fi
+fi
+
+exit 0

--- a/tests/healthcheck.bats
+++ b/tests/healthcheck.bats
@@ -1,0 +1,72 @@
+#!/usr/bin/env bats
+
+# Tests for healthcheck.sh
+
+setup() {
+    export INTERFACE="wlan0"
+    export HEALTHCHECK_START_PERIOD=15
+    export HEALTHCHECK_UPTIME_FILE=$(mktemp)
+    echo "100.00 100.00" > "$HEALTHCHECK_UPTIME_FILE"
+}
+
+teardown() {
+    rm -f "$HEALTHCHECK_UPTIME_FILE"
+    rm -rf "$BATS_TEST_TMPDIR/bin"
+}
+
+mock_bin() {
+    mkdir -p "$BATS_TEST_TMPDIR/bin"
+    cat > "$BATS_TEST_TMPDIR/bin/$1" <<EOF
+#!/bin/bash
+$2
+EOF
+    chmod +x "$BATS_TEST_TMPDIR/bin/$1"
+    export PATH="$BATS_TEST_TMPDIR/bin:$PATH"
+}
+
+@test "healthcheck script is executable" {
+    [ -x "healthcheck.sh" ]
+}
+
+@test "healthcheck returns 0 during start period" {
+    echo "10.00 10.00" > "$HEALTHCHECK_UPTIME_FILE"
+    run ./healthcheck.sh
+    [ "$status" -eq 0 ]
+}
+
+@test "healthcheck fails when hostapd is not running" {
+    mock_bin pidof 'if [ "$1" = "hostapd" ]; then exit 1; fi; exit 0'
+    run ./healthcheck.sh
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"hostapd is not running"* ]]
+}
+
+@test "healthcheck fails when dnsmasq is not running" {
+    mock_bin pidof 'if [ "$1" = "dnsmasq" ]; then exit 1; fi; exit 0'
+    run ./healthcheck.sh
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"dnsmasq is not running"* ]]
+}
+
+@test "healthcheck fails when interface is down" {
+    mock_bin pidof 'exit 0'
+    mock_bin ip 'if [ "$1" = "link" ] && [ "$2" = "show" ]; then exit 1; fi; exit 0'
+    run ./healthcheck.sh
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"interface wlan0 is not up"* ]]
+}
+
+@test "healthcheck succeeds when all checks pass" {
+    mock_bin pidof 'exit 0'
+    mock_bin ip 'exit 0'
+    run ./healthcheck.sh
+    [ "$status" -eq 0 ]
+}
+
+@test "healthcheck respects HEALTHCHECK_START_PERIOD env var" {
+    export HEALTHCHECK_START_PERIOD=30
+    echo "20.00 20.00" > "$HEALTHCHECK_UPTIME_FILE"
+    mock_bin pidof 'exit 1'
+    run ./healthcheck.sh
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## What

Adds a Docker HEALTHCHECK instruction to the Dockerfile, enabling container orchestrators (Docker Swarm, Kubernetes, ECS) to detect when the AP service has failed inside a running container.

### Changes

- **`healthcheck.sh`**: New script that verifies:
  - `hostapd` process is running
  - `dnsmasq` process is running  
  - Wireless interface is up (if `INTERFACE` env var is set)
  - Respects configurable start period via `HEALTHCHECK_START_PERIOD` env var (default: 15s)

- **Dockerfile**:
  - Adds `HEALTHCHECK` instruction using exec form `CMD ["/bin/healthcheck.sh"]`
  - Exposes `HEALTHCHECK_START_PERIOD` env var for runtime configuration
  - Follows hadolint best practices (no inline shell commands)

- **tests/healthcheck.bats**: Unit tests for the healthcheck script

## Why

Without a `HEALTHCHECK`, container orchestrators cannot automatically detect and remediate a failed AP service. This means:

- **No self-healing**: If hostapd or dnsmasq crashes, the container continues running but is non-functional
- **No visibility**: Orchestrators report the container as "healthy" even when the AP is down
- **No automatic recovery**: Load balancers continue routing traffic to broken containers

### Configuration

Override the start period at runtime:

```bash
# Docker run
docker run -e HEALTHCHECK_START_PERIOD=30s ...

# Docker Compose
healthcheck:
  start_period: 30s
```

## Testing

- Added bats unit tests in `tests/healthcheck.bats`
- Verified hadolint passes with exec form CMD
- Confirmed PR title follows conventional commits

Closes #36