### PR TITLE
refactor(lib): add missing shellcheck source/shell directives

### DIFF
--- a/lib/ctrl_interface.sh
+++ b/lib/ctrl_interface.sh
@@ -1,3 +1,4 @@
+# shellcheck shell=bash
 # compute_ctrl_interface_conf prints hostapd.conf lines enabling the
 # control interface, when CTRL_INTERFACE or HEALTHCHECK_DEEP is set to a
 # non-empty value (the deep healthcheck needs it for hostapd_cli).

--- a/lib/dhcp.sh
+++ b/lib/dhcp.sh
@@ -18,7 +18,7 @@
 # Prints the resulting range to stdout. Messages go to stderr.
 # Returns non-zero for invalid input.
 
-# shellcheck source=validation.sh
+# shellcheck source=lib/validation.sh
 . "$(dirname "${BASH_SOURCE[0]}")/validation.sh"
 
 # A dnsmasq lease time is a positive integer optionally followed by


### PR DESCRIPTION
## Summary

Implements #152 - adds the remaining missing ShellCheck directives under `lib/`:

- `lib/dhcp.sh`: corrected the source directive to `# shellcheck source=lib/validation.sh` (the previous relative path did not resolve, leaving SC1091)
- `lib/ctrl_interface.sh`: added `# shellcheck shell=bash` as line 1 (was the only lib file missing a shell directive, causing SC2148)

The other 13 `lib/*.sh` files already carried the directives; no functional code changed.

## Verification

- `shellcheck lib/*.sh *.sh` is clean: SC1091 and SC2148 findings are gone, no new findings
- `bats tests/`: 200/200 passing

Closes #152
