### PR TITLE
feat: support configurable subnet mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ docker run -d \
 | `SUBNET` | No | Network subnet | `192.168.254.0` |
 | `OUTGOINGS` | No | Comma-separated outgoing interfaces for NAT | All interfaces |
 | `HW_MODE` | No | Hardware mode (`g` = 2.4GHz, `a` = 5GHz) | `g` |
-| `DHCP_RANGE` | No | DHCP range (`start,end,mask,lease`) | Auto from SUBNET |
+| `DHCP_RANGE` | No | DHCP range (`start,end,mask,lease`). The `mask` field sets the subnet prefix used on the AP interface and NAT rules (e.g. `255.255.255.240` = `/28`) | Auto from SUBNET |
 | `DHCP_LEASE` | No | DHCP lease time (used with default range) | `12h` |
 | `MAX_STATIONS` | No | Max connected clients (`0` = unlimited) | `0` |
 | `HIDE_SSID` | No | Hide SSID broadcast (`1` = hidden) | `0` |

--- a/docs/networking.md
+++ b/docs/networking.md
@@ -1,5 +1,20 @@
 # Networking
 
+## Subnet Mask
+
+The subnet prefix defaults to `/24` (netmask `255.255.255.0`). To use a different subnet size, set the netmask field of `DHCP_RANGE` explicitly; the prefix is derived from it and applied everywhere (AP interface address, NAT rules):
+
+```bash
+docker run ... -e SUBNET=192.168.254.16 -e AP_ADDR=192.168.254.17 \
+    -e DHCP_RANGE="192.168.254.20,192.168.254.30,255.255.255.240,12h" ...
+```
+
+Notes:
+
+- The mask must be contiguous (e.g. `255.255.255.240` = `/28`).
+- `SUBNET` must be the network address for that mask (host bits zero); e.g. for a `/28`, the last octet must be a multiple of 16.
+- When `DHCP_RANGE` is unset, the default range uses a `/24` layout, so `SUBNET` must end in `.0`.
+
 ## NAT / IP Forwarding
 
 The container enables IP forwarding at runtime. For persistence across host reboots:
@@ -47,4 +62,4 @@ docker run ... -e OUTGOINGS=eth0,wwan0 ...
 
 ---
 
-_Last updated: 2026-08-24_
+_Last updated: 2026-08-25_

--- a/lib/dhcp.sh
+++ b/lib/dhcp.sh
@@ -8,12 +8,16 @@
 # three fields must be well-formed IPv4 addresses and the fourth must be a
 # dnsmasq-style lease time (integer optionally followed by h/m/s).
 #
-# SUBNET handling: this container hardcodes a /24 layout everywhere
-# (${AP_ADDR}/24 on the interface, ${SUBNET}/24 iptables rules), so only
-# /24 networks are supported. SUBNET must therefore be a valid IPv4
-# address whose last octet is 0 (a /24 network address); anything else -
-# including wrong octet counts - is rejected explicitly instead of being
-# silently mangled into a bogus default range.
+# SUBNET handling: the CIDR prefix comes from the DHCP_RANGE netmask
+# field and propagates to the interface address (${AP_ADDR}/<prefix>)
+# and NAT rules. When DHCP_RANGE is unset a default /24 range is
+# computed from SUBNET, so SUBNET must then be a valid IPv4 address
+# whose last octet is 0 (a /24 network address). With an explicit
+# DHCP_RANGE, any mask is accepted as long as SUBNET is its network
+# address; anything else - including wrong octet counts - is rejected
+# explicitly instead of being silently mangled into a bogus range.
+# The derived prefix is exported as DHCP_PREFIX for lib/interface.sh
+# and lib/nat.sh.
 #
 # Prints the resulting range to stdout. Messages go to stderr.
 # Returns non-zero for invalid input.
