### PR TITLE
docs: task-oriented How do I index

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,6 +2,33 @@
 
 Lightweight Docker container that turns a Raspberry Pi into a wireless Access Point with DHCP server. See the main [README](../README.md) for overview, prerequisites, quick start and the environment variable reference.
 
+## How do I...
+
+| Goal | Variable(s) | Docs |
+|------|-------------|------|
+| Change the network name or password | `SSID`, `WPA_PASSPHRASE` | [README environment variables](../README.md#environment-variables) |
+| Hide my SSID (don't broadcast the network name) | `HIDE_SSID=1` | [README](../README.md#environment-variables) |
+| Only let specific devices (my laptop) connect | `MAC_FILTER=1`, `MAC_ACL_FILE` | [MAC address filtering](configuration.md#mac-address-filtering-optional) |
+| Block specific devices | `MAC_FILTER=2`, `MAC_ACL_FILE` | [MAC address filtering](configuration.md#mac-address-filtering-optional) |
+| Limit how many clients can connect | `MAX_STATIONS` | [README](../README.md#environment-variables) |
+| Stop clients from seeing each other | `AP_ISOLATION=1` | [README](../README.md#environment-variables) |
+| Use WPA3 (or WPA2/WPA3 transition mode) | `WPA_VERSION=3` / `mixed` | [WPA3 (SAE)](configuration.md#wpa3-sae), [verifying client SAE support](configuration.md#verifying-client-sae-support) |
+| Get faster WiFi (802.11n/ac, 5 GHz) | `HW_MODE=a`, `CHANNEL`, `HT_ENABLED`, `HT_CAPAB`, `VHT_ENABLED`, `VHT_CAPAB` | [HT/VHT tuning](configuration.md#htvht-80211nac-tuning) |
+| Use a different channel / country | `CHANNEL`, `COUNTRY_CODE` | [Regional channel validation](configuration.md#regional-channel-validation) |
+| Change the AP's IP address or DHCP range | `AP_ADDR`, `SUBNET`, `DHCP_RANGE`, `DHCP_LEASE` | [README](../README.md#environment-variables) |
+| Change DNS servers given to clients | `PRI_DNS`, `SEC_DNS` | [README](../README.md#environment-variables) |
+| Enable IPv6 for clients | `IPV6=1` | [IPv6 support](networking.md#ipv6-support-optional) |
+| Restrict NAT to specific outgoing interfaces | `OUTGOINGS` | [Outgoing interfaces](networking.md#outgoing-interfaces) |
+| Make IP forwarding persist across reboots | host sysctl config | [NAT / IP forwarding](networking.md#nat--ip-forwarding) |
+| List connected clients | `CTRL_INTERFACE=1` + `clients.sh` | [Client inspection](operations.md#client-inspection-optional) |
+| Verify the AP is actually beaconing | `HEALTHCHECK_DEEP=1` | [Deep healthcheck](healthcheck.md#deep-healthcheck-optional) |
+| Give a DFS channel time to start (CAC wait) | `HEALTHCHECK_START_PERIOD` | [Deep healthcheck: DFS channels](healthcheck.md#deep-healthcheck-optional) |
+| Test my configuration without touching the system | `--validate` flag | [Dry-run validation](validation.md#dry-run-validation---validate) |
+| Fix "Could not connect to kernel driver" | - | [Troubleshooting](troubleshooting.md#could-not-connect-to-kernel-driver) |
+| Fix a container that exits immediately | - | [Troubleshooting](troubleshooting.md#container-exits-immediately) |
+| Diagnose missing IPv6 connectivity on clients | `IPV6` | [IPv6 troubleshooting](troubleshooting.md#ipv6-no-connectivity-or-only-link-local-addresses) |
+| Understand why the container is `unhealthy` | `HEALTHCHECK_START_PERIOD`, `HEALTHCHECK_DEEP` | [Health Check](healthcheck.md) |
+
 ## Contents
 
 | Document | Description |


### PR DESCRIPTION
# docs: task-oriented How do I index

Adds a "How do I..." table to [docs/INDEX.md](docs/INDEX.md) that maps user goals to the relevant environment variables and documentation anchors, as proposed in #140.

## What's included

- 22 goal-based rows covering: SSID/password changes, hidden SSID, MAC allow/deny lists, station limits, client isolation, WPA3/transition mode, HT/VHT throughput, channel/country selection, AP IP/DHCP/DNS tuning, IPv6, NAT interface restriction, persistent forwarding, client listing, deep healthcheck and DFS CAC grace periods, dry-run validation, and the three troubleshooting entry points.
- All links are relative with GitHub-compatible anchors (verified against actual headings in each doc).
- Placed above the existing "Contents" table so task-oriented readers see it first.

Closes #140
