### PR TITLE
fix: make ipv6 rule functions self-contained

### DIFF
--- a/lib/ipv6.sh
+++ b/lib/ipv6.sh
@@ -8,6 +8,13 @@
 #
 # compute_dnsmasq_ipv6_conf prints the extra dnsmasq.conf line (or nothing
 # when disabled). Messages go to stderr.
+
+# Ensure parse_outgoings (lib/nat.sh) is available so the rule functions
+# below are self-contained and can be called without apply_nat_rules first.
+if ! declare -F parse_outgoings > /dev/null 2>&1 ; then
+    # shellcheck source=lib/nat.sh
+    . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/nat.sh"
+fi
 compute_dnsmasq_ipv6_conf() {
     if [ "${IPV6:-0}" != "1" ] ; then
         echo "[Info] IPV6 not enabled, skipping IPv6 RA/DHCPv6 configuration." >&2
@@ -22,11 +29,11 @@ enable_ipv6_forwarding() {
 }
 
 # apply_ipv6_rules adds ip6tables FORWARD rules mirroring the IPv4 ones.
-# ints is populated by parse_outgoings from lib/nat.sh.
 # shellcheck disable=SC2154
 apply_ipv6_rules() {
     if [ "${OUTGOINGS}" ] ; then
         local int
+        parse_outgoings
         for int in "${ints[@]}" ; do
             ip6tables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
             ip6tables -A FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT
@@ -44,10 +51,10 @@ apply_ipv6_rules() {
 }
 
 # remove_ipv6_rules deletes the ip6tables rules added by apply_ipv6_rules.
-# shellcheck disable=SC2154
 remove_ipv6_rules() {
     if [ "${OUTGOINGS}" ] ; then
         local int
+        parse_outgoings
         for int in "${ints[@]}" ; do
             ip6tables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
             ip6tables -D FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT > /dev/null 2>&1 || true

--- a/tests/ipv6.bats
+++ b/tests/ipv6.bats
@@ -61,3 +61,28 @@ setup() {
     [ "$(grep -c delete "${log}")" -eq 2 ]
     [[ "$(cat "${log}")" == *"-i wlan0 -j ACCEPT"* ]]
 }
+
+@test "remove_ipv6_rules works standalone with OUTGOINGS (no nat.sh loaded)" {
+    local log="${BATS_TEST_TMPDIR}/ip6tables-standalone.log"
+    rm -f "${log}"
+    REPO_ROOT="$REPO_ROOT" LOG="${log}" \
+    run bash -c '
+        ip6tables() { case "$*" in *"-D "*) echo "$*" >> "${LOG}" ;; esac ; }
+        . "'"${REPO_ROOT}"'/lib/ipv6.sh"
+        INTERFACE="wlan0" OUTGOINGS="eth0,eth1" remove_ipv6_rules
+    '
+    [ "$status" -eq 0 ]
+    grep -q -- "-D FORWARD -i wlan0 -o eth0 -j ACCEPT" "${log}"
+    grep -q -- "-D FORWARD -i eth1 -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT" "${log}"
+}
+
+@test "apply_ipv6_rules works standalone with OUTGOINGS (no nat.sh loaded)" {
+    run bash -c '
+        ip6tables() { echo "ip6tables $*" >&2; }
+        . "'"${REPO_ROOT}"'/lib/ipv6.sh"
+        INTERFACE="wlan0" OUTGOINGS="eth0,eth1" apply_ipv6_rules
+    '
+    [ "$status" -eq 0 ]
+    [[ "${output}" == *"ip6tables -A FORWARD -i eth0 -o wlan0"* ]]
+    [[ "${output}" == *"ip6tables -A FORWARD -i wlan0 -o eth1 -j ACCEPT"* ]]
+}


### PR DESCRIPTION
## Summary

Fixes #159

- `apply_ipv6_rules` and `remove_ipv6_rules` in `lib/ipv6.sh` iterated `${ints[@]}` assuming `parse_outgoings` had been called earlier by `lib/nat.sh`. Called standalone (e.g. from cleanup paths), the array was stale or empty and no per-interface rules were removed.
- Both functions now call `parse_outgoings` at the top, mirroring `apply_nat_rules`/`remove_nat_rules`.
- `lib/ipv6.sh` lazily sources `lib/nat.sh` (only if `parse_outgoings` is not already defined) so the ipv6 lib is fully self-contained.
- Added bats tests that source only `lib/ipv6.sh` and call both functions with `OUTGOINGS=eth0,eth1`, verifying per-interface rules are applied/removed without any nat function having run first.

## Test results

- `bats tests/`: 217 tests, all passing (including 2 new standalone ipv6 tests).

## Checklist

- [x] remove_ipv6_rules works when called standalone without prior apply_nat_rules
- [x] Bats tests calling ipv6 functions directly without nat functions
