### PR TITLE
feat(healthcheck): verify AP IP assigned to interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,20 @@ docker logs rpi-hostap
 
 Ensure the WiFi interface is up and not in use by another process.
 
+## Health Check
+
+The container defines a Docker `HEALTHCHECK` that runs `/bin/healthcheck.sh` every 30s (15s start period, 3 retries). The check verifies, in order:
+
+1. The container has been up longer than the grace period (`HEALTHCHECK_START_PERIOD`, default 15s); during this period it always passes.
+2. The `hostapd` process is running.
+3. The `dnsmasq` process is running.
+4. The wireless interface (`INTERFACE`) exists and is up.
+5. If `AP_ADDR` is set: the address is actually assigned to `INTERFACE` (via `ip -4 addr show`). This catches cases where IP configuration failed after hostapd started.
+
+If any check fails, the container is reported as `unhealthy`.
+
+Note: the AP's beaconing status itself is not verified — that would require enabling the hostapd control interface (`ctrl_interface`) in the generated config and querying it with `hostapd_cli`, which is intentionally not enabled to keep the container config minimal.
+
 ## Contributing
 
 See [CI.md](CI.md) for details on the release process and versioning.

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -33,6 +33,14 @@ if [ -n "$INTERFACE" ]; then
         echo "interface $INTERFACE is not up" >&2
         exit 1
     fi
+
+    # Check if the AP IP is assigned to the interface (if AP_ADDR is set)
+    if [ -n "$AP_ADDR" ]; then
+        if ! ip -4 addr show dev "$INTERFACE" | grep -q "$AP_ADDR"; then
+            echo "address $AP_ADDR is not assigned to interface $INTERFACE" >&2
+            exit 1
+        fi
+    fi
 fi
 
 exit 0

--- a/tests/healthcheck.bats
+++ b/tests/healthcheck.bats
@@ -63,6 +63,31 @@ EOF
     [ "$status" -eq 0 ]
 }
 
+@test "healthcheck fails when AP_ADDR is not assigned to interface" {
+    export AP_ADDR="192.168.254.1"
+    mock_bin pidof 'exit 0'
+    mock_bin ip 'if [ "$1" = "-4" ]; then echo "no match"; exit 0; fi; exit 0'
+    run ./healthcheck.sh
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"192.168.254.1 is not assigned to interface wlan0"* ]]
+}
+
+@test "healthcheck passes when AP_ADDR is assigned to interface" {
+    export AP_ADDR="192.168.254.1"
+    mock_bin pidof 'exit 0'
+    mock_bin ip 'if [ "$1" = "-4" ]; then echo "inet 192.168.254.1/24"; exit 0; fi; exit 0'
+    run ./healthcheck.sh
+    [ "$status" -eq 0 ]
+}
+
+@test "healthcheck skips AP_ADDR check when unset" {
+    unset AP_ADDR
+    mock_bin pidof 'exit 0'
+    mock_bin ip 'if [ "$1" = "-4" ]; then exit 1; fi; exit 0'
+    run ./healthcheck.sh
+    [ "$status" -eq 0 ]
+}
+
 @test "healthcheck respects HEALTHCHECK_START_PERIOD env var" {
     export HEALTHCHECK_START_PERIOD=30
     echo "20.00 20.00" > "$HEALTHCHECK_UPTIME_FILE"


### PR DESCRIPTION
## Summary

Enhances `healthcheck.sh` per #91:

- Fails the healthcheck when `${AP_ADDR}` is set but not actually assigned to `${INTERFACE}` (`ip -4 addr show dev "$INTERFACE" | grep -q "$AP_ADDR"`). The check runs only when both `INTERFACE` and `AP_ADDR` are set, and only after the interface-exists check.
- Adds a **Health Check** section to the README documenting all checks, the start-period grace behavior, and why `hostapd_cli` beaconing verification was intentionally not added.
- Adds 3 new bats tests in `tests/healthcheck.bats`: failure when AP_ADDR missing, success when assigned, skip when unset.

### hostapd_cli decision

Skipped. Verifying AP operational status via `hostapd_cli` would require adding `ctrl_interface=/var/run/hostapd` to the generated hostapd.conf and shipping/querying the control socket — an invasive change to wlanstart.sh for marginal benefit over the process + IP checks. Documented as a note in the README instead.

Closes #91

## Test plan

- [x] `shellcheck -x healthcheck.sh` clean
- [x] `bats tests/healthcheck.bats` — 10/10 pass locally
- [x] CI green
