### PR TITLE
chore(ci): run PR workflow jobs conditionally based on changed paths

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,6 +10,33 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    outputs:
+      scripts: ${{ steps.filter.outputs.scripts }}
+      dockerfile: ${{ steps.filter.outputs.dockerfile }}
+      tests: ${{ steps.filter.outputs.tests }}
+      workflow: ${{ steps.filter.outputs.workflow }}
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
+        id: filter
+        with:
+          filters: |
+            scripts:
+              - 'wlanstart.sh'
+              - 'healthcheck.sh'
+              - 'scripts/**'
+              - 'lib/**'
+            dockerfile:
+              - 'Dockerfile'
+            tests:
+              - 'tests/**'
+            workflow:
+              - '.github/workflows/pr.yml'
+
   pr-title:
     runs-on: ubuntu-latest
     permissions:
@@ -22,6 +49,8 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.tests == 'true' || needs.changes.outputs.scripts == 'true' || needs.changes.outputs.workflow == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -39,6 +68,8 @@ jobs:
 
   lint:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.dockerfile == 'true' || needs.changes.outputs.workflow == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -50,6 +81,8 @@ jobs:
 
   shellcheck:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.scripts == 'true' || needs.changes.outputs.tests == 'true' || needs.changes.outputs.workflow == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -63,6 +96,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    needs: changes
+    if: needs.changes.outputs.dockerfile == 'true' || needs.changes.outputs.scripts == 'true' || needs.changes.outputs.workflow == 'true'
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

Implements conditional job execution in `.github/workflows/pr.yml` per #96:

- Adds a `changes` detection job using `dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d` (pinned to full-length SHA, v4.0.3) with filters for `scripts`, `dockerfile`, `tests`, and `workflow`.
- Guards downstream jobs per the issue's table:
  | Job | Runs when |
  |---|---|
  | `pr-title` | always |
  | `test` | tests, scripts, or workflow changed |
  | `lint` | dockerfile or workflow changed |
  | `shellcheck` | scripts, tests, or workflow changed |
  | `build` | dockerfile, scripts, or workflow changed |
- Changes to `.github/workflows/pr.yml` force all jobs to run.

Closes #96
