### PR TITLE
docs: heading hierarchy and version/staleness markers

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -21,3 +21,7 @@ Lightweight Docker container that turns a Raspberry Pi into a wireless Access Po
 | Test a configuration without touching the system | [`wlanstart.sh --validate`](validation.md#dry-run-validation---validate) |
 | Complete `docker run` example with all option groups | [README](../README.md#full-featured-example) |
 | List connected clients | [`clients.sh`](operations.md#client-inspection-optional) |
+
+---
+
+_Last updated: 2026-08-24_

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -16,7 +16,7 @@ docker run ... \
   ...
 ```
 
-Notes:
+### Notes
 
 - `HT_ENABLED=1` emits `ieee80211n=1`; `HT_CAPAB` sets the optional `ht_capab=` line.
 - `VHT_ENABLED=1` emits `ieee80211ac=1` and requires 5 GHz operation (`HW_MODE=a`); `VHT_CAPAB` sets the optional `vht_capab=` line.
@@ -39,7 +39,9 @@ MAC filtering is **off by default**; behavior is unchanged unless you set `MAC_F
 docker run ... -e MAC_FILTER=1 -v /path/to/hostapd.accept:/etc/hostapd.accept:ro ...
 ```
 
-File format (one MAC per line):
+### File Format
+
+One MAC per line:
 
 ```
 aa:bb:cc:dd:ee:ff
@@ -48,15 +50,24 @@ aa:bb:cc:dd:ee:ff
 
 ## WPA3 (SAE)
 
+### WPA3-Only (`WPA_VERSION=3`)
+
 Setting `WPA_VERSION=3` enables WPA3-SAE authentication. Note:
+
 - Client devices must support SAE (wpa_supplicant 2.7+, iOS 13+/macOS 10.15+, Android 10+).
 - Older clients that only support WPA2 will not be able to connect.
+
+### Transition Mode (`WPA_VERSION=mixed`)
 
 Setting `WPA_VERSION=mixed` enables WPA2/WPA3 transition mode: WPA3-SAE capable devices use SAE, while legacy WPA2 clients can still connect with WPA2-PSK. Note that transition mode is considered less secure than WPA3-only.
 
 ## Regional Channel Validation
 
-When `COUNTRY_CODE` is set, 2.4 GHz channels (`hw_mode=g` or `b`) are validated against regional limits:
+When `COUNTRY_CODE` is set, channels are validated against regional limits.
+
+### 2.4 GHz Channels
+
+For 2.4 GHz (`hw_mode=g` or `b`):
 
 | Region | Countries | Allowed Channels (2.4 GHz) |
 |--------|-----------|---------------------------|
@@ -66,6 +77,8 @@ When `COUNTRY_CODE` is set, 2.4 GHz channels (`hw_mode=g` or `b`) are validated 
 
 Unknown countries fall back to the ETSI limit (1–13). A warning is emitted if `COUNTRY_CODE` is not set.
 
+### 5 GHz Channels
+
 For 5 GHz (`hw_mode=a`), channels are validated against the allowed 5 GHz set:
 
 - **Non-DFS channels** (always allowed): 36, 40, 44, 48, 149, 153, 157, 161, 165
@@ -73,3 +86,7 @@ For 5 GHz (`hw_mode=a`), channels are validated against the allowed 5 GHz set:
 - Any other channel is rejected with a clear error.
 
 See also: [DFS CAC wait times](healthcheck.md#deep-healthcheck-optional) affect the healthcheck grace period on radar channels.
+
+---
+
+_Last updated: 2026-08-24_

--- a/docs/healthcheck.md
+++ b/docs/healthcheck.md
@@ -29,3 +29,7 @@ docker run ... -e HEALTHCHECK_DEEP=1 -e HEALTHCHECK_START_PERIOD=90 ...
 ```
 
 Note: enabling [`CTRL_INTERFACE`](operations.md#client-inspection-optional) already emits the same config lines, so the two options are compatible - either one suffices for `hostapd_cli` to work.
+
+---
+
+_Last updated: 2026-08-24_

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -23,7 +23,7 @@ IPv6 is **off by default**; behavior is unchanged unless you set `IPV6=1`. When 
 docker run ... -e IPV6=1 ...
 ```
 
-Caveats:
+### Caveats
 
 - Client IPv6 connectivity depends on the upstream network advertising an IPv6 prefix (Router Advertisements on the outgoing interface). Without an upstream prefix, clients will only obtain link-local addresses.
 - The container sets forwarding at runtime via `/proc/sys`; for host persistence across reboots see the sysctl commands above.
@@ -42,3 +42,7 @@ For multiple interfaces:
 ```bash
 docker run ... -e OUTGOINGS=eth0,wwan0 ...
 ```
+
+---
+
+_Last updated: 2026-08-24_

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -19,3 +19,7 @@ docker exec rpi-hostap clients.sh
 Output includes MAC address, signal, connected time and tx/rx rates per station (as reported by `hostapd_cli all_sta`). The control interface directory can be overridden with `CTRL_IFACE_DIR` (default `/var/run/hostapd`).
 
 See also: the [deep healthcheck](healthcheck.md#deep-healthcheck-optional) uses the same control interface - enabling either option is sufficient for both.
+
+---
+
+_Last updated: 2026-08-24_

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -21,3 +21,7 @@ Ensure the WiFi interface is up and not in use by another process.
 To test your configuration without touching the system, use [dry-run validation (`--validate`)](validation.md#dry-run-validation---validate).
 
 If the container runs but is reported as `unhealthy`, see [Health Check](healthcheck.md).
+
+---
+
+_Last updated: 2026-08-24_

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -15,3 +15,7 @@ It applies the same environment defaults as a normal start, runs every validator
 On invalid configuration it exits non-zero and lists all validation errors (not just the first). This is covered in CI by the bats suite (`tests/validate_mode.bats`).
 
 Dry-run validation is also the recommended first step when [troubleshooting a container that exits immediately](troubleshooting.md#container-exits-immediately).
+
+---
+
+_Last updated: 2026-08-24_


### PR DESCRIPTION
## Summary

Docs polish from issue #143 (tech-writer review follow-up to #139):

### Heading hierarchy
- `docs/configuration.md`: added `###` sub-sections - HT/VHT "Notes", MAC filtering "File Format", WPA3 split into "WPA3-Only" and "Transition Mode", and "Regional Channel Validation" split into "2.4 GHz Channels" / "5 GHz Channels". No meaning changes; only re-grouping of existing content.
- `docs/networking.md`: promoted the IPv6 "Caveats" list under a `###` heading.
- Short pages (INDEX, operations, troubleshooting, validation, healthcheck) keep a flat `#`/`##` structure, which is appropriate at their length.

### Staleness marker
- Added a footer `_Last updated: 2026-08-24_` (below an `---` rule) to every page in `docs/`.

### Toolchain fit
- There is no mkdocs/docusaurus or markdownlint config in this repo - docs are rendered by GitHub directly, so a plain Markdown footer is the simplest marker that renders everywhere. If automation is wanted later, this line can be bumped by CI in a follow-up.

## Tests

- No lint/test scripts apply: the Makefile has no docs/markdown targets and CI lint is hadolint (Dockerfile-only). Bats tests are unaffected by docs-only changes, so no new tests were added.

Closes #143
