### PR TITLE
fix: quote remaining expansions and use arrays for OUTGOINGS parsing

### DIFF
--- a/tests/cleanup.bats
+++ b/tests/cleanup.bats
@@ -11,7 +11,7 @@ setup() {
 }
 
 load_cleanup() {
-    eval "$(sed -n '/^cleanup()/,/^}/p; /^trap cleanup/p' wlanstart.sh)"
+    eval "$(sed -n '/^parse_outgoings()/,/^}/p; /^cleanup()/,/^}/p; /^trap cleanup/p' wlanstart.sh)"
 }
 
 run_cleanup_mocked() {
@@ -24,7 +24,7 @@ _mock_log() { echo \"\$@\" >> \"$_MOCK_LOG\"; }
 iptables() { _mock_log \"iptables \$@\"; }
 kill() { _mock_log \"kill \$@\"; }
 wait() { _mock_log \"wait \$@\"; }
-$(sed -n '/^cleanup()/,/^}/p' wlanstart.sh)
+$(sed -n '/^parse_outgoings()/,/^}/p; /^cleanup()/,/^}/p' wlanstart.sh)
 INTERFACE=\"$INTERFACE\"
 SUBNET=\"$SUBNET\"
 OUTGOINGS=\"$OUTGOINGS\"
@@ -34,6 +34,28 @@ cleanup
 "
     cat "$mock_log"
     rm -f "$mock_log"
+}
+
+@test "parse_outgoings parses comma-separated interfaces" {
+    load_cleanup
+    OUTGOINGS="eth0,wlan0" parse_outgoings
+    [ "${#ints[@]}" -eq 2 ]
+    [ "${ints[0]}" = "eth0" ]
+    [ "${ints[1]}" = "wlan0" ]
+}
+
+@test "parse_outgoings collapses repeated commas" {
+    load_cleanup
+    OUTGOINGS="eth0,,wlan0," parse_outgoings
+    [ "${#ints[@]}" -eq 2 ]
+    [ "${ints[0]}" = "eth0" ]
+    [ "${ints[1]}" = "wlan0" ]
+}
+
+@test "parse_outgoings yields empty array when OUTGOINGS unset" {
+    load_cleanup
+    OUTGOINGS="" parse_outgoings
+    [ "${#ints[@]}" -eq 0 ]
 }
 
 @test "cleanup function is defined" {

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -10,8 +10,8 @@ cleanup() {
     echo "Removing iptables rules..."
 
     if [ "${OUTGOINGS}" ] ; then
-        ints="$(sed -E 's/,+/ /g' <<<"${OUTGOINGS}")"
-        for int in ${ints} ; do
+        read -r -a ints <<<"$(sed -E 's/,+/ /g' <<<"${OUTGOINGS}")"
+        for int in "${ints[@]}" ; do
             echo "Removing iptables for outgoing traffics on ${int}..."
             iptables -t nat -D POSTROUTING -s "${SUBNET}"/24 -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
             iptables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
@@ -154,10 +154,10 @@ echo "NAT settings ip_dynaddr, ip_forward"
 
 
 for i in ip_dynaddr ip_forward ; do
-  if [ "$(cat /proc/sys/net/ipv4/$i)" -eq 1 ] ; then
-    echo "$i" already 1
+  if [ "$(cat "/proc/sys/net/ipv4/${i}")" -eq 1 ] ; then
+    echo "${i}" already 1
   else
-    echo "1" > /proc/sys/net/ipv4/$i
+    echo "1" > "/proc/sys/net/ipv4/${i}"
   fi
 done
 
@@ -165,8 +165,8 @@ cat /proc/sys/net/ipv4/ip_dynaddr
 cat /proc/sys/net/ipv4/ip_forward
 
 if [ "${OUTGOINGS}" ] ; then
-   ints="$(sed -E 's/,+/ /g' <<<"${OUTGOINGS}")"
-   for int in ${ints}
+   read -r -a ints <<<"$(sed -E 's/,+/ /g' <<<"${OUTGOINGS}")"
+   for int in "${ints[@]}"
    do
       echo "Setting iptables for outgoing traffics on ${int}..."
 

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+parse_outgoings() {
+    ints=()
+    local -a raw
+    local i
+    IFS=',' read -r -a raw <<<"${OUTGOINGS}"
+    for i in "${raw[@]}" ; do
+        [ -n "${i}" ] && ints+=("${i}")
+    done
+}
+
 cleanup() {
     echo "Shutting down..."
     kill "${HOSTAPD_PID}" 2>/dev/null
@@ -10,16 +20,16 @@ cleanup() {
     echo "Removing iptables rules..."
 
     if [ "${OUTGOINGS}" ] ; then
-        read -r -a ints <<<"$(sed -E 's/,+/ /g' <<<"${OUTGOINGS}")"
+        parse_outgoings
         for int in "${ints[@]}" ; do
             echo "Removing iptables for outgoing traffics on ${int}..."
-            iptables -t nat -D POSTROUTING -s "${SUBNET}"/24 -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
+            iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
             iptables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
             iptables -D FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT > /dev/null 2>&1 || true
         done
     else
         echo "Removing iptables for outgoing traffics on all interfaces..."
-        iptables -t nat -D POSTROUTING -s "${SUBNET}"/24 -j MASQUERADE > /dev/null 2>&1 || true
+        iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -j MASQUERADE > /dev/null 2>&1 || true
         iptables -D FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
         iptables -D FORWARD -i "${INTERFACE}" -j ACCEPT > /dev/null 2>&1 || true
     fi
@@ -165,13 +175,13 @@ cat /proc/sys/net/ipv4/ip_dynaddr
 cat /proc/sys/net/ipv4/ip_forward
 
 if [ "${OUTGOINGS}" ] ; then
-   read -r -a ints <<<"$(sed -E 's/,+/ /g' <<<"${OUTGOINGS}")"
+   parse_outgoings
    for int in "${ints[@]}"
    do
       echo "Setting iptables for outgoing traffics on ${int}..."
 
-      iptables -t nat -D POSTROUTING -s "${SUBNET}"/24 -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
-      iptables -t nat -A POSTROUTING -s "${SUBNET}"/24 -o "${int}" -j MASQUERADE
+      iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
+      iptables -t nat -A POSTROUTING -s "${SUBNET}/24" -o "${int}" -j MASQUERADE
 
       iptables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
       iptables -A FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT
@@ -182,8 +192,8 @@ if [ "${OUTGOINGS}" ] ; then
 else
    echo "Setting iptables for outgoing traffics on all interfaces..."
 
-   iptables -t nat -D POSTROUTING -s "${SUBNET}"/24 -j MASQUERADE > /dev/null 2>&1 || true
-   iptables -t nat -A POSTROUTING -s "${SUBNET}"/24 -j MASQUERADE
+   iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -j MASQUERADE > /dev/null 2>&1 || true
+   iptables -t nat -A POSTROUTING -s "${SUBNET}/24" -j MASQUERADE
 
    iptables -D FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
    iptables -A FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT


### PR DESCRIPTION
## Summary

Completes #63. Most expansions were already quoted; this PR fixes the remaining unquoted word-splitting sites:

- Replace the `sed 's/,+/ /g'` string hack with a `parse_outgoings()` helper that builds a proper array via `IFS=',' read -r -a`, filtering empty entries
- Iterate with `"${ints[@]}"` in both the cleanup handler and the setup loop
- Quote `$i` in the `/proc/sys/net/ipv4/` loop paths
- Normalize `"${SUBNET}"/24` → `"${SUBNET}/24"`

Shellcheck passes clean on `wlanstart.sh`.

Closes #63

## Tests

- Fixed `tests/cleanup.bats` helper extraction to include the new `parse_outgoings()` function (previous extraction would have broken)
- Added unit tests for `parse_outgoings`: comma parsing, repeated/empty commas collapsed, empty OUTGOINGS
- Full suite: 76 pass, 0 fail