@@ -44,13 +48,15 @@ compute_dhcp_range() {
             echo "[Error] Invalid SUBNET: '${SUBNET}' is not a valid IPv4 address." >&2
             return 1
         fi
-        # Only /24 networks are supported by the rest of the setup.
+        # Only /24 networks are supported for the default range.
         if [ "${SUBNET##*.}" != "0" ] ; then
-            echo "[Error] Invalid SUBNET: '${SUBNET}' is not a /24 network address (last octet must be 0)." >&2
+            echo "[Error] Invalid SUBNET: '${SUBNET}' is not a network address for the default /24 mask (last octet must be 0)." >&2
             return 1
         fi
         local prefix=${SUBNET%.*}
         DHCP_RANGE="${prefix}.100,${prefix}.200,255.255.255.0,${DHCP_LEASE}"
+        DHCP_PREFIX=24
+        export DHCP_PREFIX
         echo "[Warning] DHCP_RANGE not set, using default: $DHCP_RANGE" >&2
     else
         local COMMA_COUNT
@@ -76,6 +82,19 @@ compute_dhcp_range() {
             echo "[Error] Invalid DHCP_RANGE: field 3 '${netmask}' is not a valid IPv4 address" >&2
             return 1
         fi
+        # Derive the CIDR prefix from the netmask; this propagates to the
+        # interface address (${AP_ADDR}/<prefix>) and NAT rules.
+        if ! DHCP_PREFIX=$(netmask_to_prefix "${netmask}") ; then
+            echo "[Error] Invalid DHCP_RANGE: field 3 '${netmask}' is not a usable netmask" >&2
+            return 1
+        fi
+        # SUBNET must be the network address for the configured mask.
+        if [ -n "${SUBNET:-}" ] && validate_ipv4 "${SUBNET}" \
+           && ! is_network_address "${SUBNET}" "${netmask}" ; then
+            echo "[Error] Invalid SUBNET: '${SUBNET}' is not a network address for mask ${netmask} (host bits must be 0)." >&2
+            return 1
+        fi
+        export DHCP_PREFIX
         if ! validate_lease_time "${lease_time}" ; then
             echo "[Error] Invalid DHCP_RANGE: field 4 '${lease_time}' is not a valid lease time" >&2
             echo "  Expected: integer optionally followed by h/m/s (e.g. 12h, 3600)" >&2

--- a/lib/interface.sh
+++ b/lib/interface.sh
@@ -11,8 +11,8 @@ setup_interface() {
         echo "[Error] Failed to flush addresses on ${INTERFACE}" >&2
         return 1
     }
-    ip addr add "${AP_ADDR}"/24 dev "${INTERFACE}" || {
-        echo "[Error] Failed to assign ${AP_ADDR}/24 to ${INTERFACE}" >&2
+    ip addr add "${AP_ADDR}/${DHCP_PREFIX:-24}" dev "${INTERFACE}" || {
+        echo "[Error] Failed to assign ${AP_ADDR}/${DHCP_PREFIX:-24} to ${INTERFACE}" >&2
         return 1
     }
 }

--- a/lib/nat.sh
+++ b/lib/nat.sh
@@ -22,8 +22,8 @@ apply_nat_rules() {
         do
             echo "Setting iptables for outgoing traffics on ${int}..."
 
-            iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
-            iptables -t nat -A POSTROUTING -s "${SUBNET}/24" -o "${int}" -j MASQUERADE
+            iptables -t nat -D POSTROUTING -s "${SUBNET}/${DHCP_PREFIX:-24}" -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
+            iptables -t nat -A POSTROUTING -s "${SUBNET}/${DHCP_PREFIX:-24}" -o "${int}" -j MASQUERADE
 
             iptables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
             iptables -A FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT
@@ -34,8 +34,8 @@ apply_nat_rules() {
     else
         echo "Setting iptables for outgoing traffics on all interfaces..."
 
-        iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -j MASQUERADE > /dev/null 2>&1 || true
-        iptables -t nat -A POSTROUTING -s "${SUBNET}/24" -j MASQUERADE
+        iptables -t nat -D POSTROUTING -s "${SUBNET}/${DHCP_PREFIX:-24}" -j MASQUERADE > /dev/null 2>&1 || true
+        iptables -t nat -A POSTROUTING -s "${SUBNET}/${DHCP_PREFIX:-24}" -j MASQUERADE
 
         iptables -D FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
         iptables -A FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT
@@ -71,13 +71,13 @@ remove_nat_rules() {
         parse_outgoings
         for int in "${ints[@]}" ; do
             echo "Removing iptables for outgoing traffics on ${int}..."
-            iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
+            iptables -t nat -D POSTROUTING -s "${SUBNET}/${DHCP_PREFIX:-24}" -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
             iptables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
             iptables -D FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT > /dev/null 2>&1 || true
         done
     else
         echo "Removing iptables for outgoing traffics on all interfaces..."
-        iptables -t nat -D POSTROUTING -s "${SUBNET}/24" -j MASQUERADE > /dev/null 2>&1 || true
+        iptables -t nat -D POSTROUTING -s "${SUBNET}/${DHCP_PREFIX:-24}" -j MASQUERADE > /dev/null 2>&1 || true
         iptables -D FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
         iptables -D FORWARD -i "${INTERFACE}" -j ACCEPT > /dev/null 2>&1 || true
     fi

--- a/lib/validation.sh
+++ b/lib/validation.sh
@@ -59,6 +59,58 @@ validate_ssid() {
     fi
 }
 
+# netmask_to_prefix converts a dotted-decimal netmask to its CIDR prefix
+# length (e.g. 255.255.255.240 -> 28). The mask must be contiguous
+# (255s, then optionally one partial octet, then 0s). Pure bash so it can
+# be tested on macOS without network tools. Prints the prefix on stdout.
+netmask_to_prefix() {
+    local mask=${1:-} octet prefix=0 seen_partial=0
+    if ! validate_ipv4 "${mask}" ; then
+        echo "[Error] Invalid netmask: '${mask}' is not a valid IPv4 address." >&2
+        return 1
+    fi
+    for octet in ${mask//./ } ; do
+        if [ "${octet}" = "255" ] && [ "${seen_partial}" -eq 0 ] ; then
+            prefix=$((prefix + 8))
+        elif [ "${octet}" = "0" ] ; then
+            seen_partial=1
+        elif [ "${seen_partial}" -eq 0 ] ; then
+            # Partial octet: must be contiguous high bits (128..254)
+            case "${octet}" in
+                128) prefix=$((prefix + 1)) ;;
+                192) prefix=$((prefix + 2)) ;;
+                224) prefix=$((prefix + 3)) ;;
+                240) prefix=$((prefix + 4)) ;;
+                248) prefix=$((prefix + 5)) ;;
+                252) prefix=$((prefix + 6)) ;;
+                254) prefix=$((prefix + 7)) ;;
+                *)
+                    echo "[Error] Invalid netmask: '${mask}' is not a contiguous mask." >&2
+                    return 1
+                    ;;
+            esac
+            seen_partial=1
+        else
+            echo "[Error] Invalid netmask: '${mask}' is not a contiguous mask." >&2
+            return 1
+        fi
+    done
+    echo "${prefix}"
+}
+
+# is_network_address checks that addr has all host bits zero for the
+# given dotted-decimal netmask (i.e. addr & mask == addr). Pure bash.
+is_network_address() {
+    local addr=${1:-} mask=${2:-}
+    local a1 a2 a3 a4 m1 m2 m3 m4
+    IFS=. read -r a1 a2 a3 a4 <<<"${addr}"
+    IFS=. read -r m1 m2 m3 m4 <<<"${mask}"
+    [ $(( a1 & m1 )) -eq "${a1}" ] || return 1
+    [ $(( a2 & m2 )) -eq "${a2}" ] || return 1
+    [ $(( a3 & m3 )) -eq "${a3}" ] || return 1
+    [ $(( a4 & m4 )) -eq "${a4}" ] || return 1
+}
+
 # validate_ipv4_param checks that a named parameter holds a valid IPv4
 # address, printing the standard error message on failure.
 validate_ipv4_param() {

--- a/tests/dhcp_range.bats
+++ b/tests/dhcp_range.bats
@@ -167,14 +167,14 @@ setup() {
     [[ "${lines[*]}" == *"Invalid SUBNET"* ]]
 }
 
-# The container hardcodes a /24 layout (AP_ADDR/24 on the interface,
-# ${SUBNET}/24 iptables rules), so non-/24 subnets are unsupported and
-# rejected explicitly rather than silently producing a bogus /24 range.
+# The default range is /24, so SUBNET must then be a network address
+# for that mask (last octet 0). With an explicit DHCP_RANGE any
+# contiguous mask is supported; SUBNET just has to match it.
 @test "default range rejected for non-/24 SUBNET" {
     SUBNET="192.168.254.7"
     run compute_dhcp_range
     [ "$status" -eq 1 ]
-    [[ "${lines[*]}" == *"'192.168.254.7' is not a /24 network address"* ]]
+    [[ "${lines[*]}" == *"'192.168.254.7' is not a network address for the default /24 mask"* ]]
 }
 
 @test "invalid DHCP_LEASE fails for default range" {
@@ -182,4 +182,83 @@ setup() {
     run compute_dhcp_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"Invalid DHCP_LEASE: 'forever' is not a valid lease time"* ]]
+}
+
+@test "/28 DHCP_RANGE sets DHCP_PREFIX to 28" {
+    # shellcheck disable=SC2016
+    run bash -c '
+        . "'"${REPO_ROOT}"'/lib/dhcp.sh"
+        SUBNET="192.168.254.16" AP_ADDR="192.168.254.17" INTERFACE="wlan0"
+        PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4"
+        DHCP_RANGE="192.168.254.20,192.168.254.30,255.255.255.240,12h"
+        compute_dhcp_range > /dev/null || exit 1
+        echo "${DHCP_PREFIX}"
+    '
+    [ "$status" -eq 0 ]
+    [ "${output}" = "28" ]
+}
+
+@test "default range sets DHCP_PREFIX to 24" {
+    # shellcheck disable=SC2016
+    run bash -c '
+        . "'"${REPO_ROOT}"'/lib/dhcp.sh"
+        SUBNET="192.168.254.0" AP_ADDR="192.168.254.1" INTERFACE="wlan0"
+        PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4"
+        compute_dhcp_range > /dev/null 2>&1 || exit 1
+        echo "${DHCP_PREFIX}"
+    '
+    [ "$status" -eq 0 ]
+    [ "${output}" = "24" ]
+}
+
+@test "explicit /24 DHCP_RANGE sets DHCP_PREFIX to 24" {
+    # shellcheck disable=SC2016
+    run bash -c '
+        . "'"${REPO_ROOT}"'/lib/dhcp.sh"
+        SUBNET="10.10.10.0" AP_ADDR="10.10.10.1" INTERFACE="wlan0"
+        PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4"
+        DHCP_RANGE="10.10.10.50,10.10.10.150,255.255.255.0,12h"
+        compute_dhcp_range > /dev/null || exit 1
+        echo "${DHCP_PREFIX}"
+    '
+    [ "$status" -eq 0 ]
+    [ "${output}" = "24" ]
+}
+
+@test "/16 DHCP_RANGE sets DHCP_PREFIX to 16" {
+    # shellcheck disable=SC2016
+    run bash -c '
+        . "'"${REPO_ROOT}"'/lib/dhcp.sh"
+        SUBNET="192.168.0.0" AP_ADDR="192.168.254.1" INTERFACE="wlan0"
+        PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4"
+        DHCP_RANGE="192.168.100.50,192.168.200.150,255.255.0.0,12h"
+        compute_dhcp_range > /dev/null || exit 1
+        echo "${DHCP_PREFIX}"
+    '
+    [ "$status" -eq 0 ]
+    [ "${output}" = "16" ]
+}
+
+@test "non-contiguous netmask in DHCP_RANGE fails" {
+    DHCP_RANGE="192.168.254.100,192.168.254.200,255.0.255.0,12h"
+    run compute_dhcp_range
+    [ "$status" -eq 1 ]
+    [[ "${lines[*]}" == *"field 3 '255.0.255.0' is not a usable netmask"* ]]
+}
+
+@test "SUBNET with host bits set fails for /28 mask" {
+    SUBNET="192.168.254.17"
+    DHCP_RANGE="192.168.254.20,192.168.254.30,255.255.255.240,12h"
+    run compute_dhcp_range
+    [ "$status" -eq 1 ]
+    [[ "${lines[*]}" == *"Invalid SUBNET: '192.168.254.17' is not a network address for mask 255.255.255.240"* ]]
+}
+
+@test "SUBNET network address matching /28 mask is accepted" {
+    SUBNET="192.168.254.16"
+    AP_ADDR="192.168.254.17"
+    DHCP_RANGE="192.168.254.20,192.168.254.30,255.255.255.240,12h"
+    run compute_dhcp_range
+    [ "$status" -eq 0 ]
+    [ "${lines[@]: -1}" = "192.168.254.20,192.168.254.30,255.255.255.240,12h" ]
 }

