### PR TITLE
feat: add --version flag to wlanstart.sh

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -64,6 +64,8 @@ jobs:
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7.3.0
         with:
           context: .
+          build-args: |
+            VERSION=${{ steps.version.outputs.VERSION }}
           platforms: linux/amd64,linux/arm/v7,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,9 @@ FROM alpine:3.24.1
 
 LABEL maintainer="Sergio R. <sdelrio@users.noreply.github.com>"
 
+ARG VERSION=dev
+ENV WLANSTART_VERSION=${VERSION}
+
 RUN apk add --no-cache \
     bash=5.3.9-r1 \
     hostapd=2.11-r4 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,15 +2,17 @@ FROM alpine:3.24.1
 
 LABEL maintainer="Sergio R. <sdelrio@users.noreply.github.com>"
 
-ARG VERSION=dev
-ENV WLANSTART_VERSION=${VERSION}
-
 RUN apk add --no-cache \
     bash=5.3.9-r1 \
     hostapd=2.11-r4 \
     iptables=1.8.13-r0 \
     dnsmasq=2.92_p2-r0 \
     multirun=1.1.3-r0
+
+# Placed after the apk layer so per-release version bumps do not
+# invalidate the package-install cache.
+ARG VERSION=dev
+ENV WLANSTART_VERSION=${VERSION}
 
 ENV HEALTHCHECK_START_PERIOD=15
 

--- a/tests/version_flag.bats
+++ b/tests/version_flag.bats
@@ -1,0 +1,33 @@
+#!/usr/bin/env bats
+
+setup() {
+    ROOT="${BATS_TEST_DIRNAME}/.."
+}
+
+@test "--version prints WLANSTART_VERSION when set" {
+    version=$("$ROOT/wlanstart.sh" --version)
+    [ -n "$version" ]
+    echo "$version" | grep -Eq '^[0-9]+\.[0-9]+\.[0-9]+$'
+}
+
+@test "-V prints the same version as --version" {
+    v_long=$("$ROOT/wlanstart.sh" --version)
+    v_short=$("$ROOT/wlanstart.sh" -V)
+    [ "$v_long" = "$v_short" ]
+}
+
+@test "--version matches scripts/get-version.sh output" {
+    v_flag=$("$ROOT/wlanstart.sh" --version)
+    v_script=$("$ROOT/scripts/get-version.sh")
+    [ "$v_flag" = "$v_script" ]
+}
+
+@test "Dockerfile declares VERSION build arg and WLANSTART_VERSION env" {
+    grep -q 'ARG VERSION=dev' "$ROOT/Dockerfile"
+    grep -q 'ENV WLANSTART_VERSION=${VERSION}' "$ROOT/Dockerfile"
+}
+
+@test "publish workflow passes VERSION build-arg to docker build" {
+    grep -q 'build-args:' "$ROOT/.github/workflows/publish.yml"
+    grep -q 'VERSION=${{ steps.version.outputs.VERSION }}' "$ROOT/.github/workflows/publish.yml"
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -55,10 +55,20 @@ case "${1:-}" in
         VALIDATE_ONLY=1
         shift
         ;;
+    --version|-V)
+        if [ -n "${WLANSTART_VERSION:-}" ] ; then
+            echo "${WLANSTART_VERSION}"
+        elif command -v jq >/dev/null 2>&1 && [ -f "$(dirname "$0")/scripts/get-version.sh" ] ; then
+            sh "$(dirname "$0")/scripts/get-version.sh" 2>/dev/null || echo "unknown"
+        else
+            echo "unknown"
+        fi
+        exit 0
+        ;;
     "")
         ;;
     *)
-        echo "[Error] Unknown option '${1}'. Usage: wlanstart.sh [--validate|-t|--test]" >&2
+        echo "[Error] Unknown option '${1}'. Usage: wlanstart.sh [--version|-V|--validate|-t|--test]" >&2
         exit 1
         ;;
 esac


### PR DESCRIPTION
## Summary

Add `--version`/`-V` flag to `wlanstart.sh` so operators can query the image version (#164).

- `wlanstart.sh`: handles `--version|-V` alongside `--validate` in the arg parsing case; prints `WLANSTART_VERSION`, falls back to `scripts/get-version.sh` (when available, e.g. repo checkout), then `"unknown"`; exits 0.
- Unknown-option usage message now lists `[--version|-V|--validate|-t|--test]`.
- `Dockerfile`: `ARG VERSION=dev` + `ENV WLANSTART_VERSION=${VERSION}`.
- `.github/workflows/publish.yml`: passes `--build-arg VERSION=<release tag>` (from the existing version-extraction step) to `docker/build-push-action`.
- New `tests/version_flag.bats` mirroring `tests/version_sync.bats`.

Note: Docker is not available in the local environment, so the image-level acceptance check (`docker run --rm image --version` printing the release tag) was not run locally; CI covers the build.

Closes #164
