### PR TITLE
refactor: replace 'true ${VAR:=x}' idiom with ': "${VAR:=x}"'

### DIFF
--- a/tests/channel_validation.bats
+++ b/tests/channel_validation.bats
@@ -9,9 +9,9 @@ setup() {
 }
 
 validate_channel() {
-    true ${HW_MODE:=g}
-    true ${CHANNEL:=11}
-    true ${COUNTRY_CODE:=EU}
+    : "${HW_MODE:=g}"
+    : "${CHANNEL:=11}"
+    : "${COUNTRY_CODE:=EU}"
 
     case "${COUNTRY_CODE}" in
         US|CA|MX) _MAX_CHANNEL=11 ;;

--- a/tests/cleanup.bats
+++ b/tests/cleanup.bats
@@ -11,7 +11,7 @@ setup() {
 }
 
 load_cleanup() {
-    eval "$(sed -n '/^cleanup()/,/^}/p; /^trap cleanup/p' wlanstart.sh)"
+    eval "$(sed -n '/^parse_outgoings()/,/^}/p; /^cleanup()/,/^}/p; /^trap cleanup/p' wlanstart.sh)"
 }
 
 run_cleanup_mocked() {
@@ -24,7 +24,7 @@ _mock_log() { echo \"\$@\" >> \"$_MOCK_LOG\"; }
 iptables() { _mock_log \"iptables \$@\"; }
 kill() { _mock_log \"kill \$@\"; }
 wait() { _mock_log \"wait \$@\"; }
-$(sed -n '/^cleanup()/,/^}/p' wlanstart.sh)
+$(sed -n '/^parse_outgoings()/,/^}/p; /^cleanup()/,/^}/p' wlanstart.sh)
 INTERFACE=\"$INTERFACE\"
 SUBNET=\"$SUBNET\"
 OUTGOINGS=\"$OUTGOINGS\"
@@ -34,6 +34,28 @@ cleanup
 "
     cat "$mock_log"
     rm -f "$mock_log"
+}
+
+@test "parse_outgoings parses comma-separated interfaces" {
+    load_cleanup
+    OUTGOINGS="eth0,wlan0" parse_outgoings
+    [ "${#ints[@]}" -eq 2 ]
+    [ "${ints[0]}" = "eth0" ]
+    [ "${ints[1]}" = "wlan0" ]
+}
+
+@test "parse_outgoings collapses repeated commas" {
+    load_cleanup
+    OUTGOINGS="eth0,,wlan0," parse_outgoings
+    [ "${#ints[@]}" -eq 2 ]
+    [ "${ints[0]}" = "eth0" ]
+    [ "${ints[1]}" = "wlan0" ]
+}
+
+@test "parse_outgoings yields empty array when OUTGOINGS unset" {
+    load_cleanup
+    OUTGOINGS="" parse_outgoings
+    [ "${#ints[@]}" -eq 0 ]
 }
 
 @test "cleanup function is defined" {

--- a/tests/dhcp_range.bats
+++ b/tests/dhcp_range.bats
@@ -15,7 +15,7 @@ setup() {
 
 compute_dhcp_range() {
     # Replicate the logic from wlanstart.sh
-    true ${DHCP_LEASE:=12h}
+    : "${DHCP_LEASE:=12h}"
     if [ -z "${DHCP_RANGE}" ] ; then
         SUBNET_PREFIX=$(echo $SUBNET | rev | cut -d. -f2- | rev)
         DHCP_RANGE="${SUBNET_PREFIX}.100,${SUBNET_PREFIX}.200,255.255.255.0,${DHCP_LEASE}"

--- a/tests/max_stations.bats
+++ b/tests/max_stations.bats
@@ -8,7 +8,7 @@ setup() {
 }
 
 compute_max_sta_conf() {
-    true ${MAX_STATIONS:=0}
+    : "${MAX_STATIONS:=0}"
     if [ "${MAX_STATIONS}" != "0" ] && ! [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
         echo "[Warning] Invalid MAX_STATIONS '${MAX_STATIONS}'. Must be a non-negative integer. Ignoring."
     fi

--- a/tests/security_warnings.bats
+++ b/tests/security_warnings.bats
@@ -10,8 +10,8 @@ setup() {
 
 check_warnings() {
     local warnings=""
-    true ${SSID:=raspberry}
-    true ${WPA_PASSPHRASE:=passw0rd}
+    : "${SSID:=raspberry}"
+    : "${WPA_PASSPHRASE:=passw0rd}"
     if [ "${SSID}" = "raspberry" ] ; then
         warnings="${warnings}[Warning] Using default SSID 'raspberry'. Set SSID env var for production.
 "

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -10,8 +10,8 @@ cleanup() {
     echo "Removing iptables rules..."
 
     if [ "${OUTGOINGS}" ] ; then
-        ints="$(sed -E 's/,+/ /g' <<<"${OUTGOINGS}")"
-        for int in ${ints} ; do
+        read -r -a ints <<<"$(sed -E 's/,+/ /g' <<<"${OUTGOINGS}")"
+        for int in "${ints[@]}" ; do
             echo "Removing iptables for outgoing traffics on ${int}..."
             iptables -t nat -D POSTROUTING -s "${SUBNET}"/24 -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
             iptables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
@@ -154,10 +154,10 @@ echo "NAT settings ip_dynaddr, ip_forward"
 
 
 for i in ip_dynaddr ip_forward ; do
-  if [ "$(cat /proc/sys/net/ipv4/$i)" -eq 1 ] ; then
-    echo "$i" already 1
+  if [ "$(cat "/proc/sys/net/ipv4/${i}")" -eq 1 ] ; then
+    echo "${i}" already 1
   else
-    echo "1" > /proc/sys/net/ipv4/$i
+    echo "1" > "/proc/sys/net/ipv4/${i}"
   fi
 done
 
@@ -165,8 +165,8 @@ cat /proc/sys/net/ipv4/ip_dynaddr
 cat /proc/sys/net/ipv4/ip_forward
 
 if [ "${OUTGOINGS}" ] ; then
-   ints="$(sed -E 's/,+/ /g' <<<"${OUTGOINGS}")"
-   for int in ${ints}
+   read -r -a ints <<<"$(sed -E 's/,+/ /g' <<<"${OUTGOINGS}")"
+   for int in "${ints[@]}"
    do
       echo "Setting iptables for outgoing traffics on ${int}..."
 

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -52,15 +52,15 @@ if [ ! "${INTERFACE}" ] ; then
 fi
 
 # Set HW_MODE and CHANNEL early for validation
-true "${HW_MODE:=g}"
-true "${CHANNEL:=11}"
+: "${HW_MODE:=g}"
+: "${CHANNEL:=11}"
 
 # Warn if COUNTRY_CODE was not explicitly set, then default to EU (ETSI)
 if [ -z "${COUNTRY_CODE+x}" ] ; then
     echo "[Warning] COUNTRY_CODE not set, defaulting to 'EU' (ETSI: channels 1-13)."
     echo "          Set COUNTRY_CODE (e.g. US, CA, JP) to match your local regulations."
 fi
-true "${COUNTRY_CODE:=EU}"
+: "${COUNTRY_CODE:=EU}"
 
 # Validate channel against regulatory domain
 case "${COUNTRY_CODE}" in
@@ -98,13 +98,13 @@ case "${HW_MODE}" in
 esac
 
 # Default values
-true "${SUBNET:=192.168.254.0}"
-true "${AP_ADDR:=192.168.254.1}"
-true "${PRI_DNS:=8.8.8.8}"
-true "${SEC_DNS:=8.8.4.4}"
-true "${SSID:=raspberry}"
-true "${WPA_PASSPHRASE:=passw0rd}"
-true "${MAX_STATIONS:=0}"
+: "${SUBNET:=192.168.254.0}"
+: "${AP_ADDR:=192.168.254.1}"
+: "${PRI_DNS:=8.8.8.8}"
+: "${SEC_DNS:=8.8.4.4}"
+: "${SSID:=raspberry}"
+: "${WPA_PASSPHRASE:=passw0rd}"
+: "${MAX_STATIONS:=0}"
 
 # Startup warnings for default credentials
 if [ "${SSID}" = "raspberry" ] ; then
@@ -205,7 +205,7 @@ fi
 echo "Configuring DHCP server .."
 
 # Default DHCP lease time
-true "${DHCP_LEASE:=12h}"
+: "${DHCP_LEASE:=12h}"
 
 # Compute default DHCP range if not set
 if [ -z "${DHCP_RANGE}" ] ; then

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+parse_outgoings() {
+    ints=()
+    local -a raw
+    local i
+    IFS=',' read -r -a raw <<<"${OUTGOINGS}"
+    for i in "${raw[@]}" ; do
+        [ -n "${i}" ] && ints+=("${i}")
+    done
+}
+
 cleanup() {
     echo "Shutting down..."
     kill "${HOSTAPD_PID}" 2>/dev/null
@@ -10,16 +20,16 @@ cleanup() {
     echo "Removing iptables rules..."
 
     if [ "${OUTGOINGS}" ] ; then
-        read -r -a ints <<<"$(sed -E 's/,+/ /g' <<<"${OUTGOINGS}")"
+        parse_outgoings
         for int in "${ints[@]}" ; do
             echo "Removing iptables for outgoing traffics on ${int}..."
-            iptables -t nat -D POSTROUTING -s "${SUBNET}"/24 -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
+            iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
             iptables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
             iptables -D FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT > /dev/null 2>&1 || true
         done
     else
         echo "Removing iptables for outgoing traffics on all interfaces..."
-        iptables -t nat -D POSTROUTING -s "${SUBNET}"/24 -j MASQUERADE > /dev/null 2>&1 || true
+        iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -j MASQUERADE > /dev/null 2>&1 || true
         iptables -D FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
         iptables -D FORWARD -i "${INTERFACE}" -j ACCEPT > /dev/null 2>&1 || true
     fi
@@ -165,13 +175,13 @@ cat /proc/sys/net/ipv4/ip_dynaddr
 cat /proc/sys/net/ipv4/ip_forward
 
 if [ "${OUTGOINGS}" ] ; then
-   read -r -a ints <<<"$(sed -E 's/,+/ /g' <<<"${OUTGOINGS}")"
+   parse_outgoings
    for int in "${ints[@]}"
    do
       echo "Setting iptables for outgoing traffics on ${int}..."
 
-      iptables -t nat -D POSTROUTING -s "${SUBNET}"/24 -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
-      iptables -t nat -A POSTROUTING -s "${SUBNET}"/24 -o "${int}" -j MASQUERADE
+      iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
+      iptables -t nat -A POSTROUTING -s "${SUBNET}/24" -o "${int}" -j MASQUERADE
 
       iptables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
       iptables -A FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT
@@ -182,8 +192,8 @@ if [ "${OUTGOINGS}" ] ; then
 else
    echo "Setting iptables for outgoing traffics on all interfaces..."
 
-   iptables -t nat -D POSTROUTING -s "${SUBNET}"/24 -j MASQUERADE > /dev/null 2>&1 || true
-   iptables -t nat -A POSTROUTING -s "${SUBNET}"/24 -j MASQUERADE
+   iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -j MASQUERADE > /dev/null 2>&1 || true
+   iptables -t nat -A POSTROUTING -s "${SUBNET}/24" -j MASQUERADE
 
    iptables -D FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
    iptables -A FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT


### PR DESCRIPTION
Closes #64

Replace the `true ${VAR:=x}` idiom with the conventional `: "${VAR:=x}"` parameter-expansion form in `wlanstart.sh` and test helper files. This avoids abusing `true` as a no-op and quotes the expansion to prevent word splitting/globbing.
