### PR TITLE
fix(entrypoint): validate AP_ADDR/SUBNET and abort on interface/IP setup failure

### DIFF
--- a/lib/validation.sh
+++ b/lib/validation.sh
@@ -1,0 +1,24 @@
+# shellcheck shell=bash
+# Shared IPv4 address validation logic used by wlanstart.sh and tests.
+#
+# validate_ipv4 checks that its argument is a well-formed dotted-quad
+# IPv4 address (four decimal octets 0-255). Pure bash so it can be
+# tested on macOS without network tools.
+validate_ipv4() {
+    local addr=${1:-}
+    local octet
+
+    if ! [[ "${addr}" =~ ^([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})\.([0-9]{1,3})$ ]] ; then
+        return 1
+    fi
+
+    for octet in "${BASH_REMATCH[@]:1}" ; do
+        # Leading zeros are ambiguous (and 08/09 break arithmetic in some shells)
+        if [ "${#octet}" -gt 1 ] && [ "${octet:0:1}" = "0" ] ; then
+            return 1
+        fi
+        if [ "${octet}" -gt 255 ] ; then
+            return 1
+        fi
+    done
+}

--- a/tests/validation.bats
+++ b/tests/validation.bats
@@ -1,0 +1,84 @@
+#!/usr/bin/env bats
+
+# Tests exercise validate_ipv4() from lib/validation.sh — the exact
+# code used by wlanstart.sh (no duplicated logic).
+
+load_lib() {
+    . "${BATS_TEST_DIRNAME}/../lib/validation.sh"
+}
+
+# wlanstart-level early-exit check: source the exact validation blocks
+# from wlanstart.sh in a subshell.
+run_wlanstart_validation() {
+    bash -c "
+. '${BATS_TEST_DIRNAME}/../lib/validation.sh'
+$(sed -n '/if ! validate_ipv4 "\${SUBNET}"/,/^fi$/p; /if ! validate_ipv4 "\${AP_ADDR}"/,/^fi$/p' "${BATS_TEST_DIRNAME}/../wlanstart.sh")
+" 2>&1
+}
+
+@test "valid IPv4 addresses are accepted" {
+    load_lib
+    for addr in 192.168.254.0 192.168.254.1 8.8.8.8 0.0.0.0 255.255.255.255 10.0.0.1 ; do
+        run validate_ipv4 "${addr}"
+        [ "$status" -eq 0 ]
+    done
+}
+
+@test "letters are rejected" {
+    load_lib
+    run validate_ipv4 "192.168.abc.1"
+    [ "$status" -ne 0 ]
+}
+
+@test "octets above 255 are rejected" {
+    load_lib
+    run validate_ipv4 "192.168.256.1"
+    [ "$status" -ne 0 ]
+    run validate_ipv4 "300.168.0.1"
+    [ "$status" -ne 0 ]
+}
+
+@test "wrong octet count is rejected" {
+    load_lib
+    run validate_ipv4 "192.168.0"
+    [ "$status" -ne 0 ]
+    run validate_ipv4 "192.168.0.1.5"
+    [ "$status" -ne 0 ]
+}
+
+@test "empty value is rejected" {
+    load_lib
+    run validate_ipv4 ""
+    [ "$status" -ne 0 ]
+    run validate_ipv4
+    [ "$status" -ne 0 ]
+}
+
+@test "leading-zero octets are rejected" {
+    load_lib
+    run validate_ipv4 "192.168.01.1"
+    [ "$status" -ne 0 ]
+}
+
+@test "missing octets between dots is rejected" {
+    load_lib
+    run validate_ipv4 "192..0.1"
+    [ "$status" -ne 0 ]
+}
+
+@test "invalid SUBNET aborts with error before system changes" {
+    SUBNET="not.an.ip.addr" AP_ADDR="192.168.254.1" run run_wlanstart_validation
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid SUBNET"* ]]
+}
+
+@test "invalid AP_ADDR aborts with error before system changes" {
+    SUBNET="192.168.254.0" AP_ADDR="192.168.254.999" run run_wlanstart_validation
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid AP_ADDR"* ]]
+}
+
+@test "valid SUBNET and AP_ADDR pass validation" {
+    SUBNET="192.168.254.0" AP_ADDR="192.168.254.1" run run_wlanstart_validation
+    [ "$status" -eq 0 ]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -108,6 +108,20 @@ fi
 : "${WPA_PASSPHRASE:=passw0rd}"
 : "${MAX_STATIONS:=0}"
 
+# Validate AP_ADDR and SUBNET are well-formed IPv4 addresses before
+# touching the system.
+# Logic lives in lib/validation.sh, shared with tests
+# shellcheck source=lib/validation.sh
+. "$(dirname "$0")/lib/validation.sh"
+if ! validate_ipv4 "${SUBNET}" ; then
+    echo "[Error] Invalid SUBNET: '${SUBNET}' is not a valid IPv4 address." >&2
+    exit 1
+fi
+if ! validate_ipv4 "${AP_ADDR}" ; then
+    echo "[Error] Invalid AP_ADDR: '${AP_ADDR}' is not a valid IPv4 address." >&2
+    exit 1
+fi
+
 # Startup warnings for default credentials
 # Logic lives in lib/warnings.sh, shared with tests
 # shellcheck source=lib/warnings.sh
@@ -187,9 +201,18 @@ EOF
 check_interrupted
 
 # Setup interface and restart DHCP service
-ip link set "${INTERFACE}" up
-ip addr flush dev "${INTERFACE}"
-ip addr add "${AP_ADDR}"/24 dev "${INTERFACE}"
+ip link set "${INTERFACE}" up || {
+    echo "[Error] Failed to bring up interface ${INTERFACE}" >&2
+    exit 1
+}
+ip addr flush dev "${INTERFACE}" || {
+    echo "[Error] Failed to flush addresses on ${INTERFACE}" >&2
+    exit 1
+}
+ip addr add "${AP_ADDR}"/24 dev "${INTERFACE}" || {
+    echo "[Error] Failed to assign ${AP_ADDR}/24 to ${INTERFACE}" >&2
+    exit 1
+}
 check_interrupted
 
 # NAT settings


### PR DESCRIPTION
## Summary

Fixes #114.

- **New `lib/validation.sh`** exposing `validate_ipv4()`: pure-bash dotted-quad check with octet range validation (0-255), rejection of leading-zero octets and empty/malformed input. Testable on macOS without network tools.
- **wlanstart.sh**: validates `SUBNET` and `AP_ADDR` right after defaults are applied and aborts with a clear `[Error] Invalid ...` message before any system changes.
- **wlanstart.sh interface setup** (`ip link set up`, `ip addr flush`, `ip addr add`) now aborts startup with a non-zero exit and an explicit error message if any of the three commands fail, instead of continuing into NAT/dnsmasq/hostapd setup and producing a half-configured AP.

Per issue guidance, plain `exit 1` is used (consistent with existing validation failures): at the point of failure no iptables rules have been applied yet, so there is nothing to roll back.

## Tests

New `tests/validation.bats` following the existing sed-extraction / shared-lib patterns:

- valid IPv4 addresses accepted (`192.168.254.0`, `8.8.8.8`, `255.255.255.255`, ...)
- malformed values rejected: letters, octets > 255, wrong octet count, empty value, leading-zero octets, missing octets between dots
- wlanstart-level checks: invalid `SUBNET` / `AP_ADDR` abort early with the expected error messages; valid values pass

`bats tests/`: **133/133 green**. `shellcheck wlanstart.sh lib/validation.sh`: clean (only pre-existing info-level SC1091 notices shared by all lib sources).