--- a/tests/interface_prefix.bats
+++ b/tests/interface_prefix.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+# Tests exercise setup_interface() from lib/interface.sh with a stubbed
+# ip command, verifying the netmask-derived prefix (DHCP_PREFIX).
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+# shellcheck source=../lib/interface.sh
+. "${REPO_ROOT}/lib/interface.sh"
+
+LOG=""
+
+setup() {
+    export INTERFACE="wlan0"
+    export AP_ADDR="192.168.254.1"
+    unset DHCP_PREFIX
+    LOG="${BATS_TEST_TMPDIR}/ip.log"
+    ip() { echo "ip $*" >> "${LOG}"; }
+}
+
+@test "setup_interface defaults to /24 when DHCP_PREFIX is unset" {
+    run setup_interface
+    [ "$status" -eq 0 ]
+    grep -q -- "ip addr add 192.168.254.1/24 dev wlan0" "${LOG}"
+}
+
+@test "setup_interface uses DHCP_PREFIX for the interface address" {
+    DHCP_PREFIX=28
+    run setup_interface
+    [ "$status" -eq 0 ]
+    grep -q -- "ip addr add 192.168.254.1/28 dev wlan0" "${LOG}"
+}
+
+@test "setup_interface flushes addresses before assigning" {
+    run setup_interface
+    [ "$status" -eq 0 ]
+    [ "$(grep -n 'addr add' "${LOG}" | cut -d: -f1)" -gt "$(grep -n 'addr flush' "${LOG}" | cut -d: -f1)" ]
+}

