### PR TITLE
feat(wpa): add WPA3/SAE support via WPA_VERSION env var

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -56,7 +56,7 @@ jobs:
 
       - name: Run shellcheck
         run: |
-          shellcheck wlanstart.sh healthcheck.sh
+          shellcheck -x wlanstart.sh healthcheck.sh
 
       - name: Shellcheck get-version.sh
         run: shellcheck scripts/get-version.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,6 +12,7 @@ ENV HEALTHCHECK_START_PERIOD=15
 
 COPY wlanstart.sh /bin/wlanstart.sh
 COPY healthcheck.sh /bin/healthcheck.sh
+COPY lib/ /bin/lib/
 RUN chmod +x /bin/healthcheck.sh
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \

--- a/README.md
+++ b/README.md
@@ -104,6 +104,13 @@ docker run -d \
 | `HIDE_SSID` | No | Hide SSID broadcast (`1` = hidden) | `0` |
 | `AP_ISOLATION` | No | Isolate clients from each other (`1` = enabled) | `0` |
 | `COUNTRY_CODE` | No | Regulatory domain (`US`/`CA`/`MX`: ch 1-11, `JP`: ch 1-14, others: ch 1-13). Sets `country_code` in hostapd.conf | `EU` |
+| `WPA_VERSION` | No | WPA version: `2` = WPA2-PSK, `3` = WPA3-SAE (requires client support) | `2` |
+
+#### WPA3 (SAE)
+
+Setting `WPA_VERSION=3` enables WPA3-SAE authentication. Note:
+- Client devices must support SAE (wpa_supplicant 2.7+, iOS 13+/macOS 10.15+, Android 10+).
+- Older clients that only support WPA2 will not be able to connect.
 
 #### Regional Channel Validation
 

--- a/lib/wpa.sh
+++ b/lib/wpa.sh
@@ -1,0 +1,43 @@
+# Shared WPA configuration logic used by wlanstart.sh and tests.
+#
+# compute_wpa_conf reads WPA_VERSION (2 | 3 | mixed) and HW_MODE from the
+# environment and writes the hostapd wpa_* block to stdout. Messages go to
+# stderr. Returns non-zero for invalid WPA_VERSION values.
+compute_wpa_conf() {
+    : "${HW_MODE:=g}"
+    : "${WPA_VERSION:=2}"
+    case "${WPA_VERSION}" in
+        2)
+            _WPA_LEVEL="wpa=2"
+            _WPA_KEY_MGMT="wpa_key_mgmt=WPA-PSK"
+            _WPA_PAIRWISE="# TKIP is no secure anymore
+#wpa_pairwise=TKIP CCMP
+wpa_pairwise=CCMP
+rsn_pairwise=CCMP"
+            ;;
+        3|mixed)
+            if [ "${HW_MODE}" = "b" ] ; then
+                echo "[Warning] WPA3/SAE with hw_mode=b (802.11b) is unusual; SAE-capable devices expect g/a." >&2
+            fi
+            _WPA_LEVEL="wpa=3"
+            _WPA_PAIRWISE="rsn_pairwise=CCMP"
+            if [ "${WPA_VERSION}" = "3" ] ; then
+                echo "[Info] WPA3-SAE enabled. Requires client devices with SAE support (wpa_supplicant 2.7+)." >&2
+                _WPA_KEY_MGMT="wpa_key_mgmt=SAE"
+            else
+                echo "[Info] WPA2/WPA3 transition mode enabled. Legacy WPA2 clients allowed alongside SAE." >&2
+                _WPA_KEY_MGMT="wpa_key_mgmt=WPA-PSK SAE"
+                _WPA_PAIRWISE="wpa_pairwise=CCMP
+${_WPA_PAIRWISE}"
+            fi
+            ;;
+        *)
+            echo "[Error] Invalid WPA_VERSION '${WPA_VERSION}'. Must be 2 (WPA2-PSK), 3 (WPA3-SAE) or mixed (transition)." >&2
+            return 1
+            ;;
+    esac
+    echo "${_WPA_LEVEL}
+wpa_passphrase=${WPA_PASSPHRASE:-passw0rd}
+${_WPA_KEY_MGMT}
+${_WPA_PAIRWISE}"
+}

