### PR TITLE
feat: retain daemon failure log on non-zero exit

### DIFF
--- a/lib/logging.sh
+++ b/lib/logging.sh
@@ -7,15 +7,33 @@
 # "[name]" tag, the last tag seen in the captured output points at the
 # daemon that most likely failed to start.
 
+# Destination for the preserved daemon log when the container exits with
+# a failure (issue #162). Overridable for testing.
+FAILURE_LOG_PATH="${FAILURE_LOG_PATH:-/var/log/hostap-failure.log}"
+
 # report_failure <exit-status> [tagged-output-log]
 #
 # Print a final error pointing at the likely failing daemon based on the
-# last tagged line of captured daemon output.
-# shellcheck disable=SC2120
+# last tagged line of captured daemon output. When a non-empty log is
+# given, it is preserved at FAILURE_LOG_PATH so operators can inspect the
+# full tagged output after exit.
 report_failure() {
     local status="$1"
     local log="${2:-}"
     local tag="[daemon]"
+    local saved=""
+
+    # The daemon log is written by a background tee; give it a moment to
+    # flush so the preserved copy contains the full tagged output.
+    if [ -n "${log}" ] ; then
+        local prev=-
+        local _
+        for _ in 1 2 3 4 5 ; do
+            [ "$(wc -c < "${log}" 2>/dev/null || echo 0)" = "${prev}" ] && break
+            prev=$(wc -c < "${log}" 2>/dev/null || echo 0)
+            sleep 0.1
+        done
+    fi
 
     if [ -n "${log}" ] && [ -s "${log}" ] ; then
         local last
@@ -23,7 +41,10 @@ report_failure() {
         if [ -n "${last}" ] ; then
             tag="${last}"
         fi
+        if cp "${log}" "${FAILURE_LOG_PATH}" 2>/dev/null ; then
+            saved=" Full daemon log saved to ${FAILURE_LOG_PATH}."
+        fi
     fi
 
-    echo "[Error] Container exiting (status ${status}): check ${tag} lines above for startup failure." >&2
+    echo "[Error] Container exiting (status ${status}): check ${tag} lines above for startup failure.${saved}" >&2
 }

--- a/lib/logging.sh
+++ b/lib/logging.sh
@@ -41,9 +41,21 @@ report_failure() {
         if [ -n "${last}" ] ; then
             tag="${last}"
         fi
-        if cp "${log}" "${FAILURE_LOG_PATH}" 2>/dev/null ; then
-            saved=" Full daemon log saved to ${FAILURE_LOG_PATH}."
-        fi
+        # Copy, then verify the copy matches the source size so a late
+        # background-tee write that raced the copy is retried once. If the
+        # destination is unwritable (bad dir, permissions), warn and carry on.
+        local _try copied=1
+        for _try in 1 2 ; do
+            if ! cp "${log}" "${FAILURE_LOG_PATH}" 2>/dev/null ; then
+                echo "Warning: could not save daemon log to ${FAILURE_LOG_PATH}." >&2
+                copied=0
+                break
+            fi
+            [ "$(wc -c < "${log}" 2>/dev/null || echo 0)" = \
+              "$(wc -c < "${FAILURE_LOG_PATH}" 2>/dev/null || echo 0)" ] && break
+            sleep 0.1
+        done
+        [ "${copied}" = "1" ] && saved=" Full daemon log saved to ${FAILURE_LOG_PATH}."
     fi
 
     echo "[Error] Container exiting (status ${status}): check ${tag} lines above for startup failure.${saved}" >&2

--- a/tests/failure_report.bats
+++ b/tests/failure_report.bats
@@ -67,6 +67,18 @@ load_logging() {
     [[ "$output" != *"saved to"* ]]
 }
 
+@test "report_failure warns and continues when FAILURE_LOG_PATH is unwritable" {
+    load_logging
+    local log
+    log=$(mktemp)
+    printf '[hostapd] driver missing\n' > "${log}"
+    FAILURE_LOG_PATH="/nonexistent-dir-162/failure.log" run report_failure 1 "${log}"
+    rm -f "${log}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Warning: could not save daemon log to /nonexistent-dir-162/failure.log."* ]]
+    [[ "$output" != *"Full daemon log saved"* ]]
+}
+
 @test "wlanstart reports failing daemon on non-signal exit" {
     grep -q 'report_failure "${STATUS}"' "${SCRIPT}"
 }

--- a/tests/failure_report.bats
+++ b/tests/failure_report.bats
@@ -47,8 +47,66 @@ load_logging() {
     [[ "$output" == *"[Error]"* ]]
 }
 
