### PR TITLE
fix: always regenerate /etc/hostapd.conf so env var changes apply

### DIFF
--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -96,8 +96,8 @@ if [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
     _MAX_STA_CONF="max_num_sta=${MAX_STATIONS}"
 fi
 
-if [ ! -f "/etc/hostapd.conf" ] ; then
-    cat > "/etc/hostapd.conf" <<EOF
+# Always regenerate hostapd.conf so env var changes apply between runs
+cat > "/etc/hostapd.conf" <<EOF
 interface=${INTERFACE}
 ${DRIVER+"driver=${DRIVER}"}
 ssid=${SSID}
@@ -126,8 +126,6 @@ ${HT_CAPAB+"ht_capab=${HT_CAPAB}"}
 ${VHT_ENABLED+"ieee80211ac=1"}
 ${VHT_CAPAB+"vht_capab=${VHT_CAPAB}"}
 EOF
-
-fi
 
 # Setup interface and restart DHCP service
 ip link set ${INTERFACE} up


### PR DESCRIPTION
## Summary

Fixes #62.

`/etc/hostapd.conf` was only generated when the file did not already exist, so env var changes (SSID, CHANNEL, LOG_LEVEL, etc.) were silently ignored across runs when the config persisted. Now the config is always regenerated from the environment, matching the behavior of the dnsmasq config.

## Changes

- Removed the `if [ ! -f /etc/hostapd.conf ]` guard and its closing `fi` in `wlanstart.sh`.