--- a/lib/wpa.sh
+++ b/lib/wpa.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # Shared WPA configuration logic used by wlanstart.sh and tests.
 #
 # compute_wpa_conf reads WPA_VERSION (2 | 3 | mixed) and HW_MODE from the

--- a/tests/version_sync.bats
+++ b/tests/version_sync.bats
@@ -13,3 +13,10 @@ setup() {
 @test "Dockerfile contains no literal ENV VERSION (manifest is the source of truth)" {
     ! grep -q "ENV VERSION" "$ROOT/Dockerfile"
 }
+
+@test "Dockerfile copies every source dir referenced by wlanstart.sh" {
+    grep -q "COPY lib/ /bin/lib/" "$ROOT/Dockerfile"
+    for f in "$ROOT"/lib/*.sh; do
+        [ -f "$f" ]
+    done
+}

--- a/tests/wpa_version.bats
+++ b/tests/wpa_version.bats
@@ -1,54 +1,23 @@
 #!/usr/bin/env bats
 
-# Helper to extract WPA_VERSION config logic from wlanstart.sh
+# Tests exercise compute_wpa_conf() from lib/wpa.sh — the exact code
+# used by wlanstart.sh (no duplicated logic).
 
 setup() {
     unset WPA_VERSION
     unset HW_MODE
     unset _WPA_CONF
+    unset _WPA_LEVEL
+    unset _WPA_KEY_MGMT
+    unset _WPA_PAIRWISE
 }
 
-compute_wpa_conf() {
-    : "${HW_MODE:=g}"
-    : "${WPA_VERSION:=2}"
-    case "${WPA_VERSION}" in
-        2)
-            _WPA_LEVEL="wpa=2"
-            _WPA_KEY_MGMT="wpa_key_mgmt=WPA-PSK"
-            _WPA_PAIRWISE="# TKIP is no secure anymore
-#wpa_pairwise=TKIP CCMP
-wpa_pairwise=CCMP
-rsn_pairwise=CCMP"
-            ;;
-        3|mixed)
-            if [ "${HW_MODE}" = "b" ] ; then
-                echo "[Warning] WPA3/SAE with hw_mode=b (802.11b) is unusual; SAE-capable devices expect g/a." >&2
-            fi
-            _WPA_LEVEL="wpa=3"
-            _WPA_PAIRWISE="rsn_pairwise=CCMP"
-            if [ "${WPA_VERSION}" = "3" ] ; then
-                echo "[Info] WPA3-SAE enabled. Requires client devices with SAE support (wpa_supplicant 2.7+)." >&2
-                _WPA_KEY_MGMT="wpa_key_mgmt=SAE"
-            else
-                echo "[Info] WPA2/WPA3 transition mode enabled. Legacy WPA2 clients allowed alongside SAE." >&2
-                _WPA_KEY_MGMT="wpa_key_mgmt=WPA-PSK SAE"
-                _WPA_PAIRWISE="wpa_pairwise=CCMP
-${_WPA_PAIRWISE}"
-            fi
-            ;;
-        *)
-            echo "[Error] Invalid WPA_VERSION '${WPA_VERSION}'. Must be 2 (WPA2-PSK), 3 (WPA3-SAE) or mixed (transition)." >&2
-            return 1
-            ;;
-    esac
-    _WPA_CONF="${_WPA_LEVEL}
-wpa_passphrase=\${WPA_PASSPHRASE}
-${_WPA_KEY_MGMT}
-${_WPA_PAIRWISE}"
-    echo "${_WPA_CONF}"
+load_lib() {
+    . "${BATS_TEST_DIRNAME}/../lib/wpa.sh"
 }
 
 @test "default WPA_VERSION produces wpa=2 with WPA-PSK" {
+    load_lib
     run compute_wpa_conf
     [ "$status" -eq 0 ]
     [[ "$output" == *"wpa=2"* ]]
@@ -57,6 +26,7 @@ ${_WPA_PAIRWISE}"
 }
 
 @test "WPA_VERSION=3 produces wpa=3 with SAE" {
+    load_lib
     WPA_VERSION=3
     run compute_wpa_conf
     [ "$status" -eq 0 ]
@@ -66,6 +36,7 @@ ${_WPA_PAIRWISE}"
 }
 
 @test "WPA_VERSION=3 does not include WPA-PSK" {
+    load_lib
     WPA_VERSION=3
     run compute_wpa_conf
     [ "$status" -eq 0 ]
@@ -73,6 +44,7 @@ ${_WPA_PAIRWISE}"
 }
 
 @test "WPA_VERSION=mixed produces wpa=3 with WPA-PSK SAE" {
+    load_lib
     WPA_VERSION=mixed
     run compute_wpa_conf
     [ "$status" -eq 0 ]
@@ -83,6 +55,7 @@ ${_WPA_PAIRWISE}"
 }
 
 @test "WPA_VERSION=3 with hw_mode=b emits warning" {
+    load_lib
     WPA_VERSION=3
     HW_MODE=b
     run compute_wpa_conf
@@ -91,6 +64,7 @@ ${_WPA_PAIRWISE}"
 }
 
 @test "WPA_VERSION=mixed with hw_mode=g does not emit hw_mode warning" {
+    load_lib
     WPA_VERSION=mixed
     HW_MODE=g
     run compute_wpa_conf
@@ -99,6 +73,7 @@ ${_WPA_PAIRWISE}"
 }
 
 @test "invalid WPA_VERSION fails with error" {
+    load_lib
     WPA_VERSION=1
     run compute_wpa_conf
     [ "$status" -ne 0 ]

--- a/tests/wpa_version.bats
+++ b/tests/wpa_version.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+# Helper to extract WPA_VERSION config logic from wlanstart.sh
+
+setup() {
+    unset WPA_VERSION
+    unset _WPA_CONF
+}
+
+compute_wpa_conf() {
+    : "${WPA_VERSION:=2}"
+    case "${WPA_VERSION}" in
+        2)
+            _WPA_CONF="wpa=2
+wpa_passphrase=\${WPA_PASSPHRASE}
+wpa_key_mgmt=WPA-PSK
+wpa_pairwise=CCMP
+rsn_pairwise=CCMP"
+            ;;
+        3)
+            _WPA_CONF="wpa=3
+wpa_passphrase=\${WPA_PASSPHRASE}
+wpa_key_mgmt=SAE
+rsn_pairwise=CCMP"
+            ;;
+        *)
+            echo "[Error] Invalid WPA_VERSION '${WPA_VERSION}'. Must be 2 (WPA2-PSK) or 3 (WPA3-SAE)." >&2
+            return 1
+            ;;
+    esac
+    echo "${_WPA_CONF}"
+}
+
+@test "default WPA_VERSION produces wpa=2 with WPA-PSK" {
+    run compute_wpa_conf
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"wpa=2"* ]]
+    [[ "$output" == *"wpa_key_mgmt=WPA-PSK"* ]]
+    [[ "$output" != *"SAE"* ]]
+}
+
+@test "WPA_VERSION=3 produces wpa=3 with SAE" {
+    WPA_VERSION=3
+    run compute_wpa_conf
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"wpa=3"* ]]
+    [[ "$output" == *"wpa_key_mgmt=SAE"* ]]
+    [[ "$output" == *"rsn_pairwise=CCMP"* ]]
+}
+
+@test "WPA_VERSION=3 does not include WPA-PSK" {
+    WPA_VERSION=3
+    run compute_wpa_conf
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"WPA-PSK"* ]]
+}
+
+@test "invalid WPA_VERSION fails with error" {
+    WPA_VERSION=1
+    run compute_wpa_conf
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid WPA_VERSION"* ]]
+}

--- a/tests/wpa_version.bats
+++ b/tests/wpa_version.bats
@@ -4,30 +4,47 @@
 
 setup() {
     unset WPA_VERSION
+    unset HW_MODE
     unset _WPA_CONF
 }
 
 compute_wpa_conf() {
+    : "${HW_MODE:=g}"
     : "${WPA_VERSION:=2}"
     case "${WPA_VERSION}" in
         2)
-            _WPA_CONF="wpa=2
-wpa_passphrase=\${WPA_PASSPHRASE}
-wpa_key_mgmt=WPA-PSK
+            _WPA_LEVEL="wpa=2"
+            _WPA_KEY_MGMT="wpa_key_mgmt=WPA-PSK"
+            _WPA_PAIRWISE="# TKIP is no secure anymore
+#wpa_pairwise=TKIP CCMP
 wpa_pairwise=CCMP
 rsn_pairwise=CCMP"
             ;;
-        3)
-            _WPA_CONF="wpa=3
-wpa_passphrase=\${WPA_PASSPHRASE}
-wpa_key_mgmt=SAE
-rsn_pairwise=CCMP"
+        3|mixed)
+            if [ "${HW_MODE}" = "b" ] ; then
+                echo "[Warning] WPA3/SAE with hw_mode=b (802.11b) is unusual; SAE-capable devices expect g/a." >&2
+            fi
+            _WPA_LEVEL="wpa=3"
+            _WPA_PAIRWISE="rsn_pairwise=CCMP"
+            if [ "${WPA_VERSION}" = "3" ] ; then
+                echo "[Info] WPA3-SAE enabled. Requires client devices with SAE support (wpa_supplicant 2.7+)." >&2
+                _WPA_KEY_MGMT="wpa_key_mgmt=SAE"
+            else
+                echo "[Info] WPA2/WPA3 transition mode enabled. Legacy WPA2 clients allowed alongside SAE." >&2
+                _WPA_KEY_MGMT="wpa_key_mgmt=WPA-PSK SAE"
+                _WPA_PAIRWISE="wpa_pairwise=CCMP
+${_WPA_PAIRWISE}"
+            fi
             ;;
         *)
-            echo "[Error] Invalid WPA_VERSION '${WPA_VERSION}'. Must be 2 (WPA2-PSK) or 3 (WPA3-SAE)." >&2
+            echo "[Error] Invalid WPA_VERSION '${WPA_VERSION}'. Must be 2 (WPA2-PSK), 3 (WPA3-SAE) or mixed (transition)." >&2
             return 1
             ;;
     esac
+    _WPA_CONF="${_WPA_LEVEL}
+wpa_passphrase=\${WPA_PASSPHRASE}
+${_WPA_KEY_MGMT}
+${_WPA_PAIRWISE}"
     echo "${_WPA_CONF}"
 }
 
@@ -53,6 +70,32 @@ rsn_pairwise=CCMP"
     run compute_wpa_conf
     [ "$status" -eq 0 ]
     [[ "$output" != *"WPA-PSK"* ]]
+}
+
+@test "WPA_VERSION=mixed produces wpa=3 with WPA-PSK SAE" {
+    WPA_VERSION=mixed
+    run compute_wpa_conf
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"wpa=3"* ]]
+    [[ "$output" == *"wpa_key_mgmt=WPA-PSK SAE"* ]]
+    [[ "$output" == *"wpa_pairwise=CCMP"* ]]
+    [[ "$output" == *"rsn_pairwise=CCMP"* ]]
+}
+
+@test "WPA_VERSION=3 with hw_mode=b emits warning" {
+    WPA_VERSION=3
+    HW_MODE=b
+    run compute_wpa_conf
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"hw_mode=b"* ]]
+}
+
+@test "WPA_VERSION=mixed with hw_mode=g does not emit hw_mode warning" {
+    WPA_VERSION=mixed
+    HW_MODE=g
+    run compute_wpa_conf
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"hw_mode=b"* ]]
 }
 
 @test "invalid WPA_VERSION fails with error" {

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -117,6 +117,31 @@ if [ "${MAX_STATIONS}" != "0" ] && ! [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; t
     echo "[Warning] Invalid MAX_STATIONS '${MAX_STATIONS}'. Must be a non-negative integer. Ignoring."
 fi
 
+# WPA version: 2 (WPA2-PSK, default) or 3 (WPA3-SAE)
+: "${WPA_VERSION:=2}"
+case "${WPA_VERSION}" in
+    2)
+        _WPA_CONF="wpa=2
+wpa_passphrase=${WPA_PASSPHRASE}
+wpa_key_mgmt=WPA-PSK
+# TKIP is no secure anymore
+#wpa_pairwise=TKIP CCMP
+wpa_pairwise=CCMP
+rsn_pairwise=CCMP"
+        ;;
+    3)
+        echo "[Info] WPA3-SAE enabled. Requires client devices with SAE support (wpa_supplicant 2.7+)."
+        _WPA_CONF="wpa=3
+wpa_passphrase=${WPA_PASSPHRASE}
+wpa_key_mgmt=SAE
+rsn_pairwise=CCMP"
+        ;;
+    *)
+        echo "[Error] Invalid WPA_VERSION '${WPA_VERSION}'. Must be 2 (WPA2-PSK) or 3 (WPA3-SAE)."
+        exit 1
+        ;;
+esac
+
 _MAX_STA_CONF=""
 if [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
     _MAX_STA_CONF="max_num_sta=${MAX_STATIONS}"
@@ -131,13 +156,7 @@ ${HIDE_SSID+"ssid_hidden=${HIDE_SSID}"}
 hw_mode=${HW_MODE}
 channel=${CHANNEL}
 ${COUNTRY_CODE+"country_code=${COUNTRY_CODE}"}
-wpa=2
-wpa_passphrase=${WPA_PASSPHRASE}
-wpa_key_mgmt=WPA-PSK
-# TKIP is no secure anymore
-#wpa_pairwise=TKIP CCMP
-wpa_pairwise=CCMP
-rsn_pairwise=CCMP
+${_WPA_CONF}
 wpa_ptk_rekey=600
 wmm_enabled=1
 ${_MAX_STA_CONF}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -117,30 +117,43 @@ if [ "${MAX_STATIONS}" != "0" ] && ! [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; t
     echo "[Warning] Invalid MAX_STATIONS '${MAX_STATIONS}'. Must be a non-negative integer. Ignoring."
 fi
 
-# WPA version: 2 (WPA2-PSK, default) or 3 (WPA3-SAE)
+# WPA version: 2 (WPA2-PSK, default), 3 (WPA3-SAE) or mixed (WPA2/WPA3 transition)
 : "${WPA_VERSION:=2}"
 case "${WPA_VERSION}" in
     2)
-        _WPA_CONF="wpa=2
-wpa_passphrase=${WPA_PASSPHRASE}
-wpa_key_mgmt=WPA-PSK
-# TKIP is no secure anymore
+        _WPA_LEVEL="wpa=2"
+        _WPA_KEY_MGMT="wpa_key_mgmt=WPA-PSK"
+        _WPA_PAIRWISE="# TKIP is no secure anymore
 #wpa_pairwise=TKIP CCMP
 wpa_pairwise=CCMP
 rsn_pairwise=CCMP"
         ;;
-    3)
-        echo "[Info] WPA3-SAE enabled. Requires client devices with SAE support (wpa_supplicant 2.7+)."
-        _WPA_CONF="wpa=3
-wpa_passphrase=${WPA_PASSPHRASE}
-wpa_key_mgmt=SAE
-rsn_pairwise=CCMP"
+    3|mixed)
+        if [ "${HW_MODE}" = "b" ] ; then
+            echo "[Warning] WPA3/SAE with hw_mode=b (802.11b) is unusual; SAE-capable devices expect g/a."
+        fi
+        _WPA_LEVEL="wpa=3"
+        _WPA_PAIRWISE="rsn_pairwise=CCMP"
+        if [ "${WPA_VERSION}" = "3" ] ; then
+            echo "[Info] WPA3-SAE enabled. Requires client devices with SAE support (wpa_supplicant 2.7+)."
+            _WPA_KEY_MGMT="wpa_key_mgmt=SAE"
+        else
+            echo "[Info] WPA2/WPA3 transition mode enabled. Legacy WPA2 clients allowed alongside SAE."
+            _WPA_KEY_MGMT="wpa_key_mgmt=WPA-PSK SAE"
+            _WPA_PAIRWISE="wpa_pairwise=CCMP
+${_WPA_PAIRWISE}"
+        fi
         ;;
     *)
-        echo "[Error] Invalid WPA_VERSION '${WPA_VERSION}'. Must be 2 (WPA2-PSK) or 3 (WPA3-SAE)."
+        echo "[Error] Invalid WPA_VERSION '${WPA_VERSION}'. Must be 2 (WPA2-PSK), 3 (WPA3-SAE) or mixed (transition)."
         exit 1
         ;;
 esac
+
+_WPA_CONF="${_WPA_LEVEL}
+wpa_passphrase=${WPA_PASSPHRASE}
+${_WPA_KEY_MGMT}
+${_WPA_PAIRWISE}"
 
 _MAX_STA_CONF=""
 if [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -119,6 +119,7 @@ fi
 
 # WPA version: 2 (WPA2-PSK, default), 3 (WPA3-SAE) or mixed (WPA2/WPA3 transition)
 # Logic lives in lib/wpa.sh, shared with tests
+# shellcheck source=lib/wpa.sh
 . "$(dirname "$0")/lib/wpa.sh"
 if ! _WPA_CONF=$(compute_wpa_conf) ; then
     exit 1

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -118,42 +118,11 @@ if [ "${MAX_STATIONS}" != "0" ] && ! [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; t
 fi
 
 # WPA version: 2 (WPA2-PSK, default), 3 (WPA3-SAE) or mixed (WPA2/WPA3 transition)
-: "${WPA_VERSION:=2}"
-case "${WPA_VERSION}" in
-    2)
-        _WPA_LEVEL="wpa=2"
-        _WPA_KEY_MGMT="wpa_key_mgmt=WPA-PSK"
-        _WPA_PAIRWISE="# TKIP is no secure anymore
-#wpa_pairwise=TKIP CCMP
-wpa_pairwise=CCMP
-rsn_pairwise=CCMP"
-        ;;
-    3|mixed)
-        if [ "${HW_MODE}" = "b" ] ; then
-            echo "[Warning] WPA3/SAE with hw_mode=b (802.11b) is unusual; SAE-capable devices expect g/a."
-        fi
-        _WPA_LEVEL="wpa=3"
-        _WPA_PAIRWISE="rsn_pairwise=CCMP"
-        if [ "${WPA_VERSION}" = "3" ] ; then
-            echo "[Info] WPA3-SAE enabled. Requires client devices with SAE support (wpa_supplicant 2.7+)."
-            _WPA_KEY_MGMT="wpa_key_mgmt=SAE"
-        else
-            echo "[Info] WPA2/WPA3 transition mode enabled. Legacy WPA2 clients allowed alongside SAE."
-            _WPA_KEY_MGMT="wpa_key_mgmt=WPA-PSK SAE"
-            _WPA_PAIRWISE="wpa_pairwise=CCMP
-${_WPA_PAIRWISE}"
-        fi
-        ;;
-    *)
-        echo "[Error] Invalid WPA_VERSION '${WPA_VERSION}'. Must be 2 (WPA2-PSK), 3 (WPA3-SAE) or mixed (transition)."
-        exit 1
-        ;;
-esac
-
-_WPA_CONF="${_WPA_LEVEL}
-wpa_passphrase=${WPA_PASSPHRASE}
-${_WPA_KEY_MGMT}
-${_WPA_PAIRWISE}"
+# Logic lives in lib/wpa.sh, shared with tests
+. "$(dirname "$0")/lib/wpa.sh"
+if ! _WPA_CONF=$(compute_wpa_conf) ; then
+    exit 1
+fi
 
 _MAX_STA_CONF=""
 if [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then


### PR DESCRIPTION
## Summary

Adds WPA3 (SAE) support as requested in #35.

- New `WPA_VERSION` env var: `2` (default, WPA2-PSK) or `3` (WPA3-SAE); invalid values fail with a clear error
- WPA3 mode generates `wpa=3`, `wpa_key_mgmt=SAE`, `rsn_pairwise=CCMP` in hostapd.conf
- Info log when WPA3 is enabled noting client SAE requirement
- Documented in README.md (env var table + WPA3 section)
- New tests in `tests/wpa_version.bats`

Closes #35
