### PR TITLE
refactor(entrypoint): extract NAT/interface logic into lib/nat.sh and lib/interface.sh

### DIFF
--- a/lib/interface.sh
+++ b/lib/interface.sh
@@ -1,0 +1,27 @@
+# shellcheck shell=bash
+# Shared interface bring-up/teardown logic used by wlanstart.sh and tests.
+
+# setup_interface brings the AP interface up and assigns the AP address.
+setup_interface() {
+    ip link set "${INTERFACE}" up || {
+        echo "[Error] Failed to bring up interface ${INTERFACE}" >&2
+        return 1
+    }
+    ip addr flush dev "${INTERFACE}" || {
+        echo "[Error] Failed to flush addresses on ${INTERFACE}" >&2
+        return 1
+    }
+    ip addr add "${AP_ADDR}"/24 dev "${INTERFACE}" || {
+        echo "[Error] Failed to assign ${AP_ADDR}/24 to ${INTERFACE}" >&2
+        return 1
+    }
+}
+
+# teardown_interface flushes addresses and brings the link down.
+teardown_interface() {
+    if [ -n "${INTERFACE}" ] ; then
+        echo "Flushing interface ${INTERFACE}..."
+        ip addr flush dev "${INTERFACE}" 2>/dev/null || true
+        ip link set "${INTERFACE}" down 2>/dev/null || true
+    fi
+}

--- a/lib/ipv6.sh
+++ b/lib/ipv6.sh
@@ -22,7 +22,7 @@ enable_ipv6_forwarding() {
 }
 
 # apply_ipv6_rules adds ip6tables FORWARD rules mirroring the IPv4 ones.
