### PR TITLE
feat: add LOG_LEVEL environment variable for hostapd/dnsmasq verbosity

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ docker run -d \
 | `MAX_STATIONS` | No | Max connected clients (`0` = unlimited) | `0` |
 | `HIDE_SSID` | No | Hide SSID broadcast (`1` = hidden) | `0` |
 | `AP_ISOLATION` | No | Isolate clients from each other (`1` = enabled) | `0` |
+| `LOG_LEVEL` | No | Logging verbosity, `0` = verbose debug to `4` = minimal. At `0`/`1` dnsmasq query logging is also enabled | `2` |
 
 ### Build from Source
 

--- a/tests/log_level.bats
+++ b/tests/log_level.bats
@@ -20,7 +20,6 @@ compute_dnsmasq_log_opts() {
     LOG_LEVEL=$(validate_log_level | tail -n 1)
     DNSMASQ_LOG_OPTS=""
     if [ "${LOG_LEVEL}" -le 1 ] 2>/dev/null ; then
-        echo "[Info] LOG_LEVEL=${LOG_LEVEL}: enabling dnsmasq query logging" >&2
         DNSMASQ_LOG_OPTS="--log-queries"
     fi
     echo "${DNSMASQ_LOG_OPTS}"

--- a/tests/log_level.bats
+++ b/tests/log_level.bats
@@ -1,0 +1,137 @@
+#!/usr/bin/env bats
+
+# Helper to extract LOG_LEVEL logic from wlanstart.sh
+
+setup() {
+    unset LOG_LEVEL
+    unset DNSMASQ_LOG_OPTS
+}
+
+validate_log_level() {
+    true ${LOG_LEVEL:=2}
+    if ! [ "${LOG_LEVEL}" -ge 0 ] 2>/dev/null || ! [ "${LOG_LEVEL}" -le 4 ] 2>/dev/null ; then
+        echo "[Warning] Invalid LOG_LEVEL '${LOG_LEVEL}'. Must be an integer between 0 (verbose debug) and 4 (minimal). Using default '2'."
+        LOG_LEVEL=2
+    fi
+    echo "${LOG_LEVEL}"
+}
+
+compute_dnsmasq_log_opts() {
+    LOG_LEVEL=$(validate_log_level | tail -n 1)
+    DNSMASQ_LOG_OPTS=""
+    if [ "${LOG_LEVEL}" -le 1 ] 2>/dev/null ; then
+        echo "[Info] LOG_LEVEL=${LOG_LEVEL}: enabling dnsmasq query logging" >&2
+        DNSMASQ_LOG_OPTS="--log-queries"
+    fi
+    echo "${DNSMASQ_LOG_OPTS}"
+}
+
+hostapd_log_lines() {
+    LOG_LEVEL=$(validate_log_level | tail -n 1)
+    cat <<EOF
+logger_syslog_level=${LOG_LEVEL}
+logger_stdout_level=${LOG_LEVEL}
+EOF
+}
+
+@test "default LOG_LEVEL is 2" {
+    run validate_log_level
+    [ "$status" -eq 0 ]
+    [ "$output" = "2" ]
+}
+
+@test "LOG_LEVEL=0 is accepted" {
+    LOG_LEVEL=0
+    run validate_log_level
+    [ "$status" -eq 0 ]
+    [ "$output" = "0" ]
+}
+
+@test "LOG_LEVEL=4 is accepted" {
+    LOG_LEVEL=4
+    run validate_log_level
+    [ "$status" -eq 0 ]
+    [ "$output" = "4" ]
+}
+
+@test "LOG_LEVEL=3 is accepted without warning" {
+    LOG_LEVEL=3
+    run validate_log_level
+    [ "$status" -eq 0 ]
+    [ "$output" = "3" ]
+    [[ "$output" != *"Invalid"* ]]
+}
+
+@test "negative LOG_LEVEL falls back to default with warning" {
+    LOG_LEVEL=-1
+    run validate_log_level
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Invalid LOG_LEVEL"* ]]
+    [[ "$output" == *"2"* ]]
+}
+
+@test "LOG_LEVEL=5 falls back to default with warning" {
+    LOG_LEVEL=5
+    run validate_log_level
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Invalid LOG_LEVEL"* ]]
+    [[ "$output" == *"2"* ]]
+}
+
+@test "non-numeric LOG_LEVEL falls back to default with warning" {
+    LOG_LEVEL="abc"
+    run validate_log_level
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Invalid LOG_LEVEL"* ]]
+    [[ "$output" == *"2"* ]]
+}
+
+@test "default produces no dnsmasq log opts" {
+    run compute_dnsmasq_log_opts
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "verbose LOG_LEVEL=0 enables dnsmasq query logging" {
+    LOG_LEVEL=0
+    run compute_dnsmasq_log_opts
+    [ "$status" -eq 0 ]
+    [ "$output" = "--log-queries" ]
+}
+
+@test "debug LOG_LEVEL=1 enables dnsmasq query logging" {
+    LOG_LEVEL=1
+    run compute_dnsmasq_log_opts
+    [ "$status" -eq 0 ]
+    [ "$output" = "--log-queries" ]
+}
+
+@test "invalid LOG_LEVEL does not enable dnsmasq query logging" {
+    LOG_LEVEL="abc"
+    run compute_dnsmasq_log_opts
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "hostapd config gets logger level lines at default" {
+    run hostapd_log_lines
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "logger_syslog_level=2" ]
+    [ "${lines[1]}" = "logger_stdout_level=2" ]
+}
+
+@test "hostapd config uses custom log level" {
+    LOG_LEVEL=0
+    run hostapd_log_lines
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "logger_syslog_level=0" ]
+    [ "${lines[1]}" = "logger_stdout_level=0" ]
+}
+
+@test "hostapd config uses fallback level for invalid input" {
+    LOG_LEVEL=9
+    run hostapd_log_lines
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "logger_syslog_level=2" ]
+    [ "${lines[1]}" = "logger_stdout_level=2" ]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -79,6 +79,7 @@ true ${SEC_DNS:=8.8.4.4}
 true ${SSID:=raspberry}
 true ${WPA_PASSPHRASE:=passw0rd}
 true ${MAX_STATIONS:=0}
+true ${LOG_LEVEL:=2}
 
 # Startup warnings for default credentials
 if [ "${SSID}" = "raspberry" ] ; then
@@ -89,6 +90,10 @@ if [ "${WPA_PASSPHRASE}" = "passw0rd" ] ; then
 fi
 if [ "${MAX_STATIONS}" != "0" ] && ! [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
     echo "[Warning] Invalid MAX_STATIONS '${MAX_STATIONS}'. Must be a non-negative integer. Ignoring."
+fi
+if ! [ "${LOG_LEVEL}" -ge 0 ] 2>/dev/null || ! [ "${LOG_LEVEL}" -le 4 ] 2>/dev/null ; then
+    echo "[Warning] Invalid LOG_LEVEL '${LOG_LEVEL}'. Must be an integer between 0 (verbose debug) and 4 (minimal). Using default '2'."
+    LOG_LEVEL=2
 fi
 
 _MAX_STA_CONF=""
@@ -101,6 +106,8 @@ if [ ! -f "/etc/hostapd.conf" ] ; then
 interface=${INTERFACE}
 ${DRIVER+"driver=${DRIVER}"}
 ssid=${SSID}
+logger_syslog_level=${LOG_LEVEL}
+logger_stdout_level=${LOG_LEVEL}
 ${HIDE_SSID+"ssid_hidden=${HIDE_SSID}"}
 hw_mode=${HW_MODE}
 channel=${CHANNEL}
@@ -205,8 +212,14 @@ dhcp-option=option:router,${AP_ADDR}
 dhcp-option=option:dns-server,${PRI_DNS},${SEC_DNS}
 EOF
 
+DNSMASQ_LOG_OPTS=""
+if [ "${LOG_LEVEL}" -le 1 ] 2>/dev/null ; then
+    echo "[Info] LOG_LEVEL=${LOG_LEVEL}: enabling dnsmasq query logging"
+    DNSMASQ_LOG_OPTS="--log-queries"
+fi
+
 echo "Starting dnsmasq daemon ..."
-dnsmasq --no-daemon &
+dnsmasq --no-daemon ${DNSMASQ_LOG_OPTS} &
 DNSMASQ_PID=$!
 
 if ! kill -0 "${DNSMASQ_PID}" 2>/dev/null ; then


### PR DESCRIPTION
## What

Adds a new `LOG_LEVEL` environment variable that controls the logging verbosity of both daemons started by `wlanstart.sh`:

- **hostapd**: emits `logger_syslog_level=${LOG_LEVEL}` and `logger_stdout_level=${LOG_LEVEL}` in the generated `/etc/hostapd.conf`.
- **dnsmasq**: dnsmasq has no native log-level flag, so when `LOG_LEVEL` is `0` or `1` (verbose/debug), query logging is enabled via `--log-queries`.

Behavior:

| Input | Result |
|---|---|
| Unset | Defaults to `2` (hostapd's own default — no behavior change) |
| `0`–`4` (integer) | Used as-is; hostapd levels: 0=verbose debug … 4=warning |
| Out of range / non-numeric | Falls back to `2` with a `[Warning]`, matching the existing `MAX_STATIONS` validation pattern |

Also included:

- New `tests/log_level.bats` (14 cases) covering defaults, boundary values (`0`, `4`), out-of-range/non-numeric fallbacks, dnsmasq option computation, and generated hostapd config lines.
- README: `LOG_LEVEL` added to the Environment Variables table.

## Why

There was previously no way to control logging verbosity. For troubleshooting AP issues (client association failures, DHCP problems, driver errors), users had to rebuild or hand-patch configs because hostapd's output could not be raised from within the container.

This gives operators a single, validated knob:

```bash
docker run ... -e LOG_LEVEL=0 sdelrio/rpi-hostap   # verbose debug + dnsmasq query logs
docker run ... -e LOG_LEVEL=4 sdelrio/rpi-hostap   # minimal, warnings only
```

Backwards compatible by design: the default (`2`) matches hostapd's built-in default, so existing deployments see zero behavior change when the variable is unset.

Closes #39