--- a/tests/nat.bats
+++ b/tests/nat.bats
@@ -74,6 +74,14 @@ setup() {
     rm -f "${log}"
 }
 
+@test "apply_nat_rules uses DHCP_PREFIX when set" {
+    DHCP_PREFIX=28
+    iptables() { echo "iptables $*"; }
+    run apply_nat_rules
+    [ "$status" -eq 0 ]
+    [[ "${output}" == *"iptables -t nat -A POSTROUTING -s 192.168.254.0/28 -j MASQUERADE"* ]]
+}
+
 @test "remove_nat_rules deletes rules per interface with OUTGOINGS" {
     local log
     log=$(mktemp)

--- a/tests/validation.bats
+++ b/tests/validation.bats
@@ -83,3 +83,42 @@ validate_ipv4_param AP_ADDR \"\${AP_ADDR}\" || exit 1
     SUBNET="192.168.254.0" AP_ADDR="192.168.254.1" run run_wlanstart_validation
     [ "$status" -eq 0 ]
 }
+
+@test "netmask_to_prefix converts common masks" {
+    load_lib
+    for pair in "255.255.255.0:24" "255.255.0.0:16" "255.0.0.0:8" "0.0.0.0:0" "255.255.255.255:32" "255.255.255.240:28" "255.255.255.128:25" "255.255.240.0:20" ; do
+        mask="${pair%:*}"
+        want="${pair#*:}"
+        run netmask_to_prefix "${mask}"
+        [ "$status" -eq 0 ]
+        [ "${output}" = "${want}" ]
+    done
+}
+
+@test "netmask_to_prefix rejects invalid masks" {
+    load_lib
+    for mask in 255.0.255.0 255.255.0.255 255.255.255.1 255.255.255.3 not-a-mask 255.0.0 "192.168.256.0" ; do
+        run netmask_to_prefix "${mask}"
+        [ "$status" -ne 0 ]
+    done
+}
+
+@test "is_network_address accepts network addresses matching the mask" {
+    load_lib
+    for pair in "192.168.254.0:255.255.255.0" "192.168.254.16:255.255.255.240" "10.0.0.0:255.0.0.0" ; do
+        addr="${pair%%:*}"
+        mask="${pair#*:}"
+        run is_network_address "${addr}" "${mask}"
+        [ "$status" -eq 0 ]
+    done
+}
+
+@test "is_network_address rejects host bits set" {
+    load_lib
+    for pair in "192.168.254.7:255.255.255.0" "192.168.254.17:255.255.255.240" "10.1.0.0:255.0.0.0" ; do
+        addr="${pair%%:*}"
+        mask="${pair#*:}"
+        run is_network_address "${addr}" "${mask}"
+        [ "$status" -ne 0 ]
+    done
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -292,6 +292,10 @@ fi
 validate_ipv4_param SUBNET "${SUBNET}" || exit 1
 validate_ipv4_param AP_ADDR "${AP_ADDR}" || exit 1
 
+# Compute DHCP range early so the netmask-derived prefix (DHCP_PREFIX)
+# is available for setup_interface and apply_nat_rules.
+compute_dhcp_range > /dev/null || exit 1
+
 # Always regenerate hostapd.conf so env var changes apply between runs.
 # Generated atomically so a failure leaves the old config intact (#157).
 write_atomic_config emit_hostapd_conf "/etc/hostapd.conf" || exit 1


### PR DESCRIPTION
# feat: support configurable subnet mask

Closes #165

## Summary

The container previously hardcoded a `/24` prefix everywhere (`${AP_ADDR}/24` in `lib/interface.sh`, `${SUBNET}/24` in `lib/nat.sh`), making non-/24 subnets impossible. The prefix is now derived from the `DHCP_RANGE` netmask field and propagated everywhere.

## Changes

- `lib/validation.sh`: new pure-bash `netmask_to_prefix()` (contiguous-mask to CIDR conversion, e.g. `255.255.255.240` -> `28`) and `is_network_address()` (host-bits-zero check).
- `lib/dhcp.sh`: `compute_dhcp_range()` validates the explicit netmask, derives the prefix, checks that `SUBNET` is the network address for that mask, and exports it as `DHCP_PREFIX`. Default (no `DHCP_RANGE`) path still yields `/24`.
- `lib/interface.sh`: `setup_interface()` uses `${AP_ADDR}/${DHCP_PREFIX:-24}`.
- `lib/nat.sh`: MASQUERADE rules use `${SUBNET}/${DHCP_PREFIX:-24}`.
- `wlanstart.sh`: computes the DHCP range early (before interface/NAT setup) so `DHCP_PREFIX` is available.
- Docs: README env var table (`DHCP_RANGE` row) and new "Subnet Mask" section in `docs/networking.md`.

## Behavior

- Default `/24` behavior unchanged when `DHCP_RANGE` is unset.
- Any contiguous mask (e.g. `/28`) is accepted with an explicit `DHCP_RANGE`; `SUBNET` must be its network address (host bits zero).
- Non-contiguous masks and SUBNETs with host bits set are rejected with explicit errors.

## Testing

- New `tests/interface_prefix.bats`: stubbed `ip` verifying `/24` default and `/28` propagation.
- Extended `tests/validation.bats`: `netmask_to_prefix` conversions/rejections, `is_network_address` accept/reject.
- Extended `tests/dhcp_range.bats`: `DHCP_PREFIX` derivation for /28, /16, /24; network-address matching for /28 mask.
- Extended `tests/nat.bats`: `/28` MASQUERADE rule emission.
- `bats tests/`: 255 tests, all green. `shellcheck` clean.