-# ints is populated by parse_outgoings in wlanstart.sh.
+# ints is populated by parse_outgoings from lib/nat.sh.
 # shellcheck disable=SC2154
 apply_ipv6_rules() {
     if [ "${OUTGOINGS}" ] ; then

--- a/lib/nat.sh
+++ b/lib/nat.sh
@@ -1,0 +1,67 @@
+# shellcheck shell=bash
+# Shared IPv4 NAT logic used by wlanstart.sh and tests.
+#
+# parse_outgoings fills ints with the comma-separated OUTGOINGS interfaces.
+
+parse_outgoings() {
+    ints=()
+    local -a raw
+    local i
+    IFS=',' read -r -a raw <<<"${OUTGOINGS}"
+    for i in "${raw[@]}" ; do
+        [ -n "${i}" ] && ints+=("${i}")
+    done
+}
+
+# apply_nat_rules adds iptables MASQUERADE/FORWARD rules for outgoing traffic.
+apply_nat_rules() {
+    if [ "${OUTGOINGS}" ] ; then
+        local int
+        parse_outgoings
+        for int in "${ints[@]}"
+        do
+            echo "Setting iptables for outgoing traffics on ${int}..."
+
+            iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
+            iptables -t nat -A POSTROUTING -s "${SUBNET}/24" -o "${int}" -j MASQUERADE
+
+            iptables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+            iptables -A FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT
+
+            iptables -D FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT > /dev/null 2>&1 || true
+            iptables -A FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT
+        done
+    else
+        echo "Setting iptables for outgoing traffics on all interfaces..."
+
+        iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -j MASQUERADE > /dev/null 2>&1 || true
+        iptables -t nat -A POSTROUTING -s "${SUBNET}/24" -j MASQUERADE
+
+        iptables -D FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+        iptables -A FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT
+
+        iptables -D FORWARD -i "${INTERFACE}" -j ACCEPT > /dev/null 2>&1 || true
+        iptables -A FORWARD -i "${INTERFACE}" -j ACCEPT
+    fi
+}
+
+# remove_nat_rules deletes the rules added by apply_nat_rules.
+remove_nat_rules() {
+    echo "Removing iptables rules..."
+
+    if [ "${OUTGOINGS}" ] ; then
+        local int
+        parse_outgoings
+        for int in "${ints[@]}" ; do
+            echo "Removing iptables for outgoing traffics on ${int}..."
+            iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
+            iptables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+            iptables -D FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT > /dev/null 2>&1 || true
+        done
+    else
+        echo "Removing iptables for outgoing traffics on all interfaces..."
+        iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -j MASQUERADE > /dev/null 2>&1 || true
+        iptables -D FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+        iptables -D FORWARD -i "${INTERFACE}" -j ACCEPT > /dev/null 2>&1 || true
+    fi
+}

--- a/tests/cleanup.bats
+++ b/tests/cleanup.bats
@@ -9,7 +9,13 @@ setup() {
 }
 
 load_cleanup() {
-    eval "$(sed -n '/^parse_outgoings()/,/^}/p; /^cleanup()/,/^}/p; /^trap /p' wlanstart.sh)"
+    # shellcheck source=../lib/nat.sh
+    . "$(dirname "$BATS_TEST_FILENAME")/../lib/nat.sh"
+    # shellcheck source=../lib/interface.sh
+    . "$(dirname "$BATS_TEST_FILENAME")/../lib/interface.sh"
+    # shellcheck source=../lib/ipv6.sh
+    . "$(dirname "$BATS_TEST_FILENAME")/../lib/ipv6.sh"
+    eval "$(sed -n '/^cleanup()/,/^}/p' wlanstart.sh)"
 }
 
 run_cleanup_mocked() {
@@ -23,10 +29,14 @@ iptables() { _mock_log \"iptables \$@\"; }
 ip() { _mock_log \"ip \$@\"; }
 kill() { _mock_log \"kill \$@\"; }
 wait() { _mock_log \"wait \$@\"; }
-$(sed -n '/^parse_outgoings()/,/^}/p; /^cleanup()/,/^}/p' wlanstart.sh)
+. '$PWD/lib/nat.sh'
+. '$PWD/lib/interface.sh'
+. '$PWD/lib/ipv6.sh'
+$(sed -n '/^cleanup()/,/^}/p' wlanstart.sh)
 INTERFACE="$INTERFACE"
 SUBNET="$SUBNET"
 OUTGOINGS="$OUTGOINGS"
+IPV6="${IPV6:-0}"
 cleanup
 "
     cat "$mock_log"
@@ -61,7 +71,7 @@ cleanup
 }
 
 @test "trap is set for SIGINT SIGTERM SIGHUP" {
-    load_cleanup
+    eval "$(sed -n '/^trap /p' wlanstart.sh)"
     local traps
     traps=$(trap -p)
     [[ "$traps" == *"handle_signal"*"SIGINT"* ]]

--- a/tests/early_signal.bats
+++ b/tests/early_signal.bats
@@ -5,7 +5,10 @@
 SCRIPT="${BATS_TEST_DIRNAME}/../wlanstart.sh"
 
 extract_functions() {
-    sed -n '/^parse_outgoings()/,/^}/p; /^cleanup()/,/^}/p; /^_MULTIRUN_PID=""$/p; /^_SIGNALED=0$/p; /^handle_signal()/,/^}/p; /^check_interrupted()/,/^}/p' "${SCRIPT}"
+    echo ". '${BATS_TEST_DIRNAME}/../lib/nat.sh'"
+    echo ". '${BATS_TEST_DIRNAME}/../lib/interface.sh'"
+    echo ". '${BATS_TEST_DIRNAME}/../lib/ipv6.sh'"
+    sed -n '/^cleanup()/,/^}/p; /^_MULTIRUN_PID=""$/p; /^_SIGNALED=0$/p; /^handle_signal()/,/^}/p; /^check_interrupted()/,/^}/p' "${SCRIPT}"
 }
 
 @test "check_interrupted is defined" {

--- a/tests/nat.bats
+++ b/tests/nat.bats
@@ -1,0 +1,85 @@
+#!/usr/bin/env bats
+
+# Logic shared with wlanstart.sh
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+# shellcheck source=../lib/nat.sh
+. "${REPO_ROOT}/lib/nat.sh"
+
+setup() {
+    export INTERFACE="wlan0"
+    export SUBNET="192.168.254.0"
+    export OUTGOINGS=""
+}
+
+@test "parse_outgoings parses comma-separated interfaces" {
+    OUTGOINGS="eth0,wlan0" parse_outgoings
+    [ "${#ints[@]}" -eq 2 ]
+    [ "${ints[0]}" = "eth0" ]
+    [ "${ints[1]}" = "wlan0" ]
+}
+
+@test "parse_outgoings collapses repeated commas" {
+    OUTGOINGS="eth0,,wlan0," parse_outgoings
+    [ "${#ints[@]}" -eq 2 ]
+}
+
+@test "parse_outgoings yields empty array when OUTGOINGS unset" {
+    OUTGOINGS="" parse_outgoings
+    [ "${#ints[@]}" -eq 0 ]
+}
+
+@test "apply_nat_rules adds rules per interface with OUTGOINGS" {
+    export OUTGOINGS="eth0,eth1"
+    parse_outgoings
+    iptables() { echo "iptables $*"; }
+    run apply_nat_rules
+    [ "$status" -eq 0 ]
+    [[ "${output}" == *"Setting iptables for outgoing traffics on eth0..."* ]]
+    [[ "${output}" == *"iptables -t nat -A POSTROUTING -s 192.168.254.0/24 -o eth0 -j MASQUERADE"* ]]
+    [[ "${output}" == *"iptables -t nat -A POSTROUTING -s 192.168.254.0/24 -o eth1 -j MASQUERADE"* ]]
+    [[ "${output}" == *"iptables -A FORWARD -i eth0 -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT"* ]]
+    [[ "${output}" == *"iptables -A FORWARD -i wlan0 -o eth1 -j ACCEPT"* ]]
+}
+
+@test "apply_nat_rules adds generic rules without OUTGOINGS" {
+    iptables() { echo "iptables $*"; }
+    run apply_nat_rules
+    [ "$status" -eq 0 ]
+    [[ "${output}" == *"Setting iptables for outgoing traffics on all interfaces..."* ]]
+    [[ "${output}" == *"iptables -t nat -A POSTROUTING -s 192.168.254.0/24 -j MASQUERADE"* ]]
+    [[ "${output}" == *"iptables -A FORWARD -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT"* ]]
+    [[ "${output}" == *"iptables -A FORWARD -i wlan0 -j ACCEPT"* ]]
+}
+
+@test "apply_nat_rules removes stale rule before adding (delete precedes append)" {
+    local log="${BATS_TEST_TMPDIR}/iptables-order.log"
+    iptables() { echo "$1" >> "${log}"; }
+    apply_nat_rules
+    [ "$(grep -n '^-D' "${log}" | head -1 | cut -d: -f1)" -lt "$(grep -n '^-A' "${log}" | head -1 | cut -d: -f1)" ]
+}
+
+@test "remove_nat_rules deletes generic rules without OUTGOINGS" {
+    local log="${BATS_TEST_TMPDIR}/iptables.log"
+    iptables() {
+        if [ "$1" = "-D" ] ; then echo "$*" >> "${log}"; fi
+        return 0
+    }
+    run remove_nat_rules
+    [ "$status" -eq 0 ]
+    [[ "$(cat "${log}")" == *"-t nat -D POSTROUTING -s 192.168.254.0/24 -j MASQUERADE"* ]]
+    [[ "$(cat "${log}")" == *"-D FORWARD -i wlan0 -j ACCEPT"* ]]
+}
+
+@test "remove_nat_rules deletes rules per interface with OUTGOINGS" {
+    export OUTGOINGS="eth0,eth1"
+    local log="${BATS_TEST_TMPDIR}/iptables-multi.log"
+    iptables() {
+        if [ "$1" = "-D" ] ; then echo "$*" >> "${log}"; fi
+        return 0
+    }
+    run remove_nat_rules
+    [ "$status" -eq 0 ]
+    [[ "$(cat "${log}")" == *"-t nat -D POSTROUTING -s 192.168.254.0/24 -o eth0 -j MASQUERADE"* ]]
+    [[ "$(cat "${log}")" == *"-t nat -D POSTROUTING -s 192.168.254.0/24 -o eth1 -j MASQUERADE"* ]]
+    [[ "$(cat "${log}")" == *"-D FORWARD -i wlan0 -o eth0 -j ACCEPT"* ]]
+}

--- a/tests/nat.bats
+++ b/tests/nat.bats
@@ -59,27 +59,34 @@ setup() {
 }
 
 @test "remove_nat_rules deletes generic rules without OUTGOINGS" {
-    local log="${BATS_TEST_TMPDIR}/iptables.log"
-    iptables() {
-        if [ "$1" = "-D" ] ; then echo "$*" >> "${log}"; fi
-        return 0
-    }
-    run remove_nat_rules
+    local log
+    log=$(mktemp)
+    OUTGOINGS="" INTERFACE="wlan0" SUBNET="192.168.254.0" \
+    REPO_ROOT="$REPO_ROOT" LOG="$log" \
+    run bash -c '
+        iptables() { case "$*" in *"-D "*) echo "$*" >> "${LOG}" ;; esac ; }
+        . "${REPO_ROOT}/lib/nat.sh"
+        remove_nat_rules
+    '
     [ "$status" -eq 0 ]
-    [[ "$(cat "${log}")" == *"-t nat -D POSTROUTING -s 192.168.254.0/24 -j MASQUERADE"* ]]
-    [[ "$(cat "${log}")" == *"-D FORWARD -i wlan0 -j ACCEPT"* ]]
+    grep -q -- "-t nat -D POSTROUTING -s 192.168.254.0/24 -j MASQUERADE" "${log}"
+    grep -q -- "-D FORWARD -i wlan0 -j ACCEPT" "${log}"
+    rm -f "${log}"
 }
 
 @test "remove_nat_rules deletes rules per interface with OUTGOINGS" {
-    export OUTGOINGS="eth0,eth1"
-    local log="${BATS_TEST_TMPDIR}/iptables-multi.log"
-    iptables() {
-        if [ "$1" = "-D" ] ; then echo "$*" >> "${log}"; fi
-        return 0
-    }
-    run remove_nat_rules
+    local log
+    log=$(mktemp)
+    OUTGOINGS="eth0,eth1" INTERFACE="wlan0" SUBNET="192.168.254.0" \
+    REPO_ROOT="$REPO_ROOT" LOG="$log" \
+    run bash -c '
+        iptables() { case "$*" in *"-D "*) echo "$*" >> "${LOG}" ;; esac ; }
+        . "${REPO_ROOT}/lib/nat.sh"
+        remove_nat_rules
+    '
     [ "$status" -eq 0 ]
-    [[ "$(cat "${log}")" == *"-t nat -D POSTROUTING -s 192.168.254.0/24 -o eth0 -j MASQUERADE"* ]]
-    [[ "$(cat "${log}")" == *"-t nat -D POSTROUTING -s 192.168.254.0/24 -o eth1 -j MASQUERADE"* ]]
-    [[ "$(cat "${log}")" == *"-D FORWARD -i wlan0 -o eth0 -j ACCEPT"* ]]
+    grep -q -- "-t nat -D POSTROUTING -s 192.168.254.0/24 -o eth0 -j MASQUERADE" "${log}"
+    grep -q -- "-t nat -D POSTROUTING -s 192.168.254.0/24 -o eth1 -j MASQUERADE" "${log}"
+    grep -q -- "-D FORWARD -i wlan0 -o eth0 -j ACCEPT" "${log}"
+    rm -f "${log}"
 }

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -1,45 +1,23 @@
 #!/bin/bash
 
-parse_outgoings() {
-    ints=()
-    local -a raw
-    local i
-    IFS=',' read -r -a raw <<<"${OUTGOINGS}"
-    for i in "${raw[@]}" ; do
-        [ -n "${i}" ] && ints+=("${i}")
-    done
-}
+# NAT and interface logic lives in lib/nat.sh and lib/interface.sh,
+# shared with tests
+# shellcheck source=lib/nat.sh
+. "$(dirname "$0")/lib/nat.sh"
+# shellcheck source=lib/interface.sh
+. "$(dirname "$0")/lib/interface.sh"
 
 cleanup() {
     echo "Shutting down..."
 
-    echo "Removing iptables rules..."
-
-    if [ "${OUTGOINGS}" ] ; then
-        parse_outgoings
-        for int in "${ints[@]}" ; do
-            echo "Removing iptables for outgoing traffics on ${int}..."
-            iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
-            iptables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
-            iptables -D FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT > /dev/null 2>&1 || true
-        done
-    else
-        echo "Removing iptables for outgoing traffics on all interfaces..."
-        iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -j MASQUERADE > /dev/null 2>&1 || true
-        iptables -D FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
-        iptables -D FORWARD -i "${INTERFACE}" -j ACCEPT > /dev/null 2>&1 || true
-    fi
+    remove_nat_rules
 
     if [ "${IPV6:-0}" = "1" ] ; then
         echo "Removing ip6tables rules..."
         remove_ipv6_rules
     fi
 
-    if [ -n "${INTERFACE}" ] ; then
-        echo "Flushing interface ${INTERFACE}..."
-        ip addr flush dev "${INTERFACE}" 2>/dev/null || true
-        ip link set "${INTERFACE}" down 2>/dev/null || true
-    fi
+    teardown_interface
 }
 
 # multirun manages hostapd/dnsmasq and exits when any child dies.
@@ -205,18 +183,9 @@ EOF
 check_interrupted
 
 # Setup interface and restart DHCP service
-ip link set "${INTERFACE}" up || {
-    echo "[Error] Failed to bring up interface ${INTERFACE}" >&2
+if ! setup_interface ; then
     exit 1
-}
-ip addr flush dev "${INTERFACE}" || {
-    echo "[Error] Failed to flush addresses on ${INTERFACE}" >&2
-    exit 1
-}
-ip addr add "${AP_ADDR}"/24 dev "${INTERFACE}" || {
-    echo "[Error] Failed to assign ${AP_ADDR}/24 to ${INTERFACE}" >&2
-    exit 1
-}
+fi
 check_interrupted
 
 # NAT settings
@@ -234,33 +203,7 @@ done
 cat /proc/sys/net/ipv4/ip_dynaddr
 cat /proc/sys/net/ipv4/ip_forward
 
-if [ "${OUTGOINGS}" ] ; then
-   parse_outgoings
-   for int in "${ints[@]}"
-   do
-      echo "Setting iptables for outgoing traffics on ${int}..."
-
-      iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
-      iptables -t nat -A POSTROUTING -s "${SUBNET}/24" -o "${int}" -j MASQUERADE
-
-      iptables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
-      iptables -A FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT
-
-      iptables -D FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT > /dev/null 2>&1 || true
-      iptables -A FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT
-   done
-else
-   echo "Setting iptables for outgoing traffics on all interfaces..."
-
-   iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -j MASQUERADE > /dev/null 2>&1 || true
-   iptables -t nat -A POSTROUTING -s "${SUBNET}/24" -j MASQUERADE
-
-   iptables -D FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
-   iptables -A FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT
-
-   iptables -D FORWARD -i "${INTERFACE}" -j ACCEPT > /dev/null 2>&1 || true
-   iptables -A FORWARD -i "${INTERFACE}" -j ACCEPT
-fi
+apply_nat_rules
 
 # Optional IPv6 support (off by default, enable with IPV6=1)
 # Logic lives in lib/ipv6.sh, shared with tests


### PR DESCRIPTION
## Summary

Pure refactor of `wlanstart.sh` (no behavior change), extracting the inline IPv4 NAT and interface logic into shared libs, mirroring the existing `lib/ipv6.sh` pattern:

- **`lib/nat.sh`** (new): `parse_outgoings`, `apply_nat_rules()` (setup block, both OUTGOINGS-specific and all-interfaces branches) and `remove_nat_rules()` (teardown half of the old `cleanup()`).
- **`lib/interface.sh`** (new): `setup_interface()` / `teardown_interface()` wrapping the `ip link/addr` commands.
- **`wlanstart.sh`**: now sources both libs and keeps only orchestration; `cleanup()` delegates to `remove_nat_rules` / `teardown_interface`; interface setup calls `setup_interface`.
- **`tests/nat.bats`** (new): 8 tests covering rule generation/removal with a stubbed `iptables`, covering both NAT branches, plus `parse_outgoings` cases.
- Updated `tests/cleanup.bats` and `tests/early_signal.bats` to source the new libs instead of sed-extracting functions from `wlanstart.sh`.

Closes #117

## Test plan

- [x] `shellcheck -x wlanstart.sh lib/nat.sh lib/interface.sh` — clean
- [x] Full bats suite: 164/164 green locally
- [x] CI checks on this PR
