### PR TITLE
refactor: extract channel validation to shared lib

### DIFF
--- a/lib/channel.sh
+++ b/lib/channel.sh
@@ -1,0 +1,43 @@
+# shellcheck shell=bash
+# Shared channel/hw_mode/country validation logic used by wlanstart.sh and tests.
+#
+# validate_channel reads HW_MODE, CHANNEL and COUNTRY_CODE from the
+# environment (applying the same defaults as wlanstart.sh) and returns
+# non-zero when the channel is not allowed. Messages go to stderr.
+validate_channel() {
+    : "${HW_MODE:=g}"
+    : "${CHANNEL:=11}"
+    : "${COUNTRY_CODE:=EU}"
+
+    case "${COUNTRY_CODE}" in
+        US|CA|MX) _MAX_CHANNEL=11 ;;
+        JP)       _MAX_CHANNEL=14 ;;
+        *)        _MAX_CHANNEL=13 ;;  # fallback: Europe (ETSI)
+    esac
+
+    case "${HW_MODE}" in
+        g|b)
+            if ! [ "${CHANNEL}" -gt 0 ] 2>/dev/null; then
+                echo "[Error] Channel '${CHANNEL}' must be a positive integer" >&2
+                return 1
+            fi
+            if [ "${CHANNEL}" -gt "${_MAX_CHANNEL}" ] 2>/dev/null; then
+                echo "[Error] Channel ${CHANNEL} not allowed for country ${COUNTRY_CODE} (max ${_MAX_CHANNEL} for hw_mode=${HW_MODE})" >&2
+                return 1
+            fi
+            ;;
+        a)
+            if ! [ "${CHANNEL}" -gt 0 ] 2>/dev/null; then
+                echo "[Error] Channel '${CHANNEL}' must be a positive integer" >&2
+                return 1
+            fi
+            if [ "${CHANNEL}" -le 14 ] 2>/dev/null; then
+                echo "[Warning] Channel ${CHANNEL} may be invalid for hw_mode=a (5GHz typically > 14)" >&2
+            fi
+            ;;
+        *)
+            echo "[Warning] Unknown hw_mode='${HW_MODE}', skipping channel validation" >&2
+            ;;
+    esac
+    return 0
+}

--- a/tests/channel_validation.bats
+++ b/tests/channel_validation.bats
@@ -1,49 +1,12 @@
 #!/usr/bin/env bats
 
-# Helper to extract channel/hw_mode validation logic from wlanstart.sh
-
 setup() {
+    ROOT="${BATS_TEST_DIRNAME}/.."
     unset HW_MODE
     unset CHANNEL
     unset COUNTRY_CODE
-}
-
-validate_channel() {
-    : "${HW_MODE:=g}"
-    : "${CHANNEL:=11}"
-    : "${COUNTRY_CODE:=EU}"
-
-    case "${COUNTRY_CODE}" in
-        US|CA|MX) _MAX_CHANNEL=11 ;;
-        JP)       _MAX_CHANNEL=14 ;;
-        *)        _MAX_CHANNEL=13 ;;
-    esac
-
-    case "${HW_MODE}" in
-        g|b)
-            if ! [ "${CHANNEL}" -gt 0 ] 2>/dev/null; then
-                echo "[Error] Channel '${CHANNEL}' must be a positive integer" >&2
-                return 1
-            fi
-            if [ "${CHANNEL}" -gt "${_MAX_CHANNEL}" ] 2>/dev/null; then
-                echo "[Error] Channel ${CHANNEL} not allowed for country ${COUNTRY_CODE} (max ${_MAX_CHANNEL} for hw_mode=${HW_MODE})" >&2
-                return 1
-            fi
-            ;;
-        a)
-            if ! [ "${CHANNEL}" -gt 0 ] 2>/dev/null; then
-                echo "[Error] Channel '${CHANNEL}' must be a positive integer" >&2
-                return 1
-            fi
-            if [ "${CHANNEL}" -le 14 ] 2>/dev/null; then
-                echo "[Warning] Channel ${CHANNEL} may be invalid for hw_mode=a (5GHz typically > 14)" >&2
-            fi
-            ;;
-        *)
-            echo "[Warning] Unknown hw_mode='${HW_MODE}', skipping channel validation" >&2
-            ;;
-    esac
-    return 0
+    # shellcheck source=../lib/channel.sh
+    . "${ROOT}/lib/channel.sh"
 }
 
 # --- g/b mode (2.4 GHz) ---

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -62,40 +62,13 @@ if [ -z "${COUNTRY_CODE+x}" ] ; then
 fi
 : "${COUNTRY_CODE:=EU}"
 
-# Validate channel against regulatory domain
-case "${COUNTRY_CODE}" in
-    US|CA|MX) _MAX_CHANNEL=11 ;;
-    JP)       _MAX_CHANNEL=14 ;;
-    *)        _MAX_CHANNEL=13 ;;  # fallback: Europe (ETSI)
-esac
-
-# Validate channel against hardware mode
-
-# Validate channel against hardware mode
-case "${HW_MODE}" in
-    g|b)
-        if ! [ "${CHANNEL}" -gt 0 ] 2>/dev/null; then
-            echo "[Error] Channel '${CHANNEL}' must be a positive integer"
-            exit 1
-        fi
-        if [ "${CHANNEL}" -gt "${_MAX_CHANNEL}" ] 2>/dev/null; then
-            echo "[Error] Channel ${CHANNEL} not allowed for country ${COUNTRY_CODE} (max ${_MAX_CHANNEL} for hw_mode=${HW_MODE})"
-            exit 1
-        fi
-        ;;
-    a)
-        if ! [ "${CHANNEL}" -gt 0 ] 2>/dev/null; then
-            echo "[Error] Channel '${CHANNEL}' must be a positive integer"
-            exit 1
-        fi
-        if [ "${CHANNEL}" -le 14 ] 2>/dev/null; then
-            echo "[Warning] Channel ${CHANNEL} may be invalid for hw_mode=a (5GHz typically > 14)"
-        fi
-        ;;
-    *)
-        echo "[Warning] Unknown hw_mode='${HW_MODE}', skipping channel validation"
-        ;;
-esac
+# Validate channel against regulatory domain and hardware mode
+# Logic lives in lib/channel.sh, shared with tests
+# shellcheck source=lib/channel.sh
+. "$(dirname "$0")/lib/channel.sh"
+if ! validate_channel ; then
+    exit 1
+fi
 
 # Default values
 : "${SUBNET:=192.168.254.0}"


### PR DESCRIPTION
Closes #75

- Extract `validate_channel()` from `wlanstart.sh:66-98` into `lib/channel.sh`, following the pattern from #74
- Source the lib from both `wlanstart.sh` and `tests/channel_validation.bats`; delete the duplicated helper in the test
- Dockerfile already covers `COPY lib/ /bin/lib/`; guard test in `tests/version_sync.bats` passes

All 84 bats tests pass.
