### PR TITLE
fix(entrypoint): handle signals received before multirun starts

### DIFF
--- a/tests/early_signal.bats
+++ b/tests/early_signal.bats
@@ -1,0 +1,105 @@
+#!/usr/bin/env bats
+
+# Tests for handling signals received before multirun starts (issue #115)
+
+SCRIPT="${BATS_TEST_DIRNAME}/../wlanstart.sh"
+
+extract_functions() {
+    sed -n '/^parse_outgoings()/,/^}/p; /^cleanup()/,/^}/p; /^_MULTIRUN_PID=""$/p; /^_SIGNALED=0$/p; /^handle_signal()/,/^}/p; /^check_interrupted()/,/^}/p' "${SCRIPT}"
+}
+
+@test "check_interrupted is defined" {
+    eval "$(extract_functions)"
+    [ "$(type -t check_interrupted)" = "function" ]
+}
+
+@test "check_interrupted exits 0 and runs cleanup when _SIGNALED=1" {
+    run bash -c "
+$(extract_functions)
+iptables() { echo \"iptables \$@\"; }
+ip() { echo \"ip \$@\"; }
+export INTERFACE=wlan0 SUBNET=192.168.254.0 OUTGOINGS=
+_SIGNALED=1
+check_interrupted
+echo REACHED_AFTER_CHECK
+"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Shutting down..."* ]]
+    [[ "$output" == *"[Info] Shutdown requested during startup."* ]]
+    [[ "$output" == *"iptables -t nat -D POSTROUTING"* ]]
+    [[ "$output" != *"REACHED_AFTER_CHECK"* ]]
+}
+
+@test "check_interrupted writes shutdown notice to stderr" {
+    run bash -c "
+$(extract_functions)
+cleanup() { : ; }
+_SIGNALED=1
+check_interrupted
+"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[Info] Shutdown requested during startup."* ]]
+}
+
+@test "check_interrupted does nothing when _SIGNALED=0" {
+    run bash -c "
+$(extract_functions)
+cleanup() { echo 'CLEANUP RAN'; }
+multirun() { echo 'MULTIRUN STARTED'; }
+_SIGNALED=0
+check_interrupted
+multirun
+"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"MULTIRUN STARTED"* ]]
+    [[ "$output" != *"CLEANUP RAN"* ]]
+    [[ "$output" != *"Shutdown requested"* ]]
+}
+
+@test "trap fires on SIGTERM before multirun and startup aborts with exit 0" {
+    local mock_log
+    mock_log=$(mktemp)
+    run bash -c "
+$(extract_functions)
+cleanup() { echo 'CLEANUP RAN'; }
+multirun() { echo 'MULTIRUN STARTED' >> '${mock_log}'; }
+trap handle_signal SIGINT SIGTERM SIGHUP
+kill -TERM \$\$
+check_interrupted
+echo 'Starting dnsmasq and hostapd via multirun ...'
+multirun
+"
+    rm -f "${mock_log}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"CLEANUP RAN"* ]]
+    [[ "$output" == *"[Info] Shutdown requested during startup."* ]]
+    [[ "$output" != *"Starting dnsmasq and hostapd via multirun"* ]]
+}
+
+@test "without signal, startup proceeds past check_interrupted to multirun" {
+    local mock_log
+    mock_log=$(mktemp)
+    export MOCK_LOG="${mock_log}"
+    run bash -c "
+$(extract_functions)
+cleanup() { echo 'CLEANUP RAN'; }
+trap handle_signal SIGINT SIGTERM SIGHUP
+check_interrupted
+echo 'Starting dnsmasq and hostapd via multirun ...'
+"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Starting dnsmasq and hostapd via multirun ..."* ]]
+    [[ "$output" != *"CLEANUP RAN"* ]]
+    [[ "$output" != *"Shutdown requested"* ]]
+}
+
+@test "check_interrupted is called at each key point before multirun" {
+    local ci_calls multi_line
+    ci_calls=$(grep -n '^\s*check_interrupted\s*$' "${SCRIPT}" | tail -1 | cut -d: -f1)
+    multi_line=$(grep -n '^multirun ' "${SCRIPT}" | head -1 | cut -d: -f1)
+    [ -n "${ci_calls}" ]
+    [ -n "${multi_line}" ]
+    [ "${ci_calls}" -lt "${multi_line}" ]
+    # at least: after preflight checks, after hostapd.conf, after ip setup, after iptables
+    [ "$(grep -c '^\s*check_interrupted\s*$' "${SCRIPT}")" -ge 4 ]
+}

