### PR TITLE
feat(healthcheck): add opt-in deep AP beacon check via hostapd_cli

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,7 +302,25 @@ If any check fails, the container is reported as `unhealthy`.
 **Script grace vs Docker start-period**: there are two independent grace mechanisms. `HEALTHCHECK_START_PERIOD` (env var) controls the *script-side* grace window measured from the recorded start time. The Dockerfile's `HEALTHCHECK --start-period=15s` is the Docker-side outer bound during which failing checks do not count towards the `unhealthy` transition. If you raise the env var (e.g. `HEALTHCHECK_START_PERIOD=60`), the script keeps passing for 60s after start regardless of the Docker setting; the Dockerfile start-period only affects when Docker itself starts counting failures.
 
 | `HEALTHCHECK_START_PERIOD` | No | Grace period (seconds) after container start during which the healthcheck always passes. Measured from the container's own recorded start time (`/run/hostap-started`), not host uptime | `15` |
-Note: the AP's beaconing status itself is not verified — that would require enabling the hostapd control interface (`ctrl_interface`), available as an opt-in via `CTRL_INTERFACE` (see [Client Inspection](#client-inspection-optional)).
+| `HEALTHCHECK_DEEP` | No | Opt-in deep healthcheck: after the standard checks, verify the AP is actually beaconing via `hostapd_cli status` (requires hostapd control interface). Any non-empty value enables it; also emits `ctrl_interface=/var/run/hostapd` into the generated `hostapd.conf` (see [Deep Healthcheck](#deep-healthcheck-optional)) | unset |
+
+#### Deep Healthcheck (optional)
+
+By default the AP's beaconing status is not verified — hostapd can be alive while the radio failed to start (driver rejection, DFS CAC wait). Set `HEALTHCHECK_DEEP` to any non-empty value to opt in:
+
+```bash
+docker run ... -e HEALTHCHECK_DEEP=1 ...
+```
+
+When enabled, `wlanstart.sh` emits `ctrl_interface=/var/run/hostapd` and `ctrl_interface_group=0` into the generated `hostapd.conf`, and after the existing checks `healthcheck.sh` runs `hostapd_cli -p /var/run/hostapd -i "$INTERFACE" status`, requiring `state=ENABLED`. If hostapd reports any other state, the container is reported as `unhealthy`.
+
+**DFS channels**: on radar channels (e.g. 5 GHz DFS), Channel Availability Check (CAC) can take 60s+ before the AP starts beaconing (`state=DFS`). Raise the grace period so the deep check doesn't fail during CAC:
+
+```bash
+docker run ... -e HEALTHCHECK_DEEP=1 -e HEALTHCHECK_START_PERIOD=90 ...
+```
+
+Note: enabling `CTRL_INTERFACE` (see [Client Inspection](#client-inspection-optional)) already emits the same config lines, so the two options are compatible — either one suffices for `hostapd_cli` to work.
 
 ## Contributing
 

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -48,4 +48,15 @@ if [ -n "$INTERFACE" ]; then
     fi
 fi
 
+# Optional deep check: verify the AP is actually beaconing via hostapd_cli.
+# Requires HEALTHCHECK_DEEP set (wlanstart.sh then enables ctrl_interface).
+# Note: DFS CAC can take 60s+ on radar channels; raise HEALTHCHECK_START_PERIOD
+# (e.g. 90) so this check doesn't fail during channel availability scan.
+if [ -n "$HEALTHCHECK_DEEP" ]; then
+    if ! hostapd_cli -p /var/run/hostapd -i "$INTERFACE" status 2>/dev/null | grep -q "^state=ENABLED"; then
+        echo "hostapd is not in ENABLED state" >&2
+        exit 1
+    fi
+fi
+
 exit 0

--- a/lib/ctrl_interface.sh
+++ b/lib/ctrl_interface.sh
@@ -1,7 +1,8 @@
 # compute_ctrl_interface_conf prints hostapd.conf lines enabling the
-# control interface, only when CTRL_INTERFACE is set to a non-empty value.
+# control interface, when CTRL_INTERFACE or HEALTHCHECK_DEEP is set to a
+# non-empty value (the deep healthcheck needs it for hostapd_cli).
 compute_ctrl_interface_conf() {
-    if [ -n "${CTRL_INTERFACE:-}" ] ; then
+    if [ -n "${CTRL_INTERFACE:-}" ] || [ -n "${HEALTHCHECK_DEEP:-}" ] ; then
         echo "ctrl_interface=/var/run/hostapd"
         echo "ctrl_interface_group=0"
     fi

--- a/tests/ctrl_interface.bats
+++ b/tests/ctrl_interface.bats
@@ -5,6 +5,7 @@
 
 setup() {
     unset CTRL_INTERFACE
+    unset HEALTHCHECK_DEEP
 }
 
 load_lib() {
@@ -42,4 +43,28 @@ load_lib() {
     [ "$status" -eq 0 ]
     [ "${lines[0]}" = "ctrl_interface=/var/run/hostapd" ]
     [ "${lines[1]}" = "ctrl_interface_group=0" ]
+}
+
+@test "HEALTHCHECK_DEEP not set produces no config line" {
+    load_lib
+    run compute_ctrl_interface_conf
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "HEALTHCHECK_DEEP=1 produces ctrl_interface lines (issue #123)" {
+    load_lib
+    HEALTHCHECK_DEEP=1
+    run compute_ctrl_interface_conf
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "ctrl_interface=/var/run/hostapd" ]
+    [ "${lines[1]}" = "ctrl_interface_group=0" ]
+}
+
+@test "CTRL_INTERFACE unset with HEALTHCHECK_DEEP empty produces no config line" {
+    load_lib
+    HEALTHCHECK_DEEP=""
+    run compute_ctrl_interface_conf
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
 }

--- a/tests/healthcheck.bats
+++ b/tests/healthcheck.bats
@@ -165,3 +165,40 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" == *"hostapd is not running"* ]]
 }
+
+@test "deep check passes when hostapd state is ENABLED (issue #123)" {
+    export HEALTHCHECK_DEEP=1
+    mock_bin pidof 'exit 0'
+    mock_bin ip 'if [ "$1" = "link" ]; then echo "state UP"; fi; exit 0'
+    mock_bin hostapd_cli 'echo "state=ENABLED"; echo "ssid=raspberry"'
+    run ./healthcheck.sh
+    [ "$status" -eq 0 ]
+}
+
+@test "deep check fails when hostapd is not in ENABLED state (issue #123)" {
+    export HEALTHCHECK_DEEP=1
+    mock_bin pidof 'exit 0'
+    mock_bin ip 'if [ "$1" = "link" ]; then echo "state UP"; fi; exit 0'
+    mock_bin hostapd_cli 'echo "state=DFS"'
+    run ./healthcheck.sh
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"hostapd is not in ENABLED state"* ]]
+}
+
+@test "deep check is skipped by default (no HEALTHCHECK_DEEP)" {
+    mock_bin pidof 'exit 0'
+    mock_bin ip 'if [ "$1" = "link" ]; then echo "state UP"; fi; exit 0'
+    mock_bin hostapd_cli 'exit 1'
+    run ./healthcheck.sh
+    [ "$status" -eq 0 ]
+}
+
+@test "deep check respects start period (grace before DFS CAC finishes)" {
+    export HEALTHCHECK_DEEP=1
+    export NOW_STAMP=1000
+    echo "$((NOW_STAMP - 10))" > "$HEALTHCHECK_STARTED_FILE"
+    export HEALTHCHECK_START_PERIOD=90
+    mock_bin hostapd_cli 'echo "state=DFS"'
+    run ./healthcheck.sh
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Opt-in deep healthcheck verifying the AP is actually **beaconing** (not just that hostapd is running), via the hostapd control interface. Closes #123.

## Changes

- **`lib/ctrl_interface.sh`**: `compute_ctrl_interface_conf` now emits `ctrl_interface=/var/run/hostapd` + `ctrl_interface_group=0` when either `CTRL_INTERFACE` or the new `HEALTHCHECK_DEEP` is set (any non-empty value). Default behavior unchanged.
- **`healthcheck.sh`**: after existing checks, when `HEALTHCHECK_DEEP` is set, runs `hostapd_cli -p /var/run/hostapd -i "$INTERFACE" status` and exits 1 with `hostapd is not in ENABLED state` unless `state=ENABLED`.
- **Grace interplay**: the deep check sits after the start-period early-exit, so it respects `HEALTHCHECK_START_PERIOD`. README recommends `HEALTHCHECK_START_PERIOD=90` for DFS channels (CAC can take 60s+).
- **README**: new "Deep Healthcheck (optional)" section plus env var table entry.

## Tests

- Extended `tests/ctrl_interface.bats`: default/empty no lines; `HEALTHCHECK_DEEP=1` emits both lines.
- Extended `tests/healthcheck.bats`: deep check passes on ENABLED state, fails (exit 1) otherwise, is skipped by default, and is suppressed during the start period.
- Full bats suite: 199/199 green locally.

## Acceptance criteria

- [x] Default images behave exactly as today (no `ctrl_interface` line)
- [x] With `HEALTHCHECK_DEEP=1`, unhealthy radio state marks container unhealthy
- [x] Grace period respected for DFS CAC
- [x] Documented in README
