### PR TITLE
feat: optional IPv6 support (RA/DHCPv6 via dnsmasq)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ docker run -d \
 | `AP_ISOLATION` | No | Isolate clients from each other (`1` = enabled) | `0` |
 | `COUNTRY_CODE` | No | Regulatory domain (`US`/`CA`/`MX`: ch 1-11, `JP`: ch 1-14, others: ch 1-13). Sets `country_code` in hostapd.conf | `EU` |
 | `WPA_VERSION` | No | WPA version: `2` = WPA2-PSK, `3` = WPA3-SAE (requires client support), `mixed` = WPA2/WPA3 transition (legacy clients allowed) | `2` |
+| `IPV6` | No | Enable IPv6 RA/DHCPv6 for clients (`1` = enabled) | `0` |
 
 #### WPA3 (SAE)
 
@@ -149,6 +150,25 @@ sudo sed -i 's/#net.ipv4.ip_forward=1/net.ipv4.ip_forward=1/' /etc/sysctl.conf
 sudo sed -i 's/#net.ipv6.conf.all.forwarding=1/net.ipv6.conf.all.forwarding=1/' /etc/sysctl.conf
 sudo sysctl -p
 ```
+
+### IPv6 Support (optional)
+
+IPv6 is **off by default**; behavior is unchanged unless you set `IPV6=1`. When enabled:
+
+- `net.ipv6.conf.all.forwarding=1` is set at runtime (IPv6 forwarding).
+- dnsmasq advertises SLAAC/RA with stateless DHCPv6 on the AP interface:
+  `dhcp-range=::,constructor:<INTERFACE>,ra-names,stateless`
+- `ip6tables` FORWARD rules mirror the IPv4 handling (established/related in, new out). There is no IPv6 NAT — clients get addresses from the upstream network's prefix via RA, or link-local/ULA otherwise.
+
+```bash
+docker run ... -e IPV6=1 ...
+```
+
+Caveats:
+
+- Client IPv6 connectivity depends on the upstream network advertising an IPv6 prefix (Router Advertisements on the outgoing interface). Without an upstream prefix, clients will only obtain link-local addresses.
+- The container sets forwarding at runtime via `/proc/sys`; for host persistence across reboots see the sysctl commands above.
+- Some ISPs/hosters filter or rate-limit IPv6; test with `ping6` / `traceroute -6` from a client.
 
 ### Outgoing Interfaces
 

--- a/lib/ipv6.sh
+++ b/lib/ipv6.sh
@@ -1,0 +1,59 @@
+# shellcheck shell=bash
+# Shared optional IPv6 support used by wlanstart.sh and tests.
+#
+# IPv6 is off by default. When IPV6=1:
+#   - net.ipv6.conf.all.forwarding is set to 1
+#   - dnsmasq announces RA/stateless DHCPv6 on the AP interface
+#   - ip6tables FORWARD rules mirror the IPv4 handling
+#
+# compute_dnsmasq_ipv6_conf prints the extra dnsmasq.conf line (or nothing
+# when disabled). Messages go to stderr.
+compute_dnsmasq_ipv6_conf() {
+    if [ "${IPV6:-0}" != "1" ] ; then
+        echo "[Info] IPV6 not enabled, skipping IPv6 RA/DHCPv6 configuration." >&2
+        return 1
+    fi
+    echo "dhcp-range=::,constructor:${INTERFACE},ra-names,stateless"
+}
+
+# enable_ipv6_forwarding sets the forwarding sysctl via /proc.
+enable_ipv6_forwarding() {
+    echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
+}
+
+# apply_ipv6_rules adds ip6tables FORWARD rules mirroring the IPv4 ones.
+# ints is populated by parse_outgoings in wlanstart.sh.
+# shellcheck disable=SC2154
+apply_ipv6_rules() {
+    if [ "${OUTGOINGS}" ] ; then
+        local int
+        for int in "${ints[@]}" ; do
+            ip6tables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+            ip6tables -A FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT
+
+            ip6tables -D FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT > /dev/null 2>&1 || true
+            ip6tables -A FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT
+        done
+    else
+        ip6tables -D FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+        ip6tables -A FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT
+
+        ip6tables -D FORWARD -i "${INTERFACE}" -j ACCEPT > /dev/null 2>&1 || true
+        ip6tables -A FORWARD -i "${INTERFACE}" -j ACCEPT
+    fi
+}
+
+# remove_ipv6_rules deletes the ip6tables rules added by apply_ipv6_rules.
+# shellcheck disable=SC2154
+remove_ipv6_rules() {
+    if [ "${OUTGOINGS}" ] ; then
+        local int
+        for int in "${ints[@]}" ; do
+            ip6tables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+            ip6tables -D FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT > /dev/null 2>&1 || true
+        done
+    else
+        ip6tables -D FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+        ip6tables -D FORWARD -i "${INTERFACE}" -j ACCEPT > /dev/null 2>&1 || true
+    fi
+}

--- a/tests/ipv6.bats
+++ b/tests/ipv6.bats
@@ -1,0 +1,63 @@
+#!/usr/bin/env bats
+
+# Logic shared with wlanstart.sh
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+# shellcheck source=../lib/ipv6.sh
+. "${REPO_ROOT}/lib/ipv6.sh"
+
+setup() {
+    export INTERFACE="wlan0"
+    export OUTGOINGS=""
+    ints=()
+}
+
+@test "IPv6 disabled by default: no dnsmasq conf" {
+    unset IPV6
+    run compute_dnsmasq_ipv6_conf
+    [ "$status" -eq 1 ]
+}
+
+@test "IPv6 disabled explicitly (IPV6=0): no dnsmasq conf" {
+    IPV6=0
+    run compute_dnsmasq_ipv6_conf
+    [ "$status" -eq 1 ]
+}
+
+@test "IPV6=1 emits RA/stateless DHCPv6 range for AP interface" {
+    IPV6=1
+    run compute_dnsmasq_ipv6_conf
+    [ "$status" -eq 0 ]
+    [ "${lines[@]: -1}" = "dhcp-range=::,constructor:wlan0,ra-names,stateless" ]
+}
+
+@test "apply_ipv6_rules with OUTGOINGS calls ip6tables per interface" {
+    IPV6=1
+    OUTGOINGS="eth0,eth1"
+    parse_outgoings() { ints=("eth0" "eth1"); }
+    ip6tables() { echo "ip6tables $*"; }
+    parse_outgoings
+    run apply_ipv6_rules
+    [ "$status" -eq 0 ]
+    [[ "${output}" == *"ip6tables -A FORWARD -i eth0 -o wlan0"* ]]
+    [[ "${output}" == *"ip6tables -A FORWARD -i wlan0 -o eth1"* ]]
+}
+
+@test "apply_ipv6_rules without OUTGOINGS uses generic rules" {
+    IPV6=1
+    ip6tables() { echo "ip6tables $*"; }
+    run apply_ipv6_rules
+    [ "$status" -eq 0 ]
+    [[ "${output}" == *"ip6tables -A FORWARD -i wlan0 -j ACCEPT"* ]]
+    [[ "${output}" == *"-o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT"* ]]
+}
+
+@test "remove_ipv6_rules deletes generic rules" {
+    local log="${BATS_TEST_TMPDIR}/ip6tables.log"
+    ip6tables() {
+        if [ "$1" = "-D" ] ; then echo "delete $*" >> "${log}"; fi
+        return 0
+    }
+    remove_ipv6_rules
+    [ "$(grep -c delete "${log}")" -eq 2 ]
+    [[ "$(cat "${log}")" == *"-i wlan0 -j ACCEPT"* ]]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -34,6 +34,11 @@ cleanup() {
         iptables -D FORWARD -i "${INTERFACE}" -j ACCEPT > /dev/null 2>&1 || true
     fi
 
+    if [ "${IPV6:-0}" = "1" ] ; then
+        echo "Removing ip6tables rules..."
+        remove_ipv6_rules
+    fi
+
     if [ -n "${INTERFACE}" ] ; then
         echo "Flushing interface ${INTERFACE}..."
         ip addr flush dev "${INTERFACE}" 2>/dev/null || true
@@ -199,6 +204,19 @@ else
    iptables -A FORWARD -i "${INTERFACE}" -j ACCEPT
 fi
 
+# Optional IPv6 support (off by default, enable with IPV6=1)
+# Logic lives in lib/ipv6.sh, shared with tests
+# shellcheck source=lib/ipv6.sh
+. "$(dirname "$0")/lib/ipv6.sh"
+
+_IPV6_CONF=""
+if [ "${IPV6:-0}" = "1" ] ; then
+    echo "Enabling IPv6 forwarding..."
+    enable_ipv6_forwarding
+    echo "Setting ip6tables rules for outgoing traffics..."
+    apply_ipv6_rules
+fi
+
 echo "Configuring DHCP server .."
 
 # Logic lives in lib/dhcp.sh, shared with tests
@@ -207,11 +225,16 @@ echo "Configuring DHCP server .."
 
 DHCP_RANGE=$(compute_dhcp_range) || exit 1
 
+if [ "${IPV6:-0}" = "1" ] ; then
+    _IPV6_CONF=$(compute_dnsmasq_ipv6_conf)
+fi
+
 cat > "/etc/dnsmasq.conf" <<EOF
 interface=${INTERFACE}
 dhcp-range=${DHCP_RANGE}
 dhcp-option=option:router,${AP_ADDR}
 dhcp-option=option:dns-server,${PRI_DNS},${SEC_DNS}
+${_IPV6_CONF}
 EOF
 
 echo "Starting dnsmasq daemon ..."


### PR DESCRIPTION
# feat: optional IPv6 support (RA/DHCPv6 via dnsmasq)

Closes #94

## Summary

Adds opt-in IPv6 support, off by default with zero behavior change unless `IPV6=1`.

## Changes

- **`lib/ipv6.sh`** (new): shared IPv6 logic
  - `compute_dnsmasq_ipv6_conf` — emits `dhcp-range=::,constructor:<IFACE>,ra-names,stateless` when enabled (RA + stateless DHCPv6)
  - `enable_ipv6_forwarding` — sets `net.ipv6.conf.all.forwarding=1`
  - `apply_ipv6_rules` / `remove_ipv6_rules` — ip6tables FORWARD rules mirroring the v4 handling, honoring `OUTGOINGS`
- **`wlanstart.sh`**: sources the lib; when `IPV6=1`, enables forwarding, applies ip6tables rules and appends the dnsmasq line to `/etc/dnsmasq.conf`; cleanup removes the rules on shutdown
- **`tests/ipv6.bats`** (new): 7 tests covering default-off, explicit disable, RA/DHCPv6 line generation, rule add/remove with and without `OUTGOINGS`
- **README.md**: env var table entry plus an "IPv6 Support" section documenting setup and caveats (no v6 NAT, upstream prefix dependency, runtime sysctl)

## Testing

- `bats tests/`: 107/107 pass
- `shellcheck -x wlanstart.sh lib/ipv6.sh`: clean
