### PR TITLE
feat: reject unknown HW_MODE in validate mode

### DIFF
--- a/lib/channel.sh
+++ b/lib/channel.sh
@@ -49,3 +49,19 @@ validate_channel() {
     esac
     return 0
 }
+
+# Strict variant used by validation mode: unknown HW_MODE is an error.
+validate_channel_strict() {
+    if ! validate_channel ; then
+        return 1
+    fi
+    : "${HW_MODE:=g}"
+    case "${HW_MODE}" in
+        a|b|g) ;;
+        *)
+            echo "[Error] Unknown hw_mode='${HW_MODE}' (allowed: b, g, a)" >&2
+            return 1
+            ;;
+    esac
+    return 0
+}

--- a/tests/channel_validation.bats
+++ b/tests/channel_validation.bats
@@ -250,3 +250,37 @@ setup() {
     [ "$status" -eq 1 ]
     [[ "$output" == *"country EU"* ]]
 }
+
+# --- strict validation mode (unknown hw_mode is an error) ---
+
+@test "strict: unknown hw_mode fails with error" {
+    HW_MODE="gn"
+    CHANNEL="1"
+    run validate_channel_strict
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error"*"Unknown hw_mode='gn'"* ]]
+}
+
+@test "strict: valid hw_modes pass" {
+    for pair in "a 36" "b 1" "g 6"; do
+        set -- ${pair}
+        HW_MODE="$1"
+        CHANNEL="$2"
+        run validate_channel_strict
+        [ "$status" -eq 0 ]
+    done
+}
+
+@test "strict: default hw_mode (g) passes" {
+    unset HW_MODE
+    CHANNEL="1"
+    run validate_channel_strict
+    [ "$status" -eq 0 ]
+}
+
+@test "strict: channel errors still fail" {
+    HW_MODE="g"
+    CHANNEL="14"
+    run validate_channel_strict
+    [ "$status" -eq 1 ]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -222,7 +222,7 @@ run_validation_mode() {
         errors=$((errors + 1))
     fi
 
-    validate_channel || errors=$((errors + 1))
+    validate_channel_strict || errors=$((errors + 1))
 
     validate_ipv4_param SUBNET "${SUBNET}" || errors=$((errors + 1))
     validate_ipv4_param AP_ADDR "${AP_ADDR}" || errors=$((errors + 1))


### PR DESCRIPTION
## Summary

In `--validate` mode, an unknown `HW_MODE` (e.g. a typo like `gn`) previously passed validation with only a warning from `validate_channel`, producing an invalid `hw_mode=gn` in the generated hostapd.conf.

- Add `validate_channel_strict` to lib/channel.sh: wraps `validate_channel` and additionally treats unknown `HW_MODE` as an error (`[Error] Unknown hw_mode=... (allowed: b, g, a)`).
- `run_validation_mode` now uses the strict variant, so invalid HW_MODE is counted in the error tally and exits non-zero.
- Normal startup mode is unchanged: still warning-only via plain `validate_channel`.

Closes #163

## Testing

- New bats tests in tests/channel_validation.bats: strict unknown hw_mode fails with error; valid modes (a/b/g) pass; default hw_mode passes; channel errors still fail.
- Full suite: 235 tests green.
