### PR TITLE
refactor: extract default-credential warnings to shared lib

### DIFF
--- a/lib/warnings.sh
+++ b/lib/warnings.sh
@@ -1,0 +1,14 @@
+# shellcheck shell=bash
+# Shared default-credential warning logic used by wlanstart.sh and tests.
+#
+# emit_credential_warnings reads SSID and WPA_PASSPHRASE from the
+# environment (already defaulted) and prints a warning for each value
+# still at its insecure default.
+emit_credential_warnings() {
+    if [ "${SSID}" = "raspberry" ] ; then
+        echo "[Warning] Using default SSID 'raspberry'. Set SSID env var for production."
+    fi
+    if [ "${WPA_PASSPHRASE}" = "passw0rd" ] ; then
+        echo "[Warning] Using default WPA passphrase. Set WPA_PASSPHRASE env var for production."
+    fi
+}

--- a/tests/security_warnings.bats
+++ b/tests/security_warnings.bats
@@ -1,30 +1,16 @@
-#!/usr/bin/env bats
-
-# Helper to extract credential warning logic from wlanstart.sh
+# Shared credential warning logic from lib/warnings.sh
 
 setup() {
+    . "$(dirname "$BATS_TEST_FILENAME")/../lib/warnings.sh"
     export INTERFACE="wlan0"
     unset SSID
     unset WPA_PASSPHRASE
 }
 
 check_warnings() {
-    local warnings=""
     : "${SSID:=raspberry}"
     : "${WPA_PASSPHRASE:=passw0rd}"
-    if [ "${SSID}" = "raspberry" ] ; then
-        warnings="${warnings}[Warning] Using default SSID 'raspberry'. Set SSID env var for production.
-"
-    fi
-    if [ "${WPA_PASSPHRASE}" = "passw0rd" ] ; then
-        warnings="${warnings}[Warning] Using default WPA passphrase. Set WPA_PASSPHRASE env var for production.
-"
-    fi
-    if [ -n "${warnings}" ] ; then
-        printf "%s" "${warnings}"
-        return 0
-    fi
-    return 0
+    emit_credential_warnings
 }
 
 @test "default WPA passphrase triggers warning" {

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -107,12 +107,10 @@ esac
 : "${MAX_STATIONS:=0}"
 
 # Startup warnings for default credentials
-if [ "${SSID}" = "raspberry" ] ; then
-    echo "[Warning] Using default SSID 'raspberry'. Set SSID env var for production."
-fi
-if [ "${WPA_PASSPHRASE}" = "passw0rd" ] ; then
-    echo "[Warning] Using default WPA passphrase. Set WPA_PASSPHRASE env var for production."
-fi
+# Logic lives in lib/warnings.sh, shared with tests
+# shellcheck source=lib/warnings.sh
+. "$(dirname "$0")/lib/warnings.sh"
+emit_credential_warnings
 if [ "${MAX_STATIONS}" != "0" ] && ! [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
     echo "[Warning] Invalid MAX_STATIONS '${MAX_STATIONS}'. Must be a non-negative integer. Ignoring."
 fi


### PR DESCRIPTION
## Summary

Extracts the duplicated default-credential warning logic into `lib/warnings.sh`, following the `lib/wpa.sh` pattern from PR #74.

- New `emit_credential_warnings()` in `lib/warnings.sh`
- `wlanstart.sh` sources it and calls the function (no behavior change)
- `tests/security_warnings.bats` now tests the shared implementation instead of re-implementing it

Closes #80

## Testing

- All 84 bats tests pass
- shellcheck clean on changed files (pre-existing SC1091 info note unchanged)
