### PR TITLE
feat: use multirun to manage hostapd/dnsmasq processes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,8 @@ RUN apk add --no-cache \
     bash=5.3.9-r1 \
     hostapd=2.11-r4 \
     iptables=1.8.13-r0 \
-    dnsmasq=2.92_p2-r0
+    dnsmasq=2.92_p2-r0 \
+    multirun=1.1.3-r0
 
 ENV HEALTHCHECK_START_PERIOD=15
 

--- a/tests/cleanup.bats
+++ b/tests/cleanup.bats
@@ -6,12 +6,10 @@ setup() {
     export INTERFACE="wlan0"
     export SUBNET="192.168.254.0"
     export OUTGOINGS=""
-    export HOSTAPD_PID=""
-    export DNSMASQ_PID=""
 }
 
 load_cleanup() {
-    eval "$(sed -n '/^parse_outgoings()/,/^}/p; /^cleanup()/,/^}/p; /^trap cleanup/p' wlanstart.sh)"
+    eval "$(sed -n '/^parse_outgoings()/,/^}/p; /^cleanup()/,/^}/p; /^trap /p' wlanstart.sh)"
 }
 
 run_cleanup_mocked() {
@@ -26,11 +24,9 @@ ip() { _mock_log \"ip \$@\"; }
 kill() { _mock_log \"kill \$@\"; }
 wait() { _mock_log \"wait \$@\"; }
 $(sed -n '/^parse_outgoings()/,/^}/p; /^cleanup()/,/^}/p' wlanstart.sh)
-INTERFACE=\"$INTERFACE\"
-SUBNET=\"$SUBNET\"
-OUTGOINGS=\"$OUTGOINGS\"
-HOSTAPD_PID=\"$HOSTAPD_PID\"
-DNSMASQ_PID=\"$DNSMASQ_PID\"
+INTERFACE="$INTERFACE"
+SUBNET="$SUBNET"
+OUTGOINGS="$OUTGOINGS"
 cleanup
 "
     cat "$mock_log"
@@ -68,9 +64,9 @@ cleanup
     load_cleanup
     local traps
     traps=$(trap -p)
-    [[ "$traps" == *"cleanup"*"SIGINT"* ]]
-    [[ "$traps" == *"cleanup"*"SIGTERM"* ]]
-    [[ "$traps" == *"cleanup"*"SIGHUP"* ]]
+    [[ "$traps" == *"handle_signal"*"SIGINT"* ]]
+    [[ "$traps" == *"handle_signal"*"SIGTERM"* ]]
+    [[ "$traps" == *"handle_signal"*"SIGHUP"* ]]
 }
 
 @test "cleanup prints shutdown message" {
@@ -79,20 +75,41 @@ cleanup
     [[ "$output" == *"Shutting down..."* ]]
 }
 
+@test "cleanup no longer kills daemon PIDs (multirun handles signals)" {
+    ! grep -q 'DNSMASQ_PID\|HOSTAPD_PID' wlanstart.sh
+    ! grep -qE 'wait "\$\{DNSMASQ_PID\}"' wlanstart.sh
+}
+
+@test "handle_signal forwards signal to multirun" {
+    eval "$(sed -n '/^_MULTIRUN_PID=/p; /^_SIGNALED=/p; /^handle_signal()/,/^}/p; /^trap /p' wlanstart.sh)"
+    _MULTIRUN_PID="4242"
+    _SIGNALED=0
+    run bash -c "
+kill() { echo \"kill \$@\"; }
+$(sed -n '/^handle_signal()/,/^}/p' "${BATS_TEST_DIRNAME}/../wlanstart.sh")
+_MULTIRUN_PID=4242
+_SIGNALED=0
+handle_signal
+"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"kill 4242"* ]]
+}
+
+@test "wlanstart launches daemons via multirun with exec" {
+    grep -q 'multirun "exec dnsmasq --no-daemon" "exec /usr/sbin/hostapd /etc/hostapd.conf"' wlanstart.sh
+    ! grep -q 'wait "${DNSMASQ_PID}" "${HOSTAPD_PID}"' wlanstart.sh
+}
+
 @test "cleanup prints iptables removal message" {
     load_cleanup
     run cleanup
     [[ "$output" == *"Removing iptables rules..."* ]]
 }
 
-@test "cleanup kills hostapd and dnsmasq PIDs" {
-    export HOSTAPD_PID="1234"
-    export DNSMASQ_PID="5678"
+@test "cleanup tears down iptables and interface without touching daemons" {
     run run_cleanup_mocked
-    [[ "$output" == *"kill 1234"* ]]
-    [[ "$output" == *"kill 5678"* ]]
-    [[ "$output" == *"wait 1234"* ]]
-    [[ "$output" == *"wait 5678"* ]]
+    [[ "$output" != *"kill "* ]]
+    [[ "$output" != *"wait "* ]]
 }
 
 @test "cleanup removes iptables rules without OUTGOINGS" {

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -12,10 +12,6 @@ parse_outgoings() {
 
 cleanup() {
     echo "Shutting down..."
-    kill "${HOSTAPD_PID}" 2>/dev/null
-    kill "${DNSMASQ_PID}" 2>/dev/null
-    wait "${HOSTAPD_PID}" 2>/dev/null
-    wait "${DNSMASQ_PID}" 2>/dev/null
 
     echo "Removing iptables rules..."
 
@@ -44,11 +40,22 @@ cleanup() {
         ip addr flush dev "${INTERFACE}" 2>/dev/null || true
         ip link set "${INTERFACE}" down 2>/dev/null || true
     fi
-
-    exit 0
 }
 
-trap cleanup SIGINT SIGTERM SIGHUP
+# multirun manages hostapd/dnsmasq and exits when any child dies.
+# On SIGINT/SIGTERM we forward the signal to multirun, which relays it
+# to all children; teardown runs once multirun has exited.
+_MULTIRUN_PID=""
+_SIGNALED=0
+
+handle_signal() {
+    _SIGNALED=1
+    if [ -n "${_MULTIRUN_PID}" ] ; then
+        kill "${_MULTIRUN_PID}" 2>/dev/null || true
+    fi
+}
+
+trap handle_signal SIGINT SIGTERM SIGHUP
 
 # Check if running in privileged mode
 if [ ! -w "/sys" ] ; then
@@ -247,23 +254,16 @@ dhcp-option=option:dns-server,${PRI_DNS},${SEC_DNS}
 ${_IPV6_CONF}
 EOF
 
-echo "Starting dnsmasq daemon ..."
-dnsmasq --no-daemon &
-DNSMASQ_PID=$!
+echo "Starting dnsmasq and hostapd via multirun ..."
+multirun "exec dnsmasq --no-daemon" "exec /usr/sbin/hostapd /etc/hostapd.conf" &
+_MULTIRUN_PID=$!
 
-if ! kill -0 "${DNSMASQ_PID}" 2>/dev/null ; then
-    echo "[Error] dnsmasq failed to start."
-    exit 1
+wait "${_MULTIRUN_PID}"
+STATUS=$?
+
+cleanup
+
+if [ "${_SIGNALED}" = "1" ] ; then
+    exit 0
 fi
-
-echo "Starting HostAP daemon ..."
-/usr/sbin/hostapd /etc/hostapd.conf &
-HOSTAPD_PID=$!
-
-if ! kill -0 "${HOSTAPD_PID}" 2>/dev/null ; then
-    echo "[Error] hostapd failed to start."
-    kill "${DNSMASQ_PID}" 2>/dev/null
-    exit 1
-fi
-
-wait "${DNSMASQ_PID}" "${HOSTAPD_PID}"
+exit "${STATUS}"

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -49,9 +49,8 @@ _MULTIRUN_PID=""
 _SIGNALED=0
 
 # Invoked indirectly via trap
-# shellcheck disable=SC2329
+# shellcheck disable=SC2329,SC2317
 handle_signal() {
-    # shellcheck disable=SC2317
     _SIGNALED=1
     if [ -n "${_MULTIRUN_PID}" ] ; then
         kill "${_MULTIRUN_PID}" 2>/dev/null || true

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -48,7 +48,10 @@ cleanup() {
 _MULTIRUN_PID=""
 _SIGNALED=0
 
+# Invoked indirectly via trap
+# shellcheck disable=SC2329
 handle_signal() {
+    # shellcheck disable=SC2317
     _SIGNALED=1
     if [ -n "${_MULTIRUN_PID}" ] ; then
         kill "${_MULTIRUN_PID}" 2>/dev/null || true


### PR DESCRIPTION
# feat: use multirun to manage hostapd/dnsmasq processes

Fixes #87

## Problem

`wlanstart.sh` used bash background jobs plus `wait "${DNSMASQ_PID}" "${HOSTAPD_PID}"`. Bash's `wait` with multiple PIDs blocks until **all** children exit, so if `hostapd` crashed (driver error, USB dongle disconnect), the container kept running with only `dnsmasq` alive — a zombie AP that never exits or restarts.

## Changes

- **Dockerfile**: add `multirun=1.1.3-r0` to `apk add`, matching the existing Alpine package pinning style.
- **wlanstart.sh**:
  - Replace the two background daemons, PID health checks and `wait "${DNSMASQ_PID}" "${HOSTAPD_PID}"` with:
    ```bash
    multirun "exec dnsmasq --no-daemon" "exec /usr/sbin/hostapd /etc/hostapd.conf"
    ```
    Each child uses `exec` (per the [multirun FAQ](https://github.com/nicolas-van/multirun/blob/master/README.md#my-processes-do-not-exit-correctly)) so signals reach the daemon directly.
  - When any child exits, multirun SIGTERMs the other children's process groups and exits non-zero → Docker's restart policy recovers the AP.
  - All setup/validation/config generation is unchanged.
- **tests/cleanup.bats**: updated for multirun — removed PID kill/wait expectations, added tests for `handle_signal`, multirun launch line, and that cleanup no longer touches daemon PIDs.

## Design decision: cleanup trap vs cleanup before exec

The issue suggested possibly `exec multirun ...` (replacing the shell entirely). That was rejected: once the script `exec`s, there is no shell left to run iptables/interface teardown when multirun exits, which would leak NAT/FORWARD rules and leave `wlan0` configured across restarts.

Instead the simplest correct approach keeps the script as PID 1:

1. A `handle_signal` trap forwards SIGINT/SIGTERM to multirun (multirun relays them to all children's process groups).
2. multirun runs in the background; the script `wait`s on it.
3. After multirun exits — whether because a child died or a signal was received — `cleanup` performs iptables/ip6tables/interface teardown.
4. Exit status: 0 on signal-driven shutdown, otherwise multirun's exit status so Docker restarts on daemon failure.

## Acceptance criteria

- [x] If either hostapd or dnsmasq dies, the container exits non-zero (multirun exit code propagated).
- [x] SIGTERM/SIGINT cleanly stop both daemons and tear down iptables/interface.
- [x] multirun added in the Alpine package pinning style (`multirun=1.1.3-r0`).
- [x] Bats tests updated (116/116 passing locally).
