### PR TITLE
feat(channel): validate 5GHz channels for hw_mode=a with DFS warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,12 @@ When `COUNTRY_CODE` is set, 2.4 GHz channels (`hw_mode=g` or `b`) are validated 
 
 Unknown countries fall back to the ETSI limit (1–13). A warning is emitted if `COUNTRY_CODE` is not set.
 
+For 5 GHz (`hw_mode=a`), channels are validated against the allowed 5 GHz set:
+
+- **Non-DFS channels** (always allowed): 36, 40, 44, 48, 149, 153, 157, 161, 165
+- **DFS channels** (allowed with a radar detection/CAC warning): 52, 56, 60, 64, 100–144 (in steps of 4)
+- Any other channel is rejected with a clear error.
+
 ### Build from Source
 
 ```bash

--- a/lib/channel.sh
+++ b/lib/channel.sh
@@ -31,9 +31,17 @@ validate_channel() {
                 echo "[Error] Channel '${CHANNEL}' must be a positive integer" >&2
                 return 1
             fi
-            if [ "${CHANNEL}" -le 14 ] 2>/dev/null; then
-                echo "[Warning] Channel ${CHANNEL} may be invalid for hw_mode=a (5GHz typically > 14)" >&2
-            fi
+            case "${CHANNEL}" in
+                36|40|44|48|149|153|157|161|165)
+                    ;;
+                52|56|60|64|100|104|108|112|116|120|124|128|132|136|140|144)
+                    echo "[Warning] Channel ${CHANNEL} is a DFS channel (radar detection/CAC required), may not work on all drivers" >&2
+                    ;;
+                *)
+                    echo "[Error] Channel ${CHANNEL} not allowed for hw_mode=a (allowed: 36,40,44,48,149,153,157,161,165; DFS: 52-144)" >&2
+                    return 1
+                    ;;
+            esac
             ;;
         *)
             echo "[Warning] Unknown hw_mode='${HW_MODE}', skipping channel validation" >&2

--- a/tests/channel_validation.bats
+++ b/tests/channel_validation.bats
@@ -70,34 +70,63 @@ setup() {
 
 # --- a mode (5 GHz) ---
 
-@test "hw_mode=a with channel 36 passes" {
+@test "hw_mode=a with all non-DFS channels passes" {
     HW_MODE="a"
-    CHANNEL="36"
-    run validate_channel
-    [ "$status" -eq 0 ]
+    for ch in 36 40 44 48 149 153 157 161 165; do
+        CHANNEL="${ch}"
+        run validate_channel
+        [ "$status" -eq 0 ]
+    done
 }
 
-@test "hw_mode=a with channel 140 passes" {
+@test "hw_mode=a with DFS channel 52 warns but passes" {
     HW_MODE="a"
-    CHANNEL="140"
+    CHANNEL="52"
     run validate_channel
     [ "$status" -eq 0 ]
+    [[ "$output" == *"Warning"*"DFS"* ]]
 }
 
-@test "hw_mode=a with channel 11 issues warning" {
+@test "hw_mode=a with DFS channel 100 warns but passes" {
+    HW_MODE="a"
+    CHANNEL="100"
+    run validate_channel
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Warning"*"DFS"* ]]
+}
+
+@test "hw_mode=a with DFS channel 144 warns but passes" {
+    HW_MODE="a"
+    CHANNEL="144"
+    run validate_channel
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Warning"*"DFS"* ]]
+}
+
+@test "hw_mode=a with invalid channel fails with clear error" {
+    HW_MODE="a"
+    for ch in 15 34 50 145 1650; do
+        CHANNEL="${ch}"
+        run validate_channel
+        [ "$status" -eq 1 ]
+        [[ "$output" == *"Error"*"not allowed for hw_mode=a"* ]]
+    done
+}
+
+@test "hw_mode=a rejects channel 11 (2.4 GHz only)" {
     HW_MODE="a"
     CHANNEL="11"
     run validate_channel
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"Warning"*"may be invalid"* ]]
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error"*"not allowed for hw_mode=a"* ]]
 }
 
-@test "hw_mode=a with channel 1 issues warning" {
+@test "hw_mode=a rejects channel 1 (2.4 GHz only)" {
     HW_MODE="a"
     CHANNEL="1"
     run validate_channel
-    [ "$status" -eq 0 ]
-    [[ "$output" == *"Warning"*"may be invalid"* ]]
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error"*"not allowed for hw_mode=a"* ]]
 }
 
 # --- non-numeric channel ---


### PR DESCRIPTION
## Summary

Extends `lib/channel.sh` channel validation to cover `hw_mode=a` (5 GHz), which previously accepted any positive channel value.

- **Allowed non-DFS channels**: 36, 40, 44, 48, 149, 153, 157, 161, 165
- **DFS channels** (52, 56, 60, 64, 100, 104, ..., 144): allowed but emit a `[Warning] ... DFS channel (radar detection/CAC required) ...`
- Any other value: rejected with a clear `[Error] Channel X not allowed for hw_mode=a (...)` message
- 2.4 GHz validation (`hw_mode=g`/`b`) is unchanged

README's Regional Channel Validation section updated to document the 5 GHz behavior.

## Tests

New bats cases in `tests/channel_validation.bats`:

- All non-DFS 5 GHz channels pass without warnings
- DFS channels (52, 100, 144) pass with a DFS warning
- Invalid channels (15, 34, 50, 145, 1650) fail with a clear error
- 2.4 GHz channels (1, 11) now rejected under `hw_mode=a`

Full suite: 92/92 passing.

Closes #89
