### PR TITLE
fix: validate SSID before writing hostapd.conf

### DIFF
--- a/lib/validation.sh
+++ b/lib/validation.sh
@@ -29,6 +29,9 @@ validate_ipv4() {
 #   form a new key when written into the unquoted hostapd.conf heredoc)
 validate_ssid() {
     local ssid=${1:-}
+    # Enforce the byte limit in the C locale so multibyte UTF-8
+    # characters are counted per byte, matching the 802.11 limit.
+    local LC_ALL=C
 
     if [ -z "${ssid}" ] ; then
         echo "[Error] Invalid SSID: must not be empty." >&2
@@ -36,7 +39,7 @@ validate_ssid() {
     fi
 
     if [ "${#ssid}" -gt 32 ] ; then
-        echo "[Error] Invalid SSID: must be at most 32 characters (got ${#ssid})." >&2
+        echo "[Error] Invalid SSID: must be at most 32 bytes (got ${#ssid} bytes)." >&2
         return 1
     fi
 

--- a/lib/validation.sh
+++ b/lib/validation.sh
@@ -23,6 +23,39 @@ validate_ipv4() {
     done
 }
 
+# validate_ssid checks that its argument is a safe SSID:
+# - 1-32 bytes (802.11 limit)
+# - no newlines, '#' comments, leading whitespace, or '=' (which could
+#   form a new key when written into the unquoted hostapd.conf heredoc)
+validate_ssid() {
+    local ssid=${1:-}
+
+    if [ -z "${ssid}" ] ; then
+        echo "[Error] Invalid SSID: must not be empty." >&2
+        return 1
+    fi
+
+    if [ "${#ssid}" -gt 32 ] ; then
+        echo "[Error] Invalid SSID: must be at most 32 characters (got ${#ssid})." >&2
+        return 1
+    fi
+
+    if [[ "${ssid}" == *$'\n'* || "${ssid}" == *$'\r'* ]] ; then
+        echo "[Error] Invalid SSID: must not contain newlines." >&2
+        return 1
+    fi
+
+    if [[ "${ssid}" == *"#"* || "${ssid}" == *"="* ]] ; then
+        echo "[Error] Invalid SSID: must not contain '#' or '='." >&2
+        return 1
+    fi
+
+    if [[ "${ssid}" =~ ^[[:space:]] || "${ssid}" =~ [[:space:]]$ ]] ; then
+        echo "[Error] Invalid SSID: must not start or end with whitespace." >&2
+        return 1
+    fi
+}
+
 # validate_ipv4_param checks that a named parameter holds a valid IPv4
 # address, printing the standard error message on failure.
 validate_ipv4_param() {

--- a/tests/ssid_validation.bats
+++ b/tests/ssid_validation.bats
@@ -68,3 +68,16 @@ load_lib() {
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid SSID"* ]]
 }
+
+@test "SSID of 32 multibyte characters (over 32 bytes) is rejected" {
+    load_lib
+    run validate_ssid "$(printf 'é%.0s' {1..32})"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid SSID"* ]]
+}
+
+@test "SSID within 32 bytes containing multibyte characters is accepted" {
+    load_lib
+    run validate_ssid "ááááááááááááááá"  # 15 chars = 30 bytes in UTF-8
+    [ "$status" -eq 0 ]
+}

--- a/tests/ssid_validation.bats
+++ b/tests/ssid_validation.bats
@@ -1,0 +1,70 @@
+#!/usr/bin/env bats
+
+# Tests exercise validate_ssid() from lib/validation.sh - the exact
+# code used by wlanstart.sh (no duplicated logic).
+
+load_lib() {
+    . "${BATS_TEST_DIRNAME}/../lib/validation.sh"
+}
+
+@test "default SSID 'raspberry' is accepted" {
+    load_lib
+    run validate_ssid "raspberry"
+    [ "$status" -eq 0 ]
+}
+
+@test "32-character SSID is accepted" {
+    load_lib
+    run validate_ssid "$(printf 'a%.0s' {1..32})"
+    [ "$status" -eq 0 ]
+}
+
+@test "empty SSID is rejected" {
+    load_lib
+    run validate_ssid ""
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid SSID"* ]]
+}
+
+@test "33-character SSID is rejected with error message" {
+    load_lib
+    run validate_ssid "$(printf 'a%.0s' {1..33})"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid SSID"* ]]
+    [[ "$output" == *"32"* ]]
+}
+
+@test "SSID containing newline (config key injection) is rejected" {
+    load_lib
+    run validate_ssid $'legit\nauth_algs=1'
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid SSID"* ]]
+}
+
+@test "SSID containing '=' (config key injection) is rejected" {
+    load_lib
+    run validate_ssid "ssid=evil"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid SSID"* ]]
+}
+
+@test "SSID containing '#' (comment injection) is rejected" {
+    load_lib
+    run validate_ssid "my#ssid"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid SSID"* ]]
+}
+
+@test "SSID with leading whitespace is rejected" {
+    load_lib
+    run validate_ssid " ssid"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid SSID"* ]]
+}
+
+@test "SSID with trailing whitespace is rejected" {
+    load_lib
+    run validate_ssid "ssid "
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid SSID"* ]]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -225,6 +225,7 @@ run_validation_mode() {
 
     emit_credential_warnings >&2 || true
     validate_passphrase || errors=$((errors + 1))
+    validate_ssid "${SSID}" || errors=$((errors + 1))
     validate_mac_filter || errors=$((errors + 1))
 
     if [ "${errors}" -ne 0 ] ; then
@@ -258,6 +259,9 @@ fi
 # mode emits them above so they are not interleaved with stdout configs).
 emit_credential_warnings
 if ! validate_passphrase ; then
+    exit 1
+fi
+if ! validate_ssid "${SSID}" ; then
     exit 1
 fi
 check_interrupted


### PR DESCRIPTION
## Summary

Fixes #160: `SSID` went straight into the unquoted heredoc in `emit_hostapd_conf`, so values containing newlines or `=` could inject arbitrary hostapd.conf directives, and SSIDs over 32 bytes failed only at hostapd runtime.

- Add `validate_ssid` to `lib/validation.sh` (follows the existing `validate_passphrase` pattern):
  - Rejects empty SSID and SSIDs longer than 32 bytes (802.11 limit)
  - Rejects newlines/CR, `#`, and `=` (config key/comment injection)
  - Rejects leading/trailing whitespace
  - Clear stderr messages on failure
- Wire into `run_validation_mode` (VALIDATE_ONLY path) and the normal startup path like `validate_passphrase`
- New bats tests: `tests/ssid_validation.bats` covering empty, >32-byte, injection-style (`\n`, `=`, `#`) rejection and valid SSID acceptance

## Test results

Full suite green: 213 tests passed (`bats tests/`).
