### PR TITLE
chore(ci): cache wireless stack modules keyed on runner kernel version

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -42,11 +42,30 @@ jobs:
           sudo apt-get install -y socat iproute2 iw busybox wpasupplicant \
             "linux-headers-$(uname -r)"
 
+      - name: Get kernel version
+        id: kver
+        run: echo "version=$(uname -r)" >> "$GITHUB_OUTPUT"
+
+      # Modules are compiled against the exact running kernel, so the cache
+      # key embeds `uname -r` to guarantee compatibility; folding in the
+      # workflow file hash creates a fresh entry whenever the build recipe
+      # changes (superseded entries are evicted by GitHub's standard policy).
+      # No restore-keys: a stale/incompatible entry must never be partially
+      # restored.
+      - name: Cache wireless stack modules
+        id: hwsim-cache
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4.3.0
+        with:
+          key: hwsim-modules-${{ runner.os }}-kernel-${{ steps.kver.outputs.version }}-${{ hashFiles('.github/workflows/system-test.yml') }}
+          path: /tmp/hwsim
+
       # The azure runner kernel does not ship the 802.11 stack at all
       # (no cfg80211/mac80211/mac80211_hwsim), and hosted runners cannot
       # resume a job across a reboot to switch kernels. Build the full
-      # wireless stack out-of-tree from the matching stable kernel tag.
+      # wireless stack out-of-tree from the matching stable kernel tag;
+      # skipped entirely on a cache hit.
       - name: Build wireless stack modules
+        if: steps.hwsim-cache.outputs.cache-hit != 'true'
         run: |
           KVER="$(uname -r)"
           TAG="v$(echo "${KVER}" | grep -oE '^[0-9]+\.[0-9]+')"


### PR DESCRIPTION
# chore(ci): cache wireless stack modules keyed on runner kernel version

Refs #110

## Summary

Cache the out-of-tree wireless kernel modules built by the system test
workflow (`libarc4.ko`, `cfg80211.ko`, `mac80211.ko`, `mac80211_hwsim.ko`
in `/tmp/hwsim/`) using `actions/cache`, so subsequent CI runs skip the
expensive stable-kernel clone + module build (~several minutes).

## Changes (`.github/workflows/system-test.yml`)

1. **Get kernel version** (`id: kver`): writes `uname -r` to
   `$GITHUB_OUTPUT` for reuse in the cache key.
2. **Cache wireless stack modules** (`id: hwsim-cache`): new step placed
   before the build, using SHA-pinned `actions/cache@0057852… # v4.3.0`.
   - Key: `hwsim-modules-${{ runner.os }}-kernel-$(uname -r)-${{ hashFiles('.github/workflows/system-test.yml') }}`
   - Path: `/tmp/hwsim`
3. **Build wireless stack modules**: gated with
   `if: steps.hwsim-cache.outputs.cache-hit != 'true'`.

## Design decisions

- **Keyed on `uname -r`**: modules are compiled against the exact running
  runner kernel (`/lib/modules/$(uname -r)/build`), so keying on the
  kernel version guarantees a restored cache is always loadable.
- **Workflow hash folded into the key**: any change to the build recipe
  produces a fresh cache entry; superseded entries are discarded by
  GitHub's standard eviction policy.
- **No `restore-keys`**: deliberately omitted — a stale or incompatible
  entry must never be partially restored and then insmod'ed.
- **Expiry**: standard GitHub free-tier eviction (7 days unused).

## Test plan

- YAML validated locally (`ruby -ryaml`): parses cleanly.
- Verified every `uses:` line in the workflow is pinned to a full-length
  commit SHA with a version comment (repo rule), including the new
  `actions/cache` pin.
- Full `bats tests/` suite: 116/116 pass.
- First labeled run will populate the cache; subsequent runs should log a
  `Cache restored from key:` hit and skip the build step.
