### PR TITLE
docs: systematic See also cross-linking

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -48,6 +48,8 @@ aa:bb:cc:dd:ee:ff
 11:22:33:44:55:66
 ```
 
+See also: [client inspection](operations.md#client-inspection-optional) - use `clients.sh` to list associated stations and verify the filter allows/blocks the expected MACs.
+
 ## WPA3 (SAE)
 
 ### WPA3-Only (`WPA_VERSION=3`)
@@ -85,7 +87,7 @@ For 5 GHz (`hw_mode=a`), channels are validated against the allowed 5 GHz set:
 - **[DFS](https://en.wikipedia.org/wiki/Dynamic_frequency_selection) channels** (allowed with a radar detection/CAC warning): 52, 56, 60, 64, 100–144 (in steps of 4)
 - Any other channel is rejected with a clear error.
 
-See also: [DFS CAC wait times](healthcheck.md#deep-healthcheck-optional) affect the healthcheck grace period on radar channels.
+See also: [DFS CAC wait times](healthcheck.md#deep-healthcheck-optional) affect the healthcheck grace period on radar channels, and [dry-run validation](validation.md#dry-run-validation---validate) checks your chosen channel against these limits without touching the system.
 
 ---
 

--- a/docs/healthcheck.md
+++ b/docs/healthcheck.md
@@ -30,6 +30,8 @@ docker run ... -e HEALTHCHECK_DEEP=1 -e HEALTHCHECK_START_PERIOD=90 ...
 
 Note: enabling [`CTRL_INTERFACE`](operations.md#client-inspection-optional) already emits the same config lines, so the two options are compatible - either one suffices for `hostapd_cli` to work.
 
+See also: [regional channel validation](configuration.md#regional-channel-validation) for which 5 GHz channels are [DFS](https://en.wikipedia.org/wiki/Dynamic_frequency_selection) and trigger CAC.
+
 ---
 
 _Last updated: 2026-08-24_

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -29,6 +29,8 @@ docker run ... -e IPV6=1 ...
 - The container sets forwarding at runtime via `/proc/sys`; for host persistence across reboots see the sysctl commands above.
 - Some ISPs/hosters filter or rate-limit IPv6; test with `ping6` / `traceroute -6` from a client.
 
+See also: [IPv6 troubleshooting](troubleshooting.md#ipv6-no-connectivity-or-only-link-local-addresses) for diagnosing missing upstream prefixes and RA issues.
+
 ## Outgoing Interfaces
 
 By default, NAT is applied to all outgoing interfaces. To restrict NAT to specific interfaces, set `OUTGOINGS` to a comma-separated list when running the container:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,7 +18,7 @@ docker exec rpi-hostap clients.sh
 
 Output includes MAC address, signal, connected time and tx/rx rates per station (as reported by `hostapd_cli all_sta`). The control interface directory can be overridden with `CTRL_IFACE_DIR` (default `/var/run/hostapd`).
 
-See also: the [deep healthcheck](healthcheck.md#deep-healthcheck-optional) uses the same control interface - enabling either option is sufficient for both.
+See also: the [deep healthcheck](healthcheck.md#deep-healthcheck-optional) uses the same control interface - enabling either option is sufficient for both. Client inspection is also useful to verify that [MAC address filtering](configuration.md#mac-address-filtering-optional) works as expected.
 
 ---
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -22,6 +22,16 @@ To test your configuration without touching the system, use [dry-run validation 
 
 If the container runs but is reported as `unhealthy`, see [Health Check](healthcheck.md).
 
+## IPv6: no connectivity or only link-local addresses
+
+If clients get no global IPv6 address, check that:
+
+- `IPV6=1` is set on the container (IPv6 is off by default) - see [IPv6 support](networking.md#ipv6-support-optional).
+- The upstream network advertises an IPv6 prefix via Router Advertisements; without one clients only obtain link-local addresses.
+- Host IPv6 forwarding is persistent (`net.ipv6.conf.all.forwarding=1` in `/etc/sysctl.conf`) - see [NAT / IP forwarding](networking.md#nat--ip-forwarding).
+
+Test from a client with `ping6` / `traceroute -6`. See also the [IPv6 caveats](networking.md#caveats).
+
 ---
 
 _Last updated: 2026-08-24_

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -16,6 +16,8 @@ On invalid configuration it exits non-zero and lists all validation errors (not 
 
 Dry-run validation is also the recommended first step when [troubleshooting a container that exits immediately](troubleshooting.md#container-exits-immediately).
 
+See also: [regional channel validation](configuration.md#regional-channel-validation) (checked by the channel/regulatory validator), [MAC filtering](configuration.md#mac-address-filtering-optional) (file presence validated at start) and the [HT/VHT tuning notes](configuration.md#htvht-80211nac-tuning) for values passed through unvalidated.
+
 ---
 
 _Last updated: 2026-08-24_


### PR DESCRIPTION
Closes #142

Systematic "See also" cross-linking between related docs pages, keeping the existing links (Regional Channels <-> Deep Healthcheck, Client Inspection <-> Deep Healthcheck) intact.

## Changes

- **configuration.md**
  - MAC filtering: link to client inspection (`clients.sh`) to verify the filter works.
  - Regional channel validation: additionally link to dry-run validation for channel/regulatory checks.
- **operations.md**: client inspection also links to MAC filtering (verify allow/deny behavior).
- **networking.md**: IPv6 caveats link to the new IPv6 troubleshooting section.
- **troubleshooting.md**: new "IPv6: no connectivity or only link-local addresses" section, linking back to Networking IPv6 support / forwarding / caveats.
- **validation.md**: See-also links to regional channel validation, MAC filtering and HT/VHT tuning notes (topics whose variables the validators check or pass through).
- **healthcheck.md**: deep healthcheck links to regional channel validation (DFS channel list).

All anchors use relative markdown links; anchor slugs verified against GitHub heading conventions.

## Checks

No docs-specific lint exists in this repo - CI runs hadolint only, which does not cover `docs/*.md`.