--- a/tests/early_signal.bats
+++ b/tests/early_signal.bats
@@ -14,10 +14,12 @@ extract_functions() {
 }
 
 @test "check_interrupted exits 0 and runs cleanup when _SIGNALED=1" {
+    local mock_log
+    mock_log=$(mktemp)
     run bash -c "
 $(extract_functions)
-iptables() { echo \"iptables \$@\"; }
-ip() { echo \"ip \$@\"; }
+iptables() { echo \"iptables \$@\" >> '${mock_log}'; }
+ip() { echo \"ip \$@\" >> '${mock_log}'; }
 export INTERFACE=wlan0 SUBNET=192.168.254.0 OUTGOINGS=
 _SIGNALED=1
 check_interrupted
@@ -26,8 +28,9 @@ echo REACHED_AFTER_CHECK
     [ "$status" -eq 0 ]
     [[ "$output" == *"Shutting down..."* ]]
     [[ "$output" == *"[Info] Shutdown requested during startup."* ]]
-    [[ "$output" == *"iptables -t nat -D POSTROUTING"* ]]
+    grep -q 'iptables -t nat -D POSTROUTING' "${mock_log}"
     [[ "$output" != *"REACHED_AFTER_CHECK"* ]]
+    rm -f "${mock_log}"
 }
 
 @test "check_interrupted writes shutdown notice to stderr" {

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -57,6 +57,15 @@ handle_signal() {
     fi
 }
 
+# Exit promptly when a signal arrives before multirun is launched
+check_interrupted() {
+    if [ "${_SIGNALED}" = "1" ] ; then
+        echo "[Info] Shutdown requested during startup." >&2
+        cleanup
+        exit 0
+    fi
+}
+
 trap handle_signal SIGINT SIGTERM SIGHUP
 
 # Check if running in privileged mode
@@ -111,6 +120,7 @@ emit_credential_warnings
 if ! validate_passphrase ; then
     exit 1
 fi
+check_interrupted
 
 # MAX_STATIONS: limit number of associated stations (0 = unlimited)
 # Logic lives in lib/stations.sh, shared with tests
@@ -174,11 +184,13 @@ ${HT_CAPAB+"ht_capab=${HT_CAPAB}"}
 ${VHT_ENABLED+"ieee80211ac=1"}
 ${VHT_CAPAB+"vht_capab=${VHT_CAPAB}"}
 EOF
+check_interrupted
 
 # Setup interface and restart DHCP service
 ip link set "${INTERFACE}" up
 ip addr flush dev "${INTERFACE}"
 ip addr add "${AP_ADDR}"/24 dev "${INTERFACE}"
+check_interrupted
 
 # NAT settings
 echo "NAT settings ip_dynaddr, ip_forward"
@@ -257,6 +269,7 @@ ${_IPV6_CONF}
 EOF
 
 echo "Starting dnsmasq and hostapd via multirun ..."
+check_interrupted
 # NOTE: multirun already wraps each command in `exec`; do not add it here.
 multirun "dnsmasq --no-daemon" "/usr/sbin/hostapd /etc/hostapd.conf" &
 _MULTIRUN_PID=$!


### PR DESCRIPTION
## Problem

`wlanstart.sh:handle_signal` only sets `_SIGNALED=1` and kills `_MULTIRUN_PID`. If SIGTERM/SIGINT arrives **before** multirun is launched (during env parsing, validation, hostapd/dnsmasq.conf generation, iptables setup), nothing re-checks `_SIGNALED` in the main path, so the script runs the entire startup anyway and then blocks on `wait`.

Result: `docker stop` during startup does not stop the container promptly.

Closes #115

## Fix

Add a `check_interrupted()` helper next to `handle_signal()`:

```bash
check_interrupted() {
    if [ "${_SIGNALED}" = "1" ] ; then
        echo "[Info] Shutdown requested during startup." >&2
        cleanup
        exit 0
    fi
}
```

and call it at four key points in the startup path:

1. after the preflight/validation checks (after passphrase validation)
2. after `hostapd.conf` generation
3. after interface/IP address setup (`ip link/addr`)
4. after iptables/ip6tables/DHCP setup, immediately before `multirun ... &`

When a signal was received, the script now runs `cleanup` (tearing down any iptables rules / interface state already applied) and exits with status `0`, consistent with the existing shutdown-after-`wait` path.

## Tests

New file `tests/early_signal.bats` (follows the extraction pattern of `tests/cleanup.bats`):

- `check_interrupted` is defined
- exits `0`, runs `cleanup` (iptables teardown verified via mocks) and does **not** continue to multirun when `_SIGNALED=1`
- shutdown notice goes to stderr
- does nothing when `_SIGNALED=0` (startup proceeds to multirun mock)
- integration-style: extracted functions + real trap; sending SIGTERM via `kill -TERM $$` before multirun triggers `handle_signal`, and `check_interrupted` aborts startup with exit 0 without invoking multirun
- ordering guard: at least 4 `check_interrupted` call sites exist and the last one precedes the `multirun` line

## Verification

- `bats tests/`: all 123 tests pass
- `shellcheck wlanstart.sh`: clean (only pre-existing SC1091 info notices)
