### PR TITLE
fix(mac_filter): make disabled path a silent no-op returning success

### DIFF
--- a/lib/mac_filter.sh
+++ b/lib/mac_filter.sh
@@ -45,8 +45,7 @@ compute_mac_filter_conf() {
             echo "deny_mac_file=${MAC_ACL_FILE}"
             ;;
         *)
-            echo "[Info] MAC_FILTER not enabled, skipping MAC address filtering." >&2
-            return 1
+            return 0
             ;;
     esac
 }

--- a/tests/mac_filter.bats
+++ b/tests/mac_filter.bats
@@ -9,15 +9,17 @@ setup() {
     unset MAC_FILTER MAC_ACL_FILE
 }
 
-@test "MAC filter disabled by default: no hostapd conf" {
+@test "MAC filter disabled by default: silent no-op success" {
     run compute_mac_filter_conf
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
 }
 
-@test "MAC_FILTER=0 explicitly: no hostapd conf" {
+@test "MAC_FILTER=0 explicitly: silent no-op success" {
     MAC_FILTER=0
     run compute_mac_filter_conf
-    [ "$status" -eq 1 ]
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
 }
 
 @test "MAC_FILTER=1 emits macaddr_acl=1 and accept_mac_file" {


### PR DESCRIPTION
## Problem

`compute_mac_filter_conf` in `lib/mac_filter.sh`, when MAC filtering is disabled (the default, `MAC_FILTER` unset or `0`), printed an `[Info]` message to stderr and returned `1`. This:

- Spammed stderr on every start with a non-actionable informational message.
- Was a trap for callers running under `set -e`, since the function returned non-zero on a normal, expected path.

## Fix

The disabled path (`*`) in `compute_mac_filter_conf` is now a silent no-op that simply `return 0`s — no output, success status. Enabled paths (`MAC_FILTER=1`/`2`) are unchanged.

## Tests

Updated `tests/mac_filter.bats`:

- "MAC filter disabled by default" now asserts status `0` **and** empty output.
- "MAC_FILTER=0 explicitly" likewise asserts status `0` and empty output.
- Existing cases for `MAC_FILTER=1` and `MAC_FILTER=2` are unchanged.

Closes #116
