### PR TITLE
refactor: extract MAX_STATIONS logic to shared lib (tests duplicate logic)

### DIFF
--- a/lib/stations.sh
+++ b/lib/stations.sh
@@ -1,0 +1,17 @@
+# shellcheck shell=bash
+# Shared MAX_STATIONS logic used by wlanstart.sh and tests.
+#
+# compute_max_sta_conf reads MAX_STATIONS from the environment and writes the
+# hostapd max_num_sta line to stdout (empty when disabled). Warnings go to
+# stderr.
+compute_max_sta_conf() {
+    : "${MAX_STATIONS:=0}"
+    if [ "${MAX_STATIONS}" != "0" ] && ! [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
+        echo "[Warning] Invalid MAX_STATIONS '${MAX_STATIONS}'. Must be a non-negative integer. Ignoring." >&2
+    fi
+    _MAX_STA_CONF=""
+    if [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
+        _MAX_STA_CONF="max_num_sta=${MAX_STATIONS}"
+    fi
+    echo "${_MAX_STA_CONF}"
+}

--- a/tests/max_stations.bats
+++ b/tests/max_stations.bats
@@ -1,22 +1,12 @@
 #!/usr/bin/env bats
 
-# Helper to extract MAX_STATIONS logic from wlanstart.sh
+# Shared MAX_STATIONS logic from lib/stations.sh
 
 setup() {
     unset MAX_STATIONS
     unset _MAX_STA_CONF
-}
-
-compute_max_sta_conf() {
-    : "${MAX_STATIONS:=0}"
-    if [ "${MAX_STATIONS}" != "0" ] && ! [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
-        echo "[Warning] Invalid MAX_STATIONS '${MAX_STATIONS}'. Must be a non-negative integer. Ignoring."
-    fi
-    _MAX_STA_CONF=""
-    if [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
-        _MAX_STA_CONF="max_num_sta=${MAX_STATIONS}"
-    fi
-    echo "${_MAX_STA_CONF}"
+    # shellcheck source=../lib/stations.sh
+    . "$(dirname "$BATS_TEST_FILENAME")/../lib/stations.sh"
 }
 
 @test "default MAX_STATIONS=0 produces no config line" {

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -111,9 +111,10 @@ esac
 # shellcheck source=lib/warnings.sh
 . "$(dirname "$0")/lib/warnings.sh"
 emit_credential_warnings
-if [ "${MAX_STATIONS}" != "0" ] && ! [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
-    echo "[Warning] Invalid MAX_STATIONS '${MAX_STATIONS}'. Must be a non-negative integer. Ignoring."
-fi
+# MAX_STATIONS: limit number of associated stations (0 = unlimited)
+# Logic lives in lib/stations.sh, shared with tests
+# shellcheck source=lib/stations.sh
+. "$(dirname "$0")/lib/stations.sh"
 
 # WPA version: 2 (WPA2-PSK, default), 3 (WPA3-SAE) or mixed (WPA2/WPA3 transition)
 # Logic lives in lib/wpa.sh, shared with tests
@@ -135,10 +136,7 @@ _AP_ISOLATION_CONF=$(compute_ap_isolation_line)
 . "$(dirname "$0")/lib/ssid_hidden.sh"
 _SSID_HIDDEN_CONF=$(compute_ssid_hidden_line)
 
-_MAX_STA_CONF=""
-if [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
-    _MAX_STA_CONF="max_num_sta=${MAX_STATIONS}"
-fi
+_MAX_STA_CONF=$(compute_max_sta_conf)
 
 # Always regenerate hostapd.conf so env var changes apply between runs
 cat > "/etc/hostapd.conf" <<EOF


### PR DESCRIPTION
## Description

Extracts the `MAX_STATIONS` warning/`max_num_sta` config logic from `wlanstart.sh` into a shared `lib/stations.sh`, following the `lib/wpa.sh` pattern from PR #74.

- New `lib/stations.sh` with `compute_max_sta_conf()`
- `wlanstart.sh` sources it instead of inlining the logic
- `tests/max_stations.bats` sources the shared lib instead of re-implementing it

Closes #77

## Testing

- All 84 bats tests pass
- `shellcheck -x wlanstart.sh lib/*.sh` clean
