### PR TITLE
feat: MAC address filtering (allowlist/denylist)

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,28 @@ docker run -d \
 | `COUNTRY_CODE` | No | Regulatory domain (`US`/`CA`/`MX`: ch 1-11, `JP`: ch 1-14, others: ch 1-13). Sets `country_code` in hostapd.conf | `EU` |
 | `WPA_VERSION` | No | WPA version: `2` = WPA2-PSK, `3` = WPA3-SAE (requires client support), `mixed` = WPA2/WPA3 transition (legacy clients allowed) | `2` |
 | `IPV6` | No | Enable IPv6 RA/DHCPv6 for clients (`1` = enabled) | `0` |
+| `MAC_FILTER` | No | MAC address filtering: `0` = off, `1` = allowlist (only listed MACs), `2` = denylist (listed MACs rejected). Requires `MAC_ACL_FILE` | `0` |
+| `MAC_ACL_FILE` | No | Path to MAC list file (one MAC per line, mounted volume); required when `MAC_FILTER` is `1` or `2` | unset |
+
+#### MAC Address Filtering (optional)
+
+MAC filtering is **off by default**; behavior is unchanged unless you set `MAC_FILTER`. When enabled:
+
+- `MAC_FILTER=1` (allowlist): only MACs listed in the file can associate (`macaddr_acl=1` + `accept_mac_file=`).
+- `MAC_FILTER=2` (denylist): listed MACs are rejected (`macaddr_acl=1` + `deny_mac_file=`).
+- Startup fails with an error if the filter is enabled without `MAC_ACL_FILE`, and warns if the file is missing or unreadable.
+- Note that MAC filtering is a weak control on its own (MACs can be spoofed); combine it with WPA2/WPA3.
+
+```bash
+docker run ... -e MAC_FILTER=1 -v /path/to/hostapd.accept:/etc/hostapd.accept:ro ...
+```
+
+File format (one MAC per line):
+
+```
+aa:bb:cc:dd:ee:ff
+11:22:33:44:55:66
+```
 
 #### WPA3 (SAE)
 

--- a/lib/mac_filter.sh
+++ b/lib/mac_filter.sh
@@ -1,0 +1,52 @@
+# shellcheck shell=bash
+# Shared optional MAC address filtering used by wlanstart.sh and tests.
+#
+# MAC filtering is off by default. When MAC_FILTER is set:
+#   1 = allowlist: only MACs listed in MAC_ACL_FILE may associate
+#   2 = denylist:  MACs listed in MAC_ACL_FILE are rejected
+#
+# compute_mac_filter_conf prints the extra hostapd.conf lines (or nothing
+# when disabled). Messages go to stderr. Returns non-zero on fatal
+# validation errors (filter enabled without a file).
+
+# validate_mac_filter checks the MAC_FILTER/MAC_ACL_FILE combination.
+# Returns 1 if the filter is enabled but no file is configured.
+validate_mac_filter() {
+    case "${MAC_FILTER:-0}" in
+        0)
+            return 0
+            ;;
+        1|2)
+            if [ -z "${MAC_ACL_FILE}" ] ; then
+                echo "[Error] MAC_FILTER=${MAC_FILTER} requires MAC_ACL_FILE to be set." >&2
+                return 1
+            fi
+            if [ ! -r "${MAC_ACL_FILE}" ] ; then
+                echo "[Warning] MAC_ACL_FILE '${MAC_ACL_FILE}' is missing or unreadable; hostapd may reject all clients." >&2
+            fi
+            return 0
+            ;;
+        *)
+            echo "[Error] Invalid MAC_FILTER value '${MAC_FILTER}' (expected 0, 1 or 2)." >&2
+            return 1
+            ;;
+    esac
+}
+
+# compute_mac_filter_conf prints hostapd.conf lines for MAC filtering.
+compute_mac_filter_conf() {
+    case "${MAC_FILTER:-0}" in
+        1)
+            echo "macaddr_acl=1"
+            echo "accept_mac_file=${MAC_ACL_FILE}"
+            ;;
+        2)
+            echo "macaddr_acl=1"
+            echo "deny_mac_file=${MAC_ACL_FILE}"
+            ;;
+        *)
+            echo "[Info] MAC_FILTER not enabled, skipping MAC address filtering." >&2
+            return 1
+            ;;
+    esac
+}

