### PR TITLE
refactor: extract HIDE_SSID logic to shared lib/ssid_hidden.sh

### DIFF
--- a/lib/ssid_hidden.sh
+++ b/lib/ssid_hidden.sh
@@ -1,0 +1,9 @@
+# shellcheck shell=bash
+# Shared hidden SSID logic used by wlanstart.sh and tests.
+#
+# compute_ssid_hidden_line reads HIDE_SSID from the environment and
+# prints the hostapd `ssid_hidden=` config line, or nothing if the
+# variable is unset.
+compute_ssid_hidden_line() {
+    echo "${HIDE_SSID+"ssid_hidden=${HIDE_SSID}"}"
+}

--- a/tests/hide_ssid.bats
+++ b/tests/hide_ssid.bats
@@ -1,16 +1,8 @@
 #!/usr/bin/env bats
 
-# Helper to extract HIDE_SSID logic from wlanstart.sh
-# Tests the bash parameter expansion: ${HIDE_SSID+"ssid_hidden=${HIDE_SSID}"}
-
 setup() {
+    . "${BATS_TEST_DIRNAME}/../lib/ssid_hidden.sh"
     unset HIDE_SSID
-}
-
-compute_ssid_hidden_line() {
-    # Replicate the bash expansion from wlanstart.sh
-    local result="${HIDE_SSID+"ssid_hidden=${HIDE_SSID}"}"
-    echo "${result}"
 }
 
 @test "HIDE_SSID not set produces no config line" {

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -129,6 +129,12 @@ fi
 . "$(dirname "$0")/lib/ap_isolation.sh"
 _AP_ISOLATION_CONF=$(compute_ap_isolation_line)
 
+# Hidden SSID: emit ssid_hidden= only when HIDE_SSID is set
+# Logic lives in lib/ssid_hidden.sh, shared with tests
+# shellcheck source=lib/ssid_hidden.sh
+. "$(dirname "$0")/lib/ssid_hidden.sh"
+_SSID_HIDDEN_CONF=$(compute_ssid_hidden_line)
+
 _MAX_STA_CONF=""
 if [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
     _MAX_STA_CONF="max_num_sta=${MAX_STATIONS}"
@@ -139,7 +145,7 @@ cat > "/etc/hostapd.conf" <<EOF
 interface=${INTERFACE}
 ${DRIVER+"driver=${DRIVER}"}
 ssid=${SSID}
-${HIDE_SSID+"ssid_hidden=${HIDE_SSID}"}
+${_SSID_HIDDEN_CONF}
 hw_mode=${HW_MODE}
 channel=${CHANNEL}
 ${COUNTRY_CODE+"country_code=${COUNTRY_CODE}"}


### PR DESCRIPTION
## Summary

Extracts the duplicated `HIDE_SSID` → `ssid_hidden=` config line logic from `tests/hide_ssid.bats` into a shared `lib/ssid_hidden.sh`, following the `lib/wpa.sh` / `lib/ap_isolation.sh` pattern.

- New `lib/ssid_hidden.sh` with `compute_ssid_hidden_line()`
- `wlanstart.sh` sources it and uses `_SSID_HIDDEN_CONF=$(compute_ssid_hidden_line)` in the hostapd.conf heredoc
- `tests/hide_ssid.bats` now sources the lib instead of re-implementing the expansion

Closes #78

## Verification

- `bats tests/`: 84/84 pass
- `shellcheck wlanstart.sh lib/ssid_hidden.sh`: no new findings
