### PR TITLE
fix: validate WPA_PASSPHRASE length

### DIFF
--- a/lib/passphrase.sh
+++ b/lib/passphrase.sh
@@ -1,0 +1,13 @@
+# shellcheck shell=bash
+# Shared WPA passphrase validation logic used by wlanstart.sh and tests.
+#
+# validate_passphrase reads WPA_PASSPHRASE from the environment and returns
+# non-zero if its length is outside the 8-63 character range required by
+# WPA-PSK/SAE. Messages go to stderr.
+validate_passphrase() {
+    local len=${#WPA_PASSPHRASE}
+    if [ "${len}" -lt 8 ] || [ "${len}" -gt 63 ] ; then
+        echo "[Error] Invalid WPA_PASSPHRASE: must be 8-63 characters (got ${len})." >&2
+        return 1
+    fi
+}

--- a/tests/passphrase_validation.bats
+++ b/tests/passphrase_validation.bats
@@ -1,0 +1,52 @@
+#!/usr/bin/env bats
+
+# Tests exercise validate_passphrase() from lib/passphrase.sh — the exact
+# code used by wlanstart.sh (no duplicated logic).
+
+setup() {
+    unset WPA_PASSPHRASE
+}
+
+load_lib() {
+    . "${BATS_TEST_DIRNAME}/../lib/passphrase.sh"
+}
+
+@test "8-character passphrase is accepted" {
+    load_lib
+    WPA_PASSPHRASE=12345678
+    run validate_passphrase
+    [ "$status" -eq 0 ]
+}
+
+@test "63-character passphrase is accepted" {
+    load_lib
+    WPA_PASSPHRASE=$(printf 'a%.0s' {1..63})
+    run validate_passphrase
+    [ "$status" -eq 0 ]
+}
+
+@test "7-character passphrase is rejected with error message" {
+    load_lib
+    WPA_PASSPHRASE=1234567
+    run validate_passphrase
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid WPA_PASSPHRASE"* ]]
+    [[ "$output" == *"8-63"* ]]
+}
+
+@test "64-character passphrase is rejected with error message" {
+    load_lib
+    WPA_PASSPHRASE=$(printf 'a%.0s' {1..64})
+    run validate_passphrase
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid WPA_PASSPHRASE"* ]]
+    [[ "$output" == *"8-63"* ]]
+}
+
+@test "empty passphrase is rejected" {
+    load_lib
+    WPA_PASSPHRASE=""
+    run validate_passphrase
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid WPA_PASSPHRASE"* ]]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -84,6 +84,14 @@ fi
 # shellcheck source=lib/warnings.sh
 . "$(dirname "$0")/lib/warnings.sh"
 emit_credential_warnings
+# Validate WPA_PASSPHRASE length (8-63 chars required by WPA-PSK/SAE)
+# Logic lives in lib/passphrase.sh, shared with tests
+# shellcheck source=lib/passphrase.sh
+. "$(dirname "$0")/lib/passphrase.sh"
+if ! validate_passphrase ; then
+    exit 1
+fi
+
 # MAX_STATIONS: limit number of associated stations (0 = unlimited)
 # Logic lives in lib/stations.sh, shared with tests
 # shellcheck source=lib/stations.sh


### PR DESCRIPTION
## Summary

Validates `WPA_PASSPHRASE` length (8–63 characters) early in `wlanstart.sh`, before any daemons start, per #90.

- New `lib/passphrase.sh` with `validate_passphrase()` following the existing lib pattern
- `wlanstart.sh` sources it and exits 1 with a clear `[Error]` message on invalid length (before `/etc/hostapd.conf` generation, hostapd/dnsmasq start)
- Applies to WPA2-PSK and WPA3-SAE alike (both require 8–63 chars)
- New bats tests in `tests/passphrase_validation.bats` (boundary 8/63 accept, 7/64/empty reject)

Closes #90
