### PR TITLE
chore: add opencode commands for project review and issue creation

### DIFF
--- a/.agents/commands/create-issues.md
+++ b/.agents/commands/create-issues.md
@@ -1,0 +1,34 @@
+---
+description: Create GitHub issues from a reviewed list of fixes/improvements/features
+agent: build
+---
+
+Create GitHub issues for each item from a previously reviewed suggestions list (see /review-project). Ask the user which items to include if no list was just produced.
+
+## Rules
+
+- **Issue bodies must be written to temporary markdown files first** (one per issue) under `<repo-root>/tmp/` (this directory is gitignored per AGENTS.md), then passed via `--body-file`. Never pass long markdown inline with `--body`.
+- One issue per item; do not merge unrelated items.
+
+## Steps
+
+For each selected item:
+
+1. Write the issue body to `tmp/issue-<slug>.md`. Body should contain:
+   - `## Problem` — what is wrong / what is missing, with `file:line` references
+   - `## Proposed fix` (or `## Proposed design`) — concrete approach, code sketches where helpful
+   - `## Acceptance criteria` — checklist of verifiable outcomes
+2. Create the issue:
+   ```bash
+   gh issue create --title "<type>: <description>" --label "<labels>" --body-file tmp/issue-<slug>.md
+   ```
+3. Titles follow Conventional Commits style (`fix: ...`, `feat: ...`, `enhancement: ...`, `docs: ...`).
+4. Labels by category:
+   - Bug fix → `bugs`
+   - Improvement/refactor → `enhancement` (add `minor` if trivial)
+   - New feature → `enhancement`
+   - Docs only → `minor`
+
+## Output
+
+Report each created issue number + URL grouped by category.

--- a/.agents/commands/review-project.md
+++ b/.agents/commands/review-project.md
@@ -1,0 +1,29 @@
+---
+description: Review the project and suggest features, improvements and fixes
+agent: build
+---
+
+Review this project and produce a structured list of suggested work items.
+
+## Steps
+
+1. Explore the repository: README, entrypoint/startup scripts, Dockerfile, healthcheck, `lib/`, `scripts/`, `.github/` workflows and tests.
+2. Check open GitHub issues to avoid suggesting duplicates:
+   ```bash
+   gh issue list --state open --limit 50
+   ```
+3. Analyze the code for:
+   - **Bugs**: race conditions, incorrect shell logic (e.g. `wait` semantics), missing validation, unclean teardown, error handling gaps.
+   - **Improvements**: robustness of healthchecks, better error messages, code structure following the existing `lib/*.sh` + bats tests pattern.
+   - **Features**: useful new capabilities consistent with the project's purpose.
+   - **Docs**: undocumented env vars or behavior gaps in the README.
+
+## Output format
+
+Present findings grouped as:
+
+- **Fixes (bugs)** — numbered, each with file:line references and a short explanation of the problem and proposed fix.
+- **Improvements** — numbered, same detail level.
+- **Features** — numbered, with a brief design sketch.
+
+Do NOT create any issues yet — wait for explicit confirmation from the user.


### PR DESCRIPTION
## Summary

Adds two custom opencode commands under `.agents/commands/`:

- **`/review-project`** — explores the repo (scripts, Dockerfile, healthcheck, `lib/`, tests, workflows), checks open GitHub issues to avoid duplicates, and produces a grouped list of suggested fixes, improvements, features and docs gaps with file references. Requires explicit confirmation before any issue is created.
- **`/create-issues`** — creates one GitHub issue per reviewed item. Issue bodies are written to temporary markdown files under `tmp/` (gitignored, per AGENTS.md) and passed via `gh issue create --body-file`, avoiding shell escaping problems. Titles follow Conventional Commits; labels follow the repo convention (`bugs`, `enhancement`, `minor`).

Refs: none (tooling only)
