### PR TITLE
feat(clients): opt-in ctrl_interface and clients.sh for listing connected stations

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Run shellcheck
         run: |
-          shellcheck -x wlanstart.sh healthcheck.sh
+          shellcheck -x wlanstart.sh healthcheck.sh clients.sh
 
       - name: Shellcheck get-version.sh
         run: shellcheck scripts/get-version.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,8 +15,7 @@ COPY wlanstart.sh /bin/wlanstart.sh
 COPY healthcheck.sh /bin/healthcheck.sh
 COPY clients.sh /bin/clients.sh
 COPY lib/ /bin/lib/
-RUN chmod +x /bin/healthcheck.sh
-RUN chmod +x /bin/clients.sh
+RUN chmod +x /bin/healthcheck.sh /bin/clients.sh
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD ["/bin/healthcheck.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,10 @@ ENV HEALTHCHECK_START_PERIOD=15
 
 COPY wlanstart.sh /bin/wlanstart.sh
 COPY healthcheck.sh /bin/healthcheck.sh
+COPY clients.sh /bin/clients.sh
 COPY lib/ /bin/lib/
 RUN chmod +x /bin/healthcheck.sh
+RUN chmod +x /bin/clients.sh
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
   CMD ["/bin/healthcheck.sh"]

--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ docker run -d \
 | `VHT_ENABLED` | No | Enable 802.11ac Very High Throughput (`ieee80211ac=1`); requires 5 GHz (`HW_MODE=a`) | unset |
 | `VHT_CAPAB` | No | 802.11ac capabilities string (`vht_capab=` in hostapd.conf); requires `VHT_ENABLED` | unset |
 | `HEALTHCHECK_START_PERIOD` | No | Grace period (seconds) after container start during which the healthcheck always passes. Measured from the container's own recorded start time (`/run/hostap-started`), not host uptime | `15` |
+| `CTRL_INTERFACE` | No | Enable hostapd control interface (any non-empty value); allows `clients.sh` to list stations, see [Client Inspection](#client-inspection-optional) | unset |
+| `CTRL_IFACE_DIR` | No | Control interface socket directory used by `clients.sh` | `/var/run/hostapd` |
 
 #### HT/VHT (802.11n/ac) Tuning
 
@@ -183,6 +185,22 @@ For 5 GHz (`hw_mode=a`), channels are validated against the allowed 5 GHz set:
 - **Non-DFS channels** (always allowed): 36, 40, 44, 48, 149, 153, 157, 161, 165
 - **DFS channels** (allowed with a radar detection/CAC warning): 52, 56, 60, 64, 100–144 (in steps of 4)
 - Any other channel is rejected with a clear error.
+
+#### Client Inspection (optional)
+
+By default the hostapd control interface is not enabled, to keep the generated config minimal. Set `CTRL_INTERFACE` to any non-empty value to opt in:
+
+```bash
+docker run ... -e CTRL_INTERFACE=1 ...
+```
+
+This emits `ctrl_interface=/var/run/hostapd` and `ctrl_interface_group=0` into `hostapd.conf`. Once enabled, list currently associated stations from inside the container:
+
+```bash
+docker exec rpi-hostap clients.sh
+```
+
+Output includes MAC address, signal, connected time and tx/rx rates per station (as reported by `hostapd_cli all_sta`). The control interface directory can be overridden with `CTRL_IFACE_DIR` (default `/var/run/hostapd`).
 
 ### Build from Source
 
@@ -269,7 +287,8 @@ If any check fails, the container is reported as `unhealthy`.
 
 **Script grace vs Docker start-period**: there are two independent grace mechanisms. `HEALTHCHECK_START_PERIOD` (env var) controls the *script-side* grace window measured from the recorded start time. The Dockerfile's `HEALTHCHECK --start-period=15s` is the Docker-side outer bound during which failing checks do not count towards the `unhealthy` transition. If you raise the env var (e.g. `HEALTHCHECK_START_PERIOD=60`), the script keeps passing for 60s after start regardless of the Docker setting; the Dockerfile start-period only affects when Docker itself starts counting failures.
 
-Note: the AP's beaconing status itself is not verified — that would require enabling the hostapd control interface (`ctrl_interface`) in the generated config and querying it with `hostapd_cli`, which is intentionally not enabled to keep the container config minimal.
+| `HEALTHCHECK_START_PERIOD` | No | Grace period (seconds) after container start during which the healthcheck always passes. Measured from the container's own recorded start time (`/run/hostap-started`), not host uptime | `15` |
+Note: the AP's beaconing status itself is not verified — that would require enabling the hostapd control interface (`ctrl_interface`), available as an opt-in via `CTRL_INTERFACE` (see [Client Inspection](#client-inspection-optional)).
 
 ## Contributing
 

--- a/clients.sh
+++ b/clients.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# List stations currently associated with the AP via hostapd_cli.
+# Requires CTRL_INTERFACE=1 so hostapd.conf exposes ctrl_interface.
+set -euo pipefail
+
+if [ -z "${INTERFACE:-}" ] ; then
+    echo "[Error] INTERFACE must be set." >&2
+    exit 1
+fi
+
+exec hostapd_cli -p "${CTRL_IFACE_DIR:-/var/run/hostapd}" -i "${INTERFACE}" all_sta

--- a/lib/ctrl_interface.sh
+++ b/lib/ctrl_interface.sh
@@ -1,0 +1,8 @@
+# compute_ctrl_interface_conf prints hostapd.conf lines enabling the
+# control interface, only when CTRL_INTERFACE is set to a non-empty value.
+compute_ctrl_interface_conf() {
+    if [ -n "${CTRL_INTERFACE:-}" ] ; then
+        echo "ctrl_interface=/var/run/hostapd"
+        echo "ctrl_interface_group=0"
+    fi
+}

--- a/tests/ctrl_interface.bats
+++ b/tests/ctrl_interface.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+# Tests exercise compute_ctrl_interface_conf() from lib/ctrl_interface.sh —
+# the exact code used by wlanstart.sh (no duplicated logic).
+
+setup() {
+    unset CTRL_INTERFACE
+}
+
+load_lib() {
+    . "${BATS_TEST_DIRNAME}/../lib/ctrl_interface.sh"
+}
+
+@test "CTRL_INTERFACE not set produces no config line" {
+    load_lib
+    run compute_ctrl_interface_conf
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "CTRL_INTERFACE empty string produces no config line" {
+    load_lib
+    CTRL_INTERFACE=""
+    run compute_ctrl_interface_conf
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "CTRL_INTERFACE=1 produces ctrl_interface lines" {
+    load_lib
+    CTRL_INTERFACE=1
+    run compute_ctrl_interface_conf
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "ctrl_interface=/var/run/hostapd" ]
+    [ "${lines[1]}" = "ctrl_interface_group=0" ]
+}
+
+@test "CTRL_INTERFACE=yes produces ctrl_interface lines" {
+    load_lib
+    CTRL_INTERFACE=yes
+    run compute_ctrl_interface_conf
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "ctrl_interface=/var/run/hostapd" ]
+    [ "${lines[1]}" = "ctrl_interface_group=0" ]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -154,6 +154,12 @@ _MAC_FILTER_CONF=$(compute_mac_filter_conf)
 
 _MAX_STA_CONF=$(compute_max_sta_conf)
 
+# Control interface: opt-in via CTRL_INTERFACE (any non-empty value)
+# Logic lives in lib/ctrl_interface.sh, shared with tests
+# shellcheck source=lib/ctrl_interface.sh
+. "$(dirname "$0")/lib/ctrl_interface.sh"
+_CTRL_INTERFACE_CONF=$(compute_ctrl_interface_conf)
+
 # Always regenerate hostapd.conf so env var changes apply between runs
 cat > "/etc/hostapd.conf" <<EOF
 interface=${INTERFACE}
@@ -169,6 +175,7 @@ wmm_enabled=1
 ${_MAX_STA_CONF}
 ${_AP_ISOLATION_CONF}
 ${_MAC_FILTER_CONF}
+${_CTRL_INTERFACE_CONF}
 
 # Activate channel selection for HT High Throughput (802.11an)
 


### PR DESCRIPTION
## feat(clients): opt-in ctrl_interface and clients.sh for listing connected stations

Closes #121

### Problem

There was no way to inspect connected clients from inside the container. The README noted `ctrl_interface` was intentionally not enabled to keep the config minimal.

### Changes

- New env var `CTRL_INTERFACE`: when set to any non-empty value, emits `ctrl_interface=/var/run/hostapd` + `ctrl_interface_group=0` into hostapd.conf (logic in new `lib/ctrl_interface.sh`, following existing lib pattern)
- New `clients.sh` script (copied to `/bin/` in image like healthcheck.sh): lists associated stations via `hostapd_cli all_sta` (MAC, signal, connected time, tx/rx rates); dir overridable with `CTRL_IFACE_DIR`
- README: new "Client Inspection" section, env var table rows, updated healthcheck note
- CI: shellcheck now covers `clients.sh`

### Behavior

Default unchanged — no `ctrl_interface` line unless opted in.

### Tests

- New `tests/ctrl_interface.bats`: 4 tests (unset / empty / `1` / non-empty value)
- Full suite: 177/177 bats green; shellcheck clean on changed scripts
