### PR TITLE
test(healthcheck): add bats coverage for grace period, IP match and interface state

### DIFF
--- a/tests/healthcheck.bats
+++ b/tests/healthcheck.bats
@@ -31,9 +31,10 @@ EOF
     [ -x "healthcheck.sh" ]
 }
 
-@test "healthcheck returns 0 during start period" {
+@test "healthcheck returns 0 during start period even with dead daemons" {
     export NOW_STAMP=1000
-    echo "990" > "$HEALTHCHECK_STARTED_FILE"
+    echo "$((NOW_STAMP - 5))" > "$HEALTHCHECK_STARTED_FILE"
+    mock_bin pidof 'exit 1'
     run ./healthcheck.sh
     [ "$status" -eq 0 ]
 }
@@ -129,6 +130,14 @@ EOF
     export AP_ADDR="192.168.254.1"
     mock_bin pidof 'exit 0'
     mock_bin ip 'if [ "$1" = "link" ]; then echo "state UP"; elif [ "$1" = "-4" ]; then echo "inet 192.168.254.1/24"; fi; exit 0'
+    run ./healthcheck.sh
+    [ "$status" -eq 0 ]
+}
+
+@test "AP_ADDR matches exactly when other same-subnet addresses are also assigned" {
+    export AP_ADDR="192.168.254.1"
+    mock_bin pidof 'exit 0'
+    mock_bin ip 'if [ "$1" = "link" ]; then echo "state UP"; elif [ "$1" = "-4" ]; then echo "inet 192.168.254.100/24"; echo "inet 192.168.254.1/24"; echo "inet 192.168.254.11/24"; fi; exit 0'
     run ./healthcheck.sh
     [ "$status" -eq 0 ]
 }


### PR DESCRIPTION
## Summary

Extends `tests/healthcheck.bats` per #118. After reviewing the current `healthcheck.sh` (which already supports `HEALTHCHECK_STARTED_FILE`, `HEALTHCHECK_START_PERIOD`, and `HEALTHCHECK_DEEP`) and the existing suite, most requested cases were already covered:

- past grace, hostapd missing → exit 1 ✅ (existing)
- past grace, dnsmasq missing → exit 1 ✅ (existing)
- interface missing / down → exit 1 ✅ (existing)
- anchored AP_ADDR match (`.100` does not satisfy `.1`) ✅ (existing)

Added in this PR:

- **Grace period with dead daemons**: within grace period → exit 0 even when `pidof` reports both daemons dead (the previous "start period" test did not stub `pidof`).
- **Exact IP assignment matching**: `AP_ADDR=192.168.254.1` assigned alongside other same-subnet addresses (192.168.254.100/.11) → must pass via exact anchored `inet <addr>/` match.

## Test plan

- `bats tests/` — 200/200 green locally.