--- a/tests/mac_filter.bats
+++ b/tests/mac_filter.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+# Logic shared with wlanstart.sh
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+# shellcheck source=../lib/mac_filter.sh
+. "${REPO_ROOT}/lib/mac_filter.sh"
+
+setup() {
+    unset MAC_FILTER MAC_ACL_FILE
+}
+
+@test "MAC filter disabled by default: no hostapd conf" {
+    run compute_mac_filter_conf
+    [ "$status" -eq 1 ]
+}
+
+@test "MAC_FILTER=0 explicitly: no hostapd conf" {
+    MAC_FILTER=0
+    run compute_mac_filter_conf
+    [ "$status" -eq 1 ]
+}
+
+@test "MAC_FILTER=1 emits macaddr_acl=1 and accept_mac_file" {
+    MAC_FILTER=1
+    MAC_ACL_FILE="/etc/hostapd.accept"
+    run compute_mac_filter_conf
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "macaddr_acl=1" ]
+    [ "${lines[1]}" = "accept_mac_file=/etc/hostapd.accept" ]
+}
+
+@test "MAC_FILTER=2 emits macaddr_acl=1 and deny_mac_file" {
+    MAC_FILTER=2
+    MAC_ACL_FILE="/etc/hostapd.deny"
+    run compute_mac_filter_conf
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "macaddr_acl=1" ]
+    [ "${lines[1]}" = "deny_mac_file=/etc/hostapd.deny" ]
+}
+
+@test "validation passes when filter disabled without file" {
+    run validate_mac_filter
+    [ "$status" -eq 0 ]
+}
+
+@test "validation errors if allowlist enabled without file" {
+    MAC_FILTER=1
+    unset MAC_ACL_FILE
+    run validate_mac_filter
+    [ "$status" -eq 1 ]
+    [[ "${output}" == *"[Error]"*"MAC_ACL_FILE"* ]]
+}
+
+@test "validation errors if denylist enabled without file" {
+    MAC_FILTER=2
+    unset MAC_ACL_FILE
+    run validate_mac_filter
+    [ "$status" -eq 1 ]
+}
+
+@test "validation warns if ACL file missing" {
+    MAC_FILTER=1
+    MAC_ACL_FILE="${BATS_TEST_TMPDIR}/does-not-exist"
+    run validate_mac_filter
+    [ "$status" -eq 0 ]
+    [[ "${output}" == *"[Warning]"* ]]
+}
+
+@test "validation passes silently if ACL file readable" {
+    local f="${BATS_TEST_TMPDIR}/acl"
+    echo "aa:bb:cc:dd:ee:ff" > "${f}"
+    MAC_FILTER=2
+    MAC_ACL_FILE="${f}"
+    run validate_mac_filter
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "validation rejects invalid MAC_FILTER value" {
+    MAC_FILTER=3
+    MAC_ACL_FILE="/etc/hostapd.accept"
+    run validate_mac_filter
+    [ "$status" -eq 1 ]
+    [[ "${output}" == *"[Error]"*"Invalid MAC_FILTER"* ]]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -128,6 +128,15 @@ _AP_ISOLATION_CONF=$(compute_ap_isolation_line)
 . "$(dirname "$0")/lib/ssid_hidden.sh"
 _SSID_HIDDEN_CONF=$(compute_ssid_hidden_line)
 
+# MAC address filtering (off by default, enable with MAC_FILTER=1 or 2)
+# Logic lives in lib/mac_filter.sh, shared with tests
+# shellcheck source=lib/mac_filter.sh
+. "$(dirname "$0")/lib/mac_filter.sh"
+if ! validate_mac_filter ; then
+    exit 1
+fi
+_MAC_FILTER_CONF=$(compute_mac_filter_conf)
+
 _MAX_STA_CONF=$(compute_max_sta_conf)
 
 # Always regenerate hostapd.conf so env var changes apply between runs
@@ -144,6 +153,7 @@ wpa_ptk_rekey=600
 wmm_enabled=1
 ${_MAX_STA_CONF}
 ${_AP_ISOLATION_CONF}
+${_MAC_FILTER_CONF}
 
 # Activate channel selection for HT High Throughput (802.11an)
 


### PR DESCRIPTION
## Summary

Implements optional MAC address filtering for the AP, per #93.

- New env vars:
  - `MAC_FILTER`: `0` off (default), `1` allowlist (only listed MACs may associate), `2` denylist (listed MACs rejected)
  - `MAC_ACL_FILE`: path to the MAC list file (one MAC per line, mounted volume); required when `MAC_FILTER` is `1` or `2`
- Generated `hostapd.conf` gains `macaddr_acl=1` plus `accept_mac_file=<path>` or `deny_mac_file=<path>` when enabled
- Validation in new `lib/mac_filter.sh` (follows existing lib pattern):
  - error + exit if filter enabled without `MAC_ACL_FILE`
  - warning if file missing/unreadable
  - error on invalid `MAC_FILTER` values
- README: env var table entries + new "MAC Address Filtering" section
- Off by default: zero behavior change unless enabled

Closes #93

## Testing

- Added `tests/mac_filter.bats` (10 tests) covering disabled default, allowlist/denylist conf output, validation errors/warnings.
- Full local suite: `bats tests/` — **110/110 pass**.
- `shellcheck wlanstart.sh lib/mac_filter.sh` clean (only pre-existing SC1091 "not following" infos).
