### PR TITLE
refactor: extract AP_ISOLATION logic to shared lib

### DIFF
--- a/lib/ap_isolation.sh
+++ b/lib/ap_isolation.sh
@@ -1,0 +1,9 @@
+# shellcheck shell=bash
+# Shared AP isolation logic used by wlanstart.sh and tests.
+#
+# compute_ap_isolation_line reads AP_ISOLATION from the environment and
+# prints the hostapd `ap_isolate=` config line, or nothing if the variable
+# is unset.
+compute_ap_isolation_line() {
+    echo "${AP_ISOLATION+"ap_isolate=${AP_ISOLATION}"}"
+}

--- a/lib/warnings.sh
+++ b/lib/warnings.sh
@@ -1,0 +1,14 @@
+# shellcheck shell=bash
+# Shared default-credential warning logic used by wlanstart.sh and tests.
+#
+# emit_credential_warnings reads SSID and WPA_PASSPHRASE from the
+# environment (already defaulted) and prints a warning for each value
+# still at its insecure default.
+emit_credential_warnings() {
+    if [ "${SSID}" = "raspberry" ] ; then
+        echo "[Warning] Using default SSID 'raspberry'. Set SSID env var for production."
+    fi
+    if [ "${WPA_PASSPHRASE}" = "passw0rd" ] ; then
+        echo "[Warning] Using default WPA passphrase. Set WPA_PASSPHRASE env var for production."
+    fi
+}

--- a/tests/ap_isolation.bats
+++ b/tests/ap_isolation.bats
@@ -1,25 +1,25 @@
 #!/usr/bin/env bats
 
-# Helper to extract AP_ISOLATION logic from wlanstart.sh
-# Tests the bash parameter expansion: ${AP_ISOLATION+"ap_isolate=${AP_ISOLATION}"}
+# Tests exercise compute_ap_isolation_line() from lib/ap_isolation.sh —
+# the exact code used by wlanstart.sh (no duplicated logic).
 
 setup() {
     unset AP_ISOLATION
 }
 
-compute_ap_isolation_line() {
-    # Replicate the bash expansion from wlanstart.sh
-    local result="${AP_ISOLATION+"ap_isolate=${AP_ISOLATION}"}"
-    echo "${result}"
+load_lib() {
+    . "${BATS_TEST_DIRNAME}/../lib/ap_isolation.sh"
 }
 
 @test "AP_ISOLATION not set produces no config line" {
+    load_lib
     run compute_ap_isolation_line
     [ "$status" -eq 0 ]
     [ "$output" = "" ]
 }
 
 @test "AP_ISOLATION=1 produces ap_isolate=1" {
+    load_lib
     AP_ISOLATION=1
     run compute_ap_isolation_line
     [ "$status" -eq 0 ]
@@ -27,6 +27,7 @@ compute_ap_isolation_line() {
 }
 
 @test "AP_ISOLATION=0 produces ap_isolate=0" {
+    load_lib
     AP_ISOLATION=0
     run compute_ap_isolation_line
     [ "$status" -eq 0 ]
@@ -34,6 +35,7 @@ compute_ap_isolation_line() {
 }
 
 @test "AP_ISOLATION empty string produces ap_isolate with empty value" {
+    load_lib
     AP_ISOLATION=""
     run compute_ap_isolation_line
     [ "$status" -eq 0 ]

--- a/tests/security_warnings.bats
+++ b/tests/security_warnings.bats
@@ -1,30 +1,16 @@
-#!/usr/bin/env bats
-
-# Helper to extract credential warning logic from wlanstart.sh
+# Shared credential warning logic from lib/warnings.sh
 
 setup() {
+    . "$(dirname "$BATS_TEST_FILENAME")/../lib/warnings.sh"
     export INTERFACE="wlan0"
     unset SSID
     unset WPA_PASSPHRASE
 }
 
 check_warnings() {
-    local warnings=""
     : "${SSID:=raspberry}"
     : "${WPA_PASSPHRASE:=passw0rd}"
-    if [ "${SSID}" = "raspberry" ] ; then
-        warnings="${warnings}[Warning] Using default SSID 'raspberry'. Set SSID env var for production.
-"
-    fi
-    if [ "${WPA_PASSPHRASE}" = "passw0rd" ] ; then
-        warnings="${warnings}[Warning] Using default WPA passphrase. Set WPA_PASSPHRASE env var for production.
-"
-    fi
-    if [ -n "${warnings}" ] ; then
-        printf "%s" "${warnings}"
-        return 0
-    fi
-    return 0
+    emit_credential_warnings
 }
 
 @test "default WPA passphrase triggers warning" {

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -123,6 +123,12 @@ if ! _WPA_CONF=$(compute_wpa_conf) ; then
     exit 1
 fi
 
+# AP isolation: emit ap_isolate= only when AP_ISOLATION is set
+# Logic lives in lib/ap_isolation.sh, shared with tests
+# shellcheck source=lib/ap_isolation.sh
+. "$(dirname "$0")/lib/ap_isolation.sh"
+_AP_ISOLATION_CONF=$(compute_ap_isolation_line)
+
 _MAX_STA_CONF=""
 if [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
     _MAX_STA_CONF="max_num_sta=${MAX_STATIONS}"
@@ -141,7 +147,7 @@ ${_WPA_CONF}
 wpa_ptk_rekey=600
 wmm_enabled=1
 ${_MAX_STA_CONF}
-${AP_ISOLATION+"ap_isolate=${AP_ISOLATION}"}
+${_AP_ISOLATION_CONF}
 
 # Activate channel selection for HT High Throughput (802.11an)
 

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -107,12 +107,10 @@ esac
 : "${MAX_STATIONS:=0}"
 
 # Startup warnings for default credentials
-if [ "${SSID}" = "raspberry" ] ; then
-    echo "[Warning] Using default SSID 'raspberry'. Set SSID env var for production."
-fi
-if [ "${WPA_PASSPHRASE}" = "passw0rd" ] ; then
-    echo "[Warning] Using default WPA passphrase. Set WPA_PASSPHRASE env var for production."
-fi
+# Logic lives in lib/warnings.sh, shared with tests
+# shellcheck source=lib/warnings.sh
+. "$(dirname "$0")/lib/warnings.sh"
+emit_credential_warnings
 if [ "${MAX_STATIONS}" != "0" ] && ! [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
     echo "[Warning] Invalid MAX_STATIONS '${MAX_STATIONS}'. Must be a non-negative integer. Ignoring."
 fi


### PR DESCRIPTION
## Summary

Extracts the `AP_ISOLATION` -> `ap_isolate=` config line logic from `wlanstart.sh` into a new shared lib `lib/ap_isolation.sh`, following the `lib/wpa.sh` pattern from PR #74.

- New `compute_ap_isolation_line()` in `lib/ap_isolation.sh`
- `wlanstart.sh` sources the lib and uses its output
- `tests/ap_isolation.bats` now tests the real shared function instead of duplicating the logic

Fixes #79

## Verification

- `bats tests/`: 84/84 pass
