### PR TITLE
fix: flush interface address and bring link down in cleanup()

### DIFF
--- a/tests/cleanup.bats
+++ b/tests/cleanup.bats
@@ -22,6 +22,7 @@ run_cleanup_mocked() {
     bash -c "
 _mock_log() { echo \"\$@\" >> \"$_MOCK_LOG\"; }
 iptables() { _mock_log \"iptables \$@\"; }
+ip() { _mock_log \"ip \$@\"; }
 kill() { _mock_log \"kill \$@\"; }
 wait() { _mock_log \"wait \$@\"; }
 $(sed -n '/^parse_outgoings()/,/^}/p; /^cleanup()/,/^}/p' wlanstart.sh)
@@ -116,6 +117,19 @@ cleanup
     [[ "$output" == *"Removing iptables for outgoing traffics on eth1..."* ]]
     [[ "$output" == *"iptables -t nat -D POSTROUTING -s 192.168.254.0/24 -o eth0 -j MASQUERADE"* ]]
     [[ "$output" == *"iptables -t nat -D POSTROUTING -s 192.168.254.0/24 -o eth1 -j MASQUERADE"* ]]
+}
+
+@test "cleanup flushes interface address and brings link down" {
+    run run_cleanup_mocked
+    [[ "$output" == *"ip addr flush dev wlan0"* ]]
+    [[ "$output" == *"ip link set wlan0 down"* ]]
+}
+
+@test "cleanup skips interface teardown when INTERFACE unset" {
+    export INTERFACE=""
+    run run_cleanup_mocked
+    [[ "$output" != *"ip addr flush"* ]]
+    [[ "$output" != *"ip link set"* ]]
 }
 
 @test "cleanup exits with status 0" {

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -34,6 +34,12 @@ cleanup() {
         iptables -D FORWARD -i "${INTERFACE}" -j ACCEPT > /dev/null 2>&1 || true
     fi
 
+    if [ -n "${INTERFACE}" ] ; then
+        echo "Flushing interface ${INTERFACE}..."
+        ip addr flush dev "${INTERFACE}" 2>/dev/null || true
+        ip link set "${INTERFACE}" down 2>/dev/null || true
+    fi
+
     exit 0
 }
 


### PR DESCRIPTION
## Summary

Implements #88: the `cleanup()` trap in `wlanstart.sh` now flushes the interface address and brings the link down after removing iptables rules, guarded with `[ -n "${INTERFACE}" ]` so it is safe when INTERFACE is unset.

- Added `ip addr flush dev "${INTERFACE}"` and `ip link set "${INTERFACE}" down` (both `|| true`) to `cleanup()`
- Updated `tests/cleanup.bats`: mocked `ip` in `run_cleanup_mocked`, added tests for flush/down calls and for skipping teardown when INTERFACE is unset

Closes #88