+@test "report_failure preserves full log at FAILURE_LOG_PATH and mentions it" {
+    load_logging
+    local log dest
+    log=$(mktemp)
+    dest=$(mktemp)
+    printf '[dnsmasq] started\n[hostapd] IEEE 802.11 driver not found\n' > "${log}"
+    FAILURE_LOG_PATH="${dest}" run report_failure 1 "${log}"
+    rm -f "${log}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Full daemon log saved to ${dest}."* ]]
+    diff "${dest}" <(printf '[dnsmasq] started\n[hostapd] IEEE 802.11 driver not found\n')
+    rm -f "${dest}"
+}
+
+@test "report_failure does not mention saved log when none given" {
+    load_logging
+    run report_failure 2 ""
+    [[ "$output" != *"saved to"* ]]
+}
+
 @test "wlanstart reports failing daemon on non-signal exit" {
     grep -q 'report_failure "${STATUS}"' "${SCRIPT}"
+}
+
+@test "wlanstart removes temp daemon log only on clean shutdown (#162)" {
+    run grep -A4 'if \[ "\${STATUS}" -ne 0 \] ; then' "${SCRIPT}"
+    [[ "$output" == *"report_failure"* ]]
+    # failure branch must NOT delete the temp log; the rm lives in else/clean path
+    run bash -c "grep -c 'rm -f \"\${_DAEMON_LOG}\"' '${SCRIPT}'"
+    [ "$output" -ge 1 ]
+}
+
+@test "end-to-end: non-zero exit retains log at FAILURE_LOG_PATH" {
+    local dest
+    dest=$(mktemp)
+    run env FAILURE_LOG_PATH="${dest}" bash -c "
+$(sed -n '/^_MULTIRUN_PID=\"\"$/p; /^_SIGNALED=0$/p' "${SCRIPT}")
+cleanup() { : ; }
+. '${BATS_TEST_DIRNAME}/../lib/logging.sh'
+_DAEMON_LOG=\$(mktemp)
+multirun() {
+    echo '[hostapd] Could not configure driver mode'
+    return 1
+}
+multirun 'x' 'y' > >(tee \"\${_DAEMON_LOG}\") 2>&1 &
+_MULTIRUN_PID=\$!
+wait \"\${_MULTIRUN_PID}\"
+STATUS=\$?
+if [ \"\${STATUS}\" -ne 0 ] ; then
+    report_failure \"\${STATUS}\" \"\${_DAEMON_LOG}\"
+else
+    rm -f \"\${_DAEMON_LOG}\"
+fi
+exit \"\${STATUS}\"
+"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[Error] Container exiting (status 1)"* ]]
+    [[ "$output" == *"Full daemon log saved to ${dest}."* ]]
+    grep -q '\[hostapd\] Could not configure driver mode' "${dest}"
+    rm -f "${dest}" "${_DAEMON_LOG:-/dev/null}" 2>/dev/null || true
 }
 
 @test "wlanstart tees multirun output to a log for failure attribution" {

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -340,11 +340,16 @@ STATUS=$?
 cleanup
 
 if [ "${_SIGNALED}" = "1" ] ; then
+    # Clean shutdown after signal: temp log is not needed.
     rm -f "${_DAEMON_LOG}"
     exit 0
 fi
 if [ "${STATUS}" -ne 0 ] ; then
+    # Preserve the full tagged daemon log for post-mortem (issue #162);
+    # report_failure copies it to FAILURE_LOG_PATH and mentions the path.
+    # The temp log is only removed on clean shutdown / signal exit.
     report_failure "${STATUS}" "${_DAEMON_LOG}"
+else
+    rm -f "${_DAEMON_LOG}"
 fi
-rm -f "${_DAEMON_LOG}"
 exit "${STATUS}"


### PR DESCRIPTION
# Retain daemon failure log on non-zero exit (#162)

## Problem

On a daemon startup failure, `report_failure` printed a single line pointing at the likely failing daemon and the tagged `[dnsmasq]`/`[hostapd]` temp log (`${_DAEMON_LOG}`) was deleted immediately. Operators lost the full tagged output needed for post-mortem analysis.

## Changes

- `lib/logging.sh`: `report_failure` now copies the captured daemon log to `/var/log/hostap-failure.log` (configurable via `FAILURE_LOG_PATH`) and appends "Full daemon log saved to <path>" to the error message. Before copying, it briefly waits (up to ~0.5s) for the background `tee` to finish flushing so the preserved copy is complete.
- `wlanstart.sh`: the temp log is now removed only on clean shutdown (signal exit or zero exit status). On non-zero exit it is kept alongside the preserved copy.

## Acceptance criteria

- Non-zero exit -> full tagged log retained at `/var/log/hostap-failure.log` - covered by new tests.
- Error message includes the log path.
- Clean shutdown still removes the temp log.

## Tests

New/updated bats tests in `tests/failure_report.bats`:

- `report_failure preserves full log at FAILURE_LOG_PATH and mentions it`
- `report_failure does not mention saved log when none given`
- `wlanstart removes temp daemon log only on clean shutdown (#162)`
- `end-to-end: non-zero exit retains log at FAILURE_LOG_PATH`

Full suite: `bats tests/` - 230/230 green.

Closes #162
