### PR TITLE
feat(clients): clear error when control interface disabled

### DIFF
--- a/clients.sh
+++ b/clients.sh
@@ -9,4 +9,12 @@ if [[ -z "${INTERFACE:-}" ]] ; then
     exit 1
 fi
 
-exec hostapd_cli -p "${CTRL_IFACE_DIR:-/var/run/hostapd}" -i "${INTERFACE}" all_sta
+CTRL_IFACE_DIR="${CTRL_IFACE_DIR:-/var/run/hostapd}"
+
+if [[ ! -d "${CTRL_IFACE_DIR}" ]] ; then
+    echo "[Error] Control interface not available at ${CTRL_IFACE_DIR}." >&2
+    echo "Restart the container with -e CTRL_INTERFACE=1 to enable it." >&2
+    exit 1
+fi
+
+exec hostapd_cli -p "${CTRL_IFACE_DIR}" -i "${INTERFACE}" all_sta

--- a/tests/clients.bats
+++ b/tests/clients.bats
@@ -1,0 +1,45 @@
+#!/usr/bin/env bats
+
+# Tests exercise clients.sh directly with a stubbed hostapd_cli.
+
+setup() {
+    unset INTERFACE
+    unset CTRL_IFACE_DIR
+    export PATH="${BATS_TEST_TMPDIR}:${PATH}"
+    cat > "${BATS_TEST_TMPDIR}/hostapd_cli" <<'EOF'
+#!/bin/bash
+echo "stub hostapd_cli: $*"
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/hostapd_cli"
+}
+
+@test "missing socket dir prints actionable error and exits non-zero (issue #161)" {
+    export INTERFACE=wlan0
+    run "${BATS_TEST_DIRNAME}/../clients.sh"
+    [ "$status" -ne 0 ]
+    [ "${lines[0]}" = "[Error] Control interface not available at /var/run/hostapd." ]
+    [ "${lines[1]}" = "Restart the container with -e CTRL_INTERFACE=1 to enable it." ]
+}
+
+@test "missing custom CTRL_IFACE_DIR dir reports the configured path" {
+    export INTERFACE=wlan0
+    export CTRL_IFACE_DIR=/nonexistent/hostapd
+    run "${BATS_TEST_DIRNAME}/../clients.sh"
+    [ "$status" -ne 0 ]
+    [ "${lines[0]}" = "[Error] Control interface not available at /nonexistent/hostapd." ]
+}
+
+@test "socket dir present execs hostapd_cli all_sta" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    run "${BATS_TEST_DIRNAME}/../clients.sh"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stub hostapd_cli: -p ${CTRL_IFACE_DIR} -i wlan0 all_sta"* ]]
+}
+
+@test "INTERFACE unset fails before control interface check" {
+    run "${BATS_TEST_DIRNAME}/../clients.sh"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"INTERFACE must be set"* ]]
+}


### PR DESCRIPTION
## Summary

- `clients.sh` now pre-checks for the control interface directory before exec'ing `hostapd_cli`. When the socket directory is missing (e.g. container started without `-e CTRL_INTERFACE=1`), it prints an actionable error to stderr and exits non-zero:
  ```
  [Error] Control interface not available at /var/run/hostapd.
  Restart the container with -e CTRL_INTERFACE=1 to enable it.
  ```
- When the directory exists, behavior is unchanged (exec `hostapd_cli -p <dir> -i <iface> all_sta`). A custom `CTRL_IFACE_DIR` is respected in both the check and the error message.

Closes #161

## Tests

New `tests/clients.bats` (4 tests, stubbed `hostapd_cli`):
- missing default socket dir -> exact error message + non-zero exit
- missing custom `CTRL_IFACE_DIR` -> reports configured path
- socket dir present -> stub receives `-p <dir> -i <iface> all_sta`
- `INTERFACE` unset still fails first with the existing error

Full suite: 204/204 passing locally.
