### PR TITLE
feat(clients): add deauth subcommand

### DIFF
--- a/clients.sh
+++ b/clients.sh
@@ -1,8 +1,14 @@
 #!/bin/bash
 
-# List stations currently associated with the AP via hostapd_cli.
+# Client management via hostapd_cli.
+#   clients.sh              list all associated stations (all_sta)
+#   clients.sh deauth <mac> deauthenticate a station
 # Requires CTRL_INTERFACE=1 so hostapd.conf exposes ctrl_interface.
 set -euo pipefail
+
+usage() {
+    echo "Usage: clients.sh [deauth <mac>]" >&2
+}
 
 if [[ -z "${INTERFACE:-}" ]] ; then
     echo "[Error] INTERFACE must be set." >&2
@@ -17,4 +23,26 @@ if [[ ! -d "${CTRL_IFACE_DIR}" ]] ; then
     exit 1
 fi
 
-exec hostapd_cli -p "${CTRL_IFACE_DIR}" -i "${INTERFACE}" all_sta
+CMD="${1:-}"
+
+case "${CMD}" in
+    "")
+        exec hostapd_cli -p "${CTRL_IFACE_DIR}" -i "${INTERFACE}" all_sta
+        ;;
+    deauth)
+        if [[ $# -ne 2 ]] ; then
+            usage
+            exit 1
+        fi
+        MAC="${2}"
+        if [[ ! "${MAC}" =~ ^([0-9a-fA-F]{2}:){5}[0-9a-fA-F]{2}$ ]] ; then
+            echo "[Error] Invalid MAC address '${MAC}' (expected aa:bb:cc:dd:ee:ff)." >&2
+            exit 1
+        fi
+        exec hostapd_cli -p "${CTRL_IFACE_DIR}" -i "${INTERFACE}" deauthenticate "${MAC}"
+        ;;
+    *)
+        usage
+        exit 1
+        ;;
+esac

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,6 +18,14 @@ docker exec rpi-hostap clients.sh
 
 Output includes MAC address, signal, connected time and tx/rx rates per station (as reported by `hostapd_cli all_sta`). The control interface directory can be overridden with `CTRL_IFACE_DIR` (default `/var/run/hostapd`).
 
+To deauthenticate a specific station, pass its MAC address as a `deauth` subcommand:
+
+```bash
+docker exec rpi-hostap clients.sh deauth aa:bb:cc:dd:ee:ff
+```
+
+The MAC must be in `aa:bb:cc:dd:ee:ff` format (case-insensitive); invalid addresses are rejected with an error.
+
 See also: the [deep healthcheck](healthcheck.md#deep-healthcheck-optional) uses the same control interface - enabling either option is sufficient for both. Client inspection is also useful to verify that [MAC address filtering](configuration.md#mac-address-filtering-optional) works as expected.
 
 ---

--- a/tests/clients.bats
+++ b/tests/clients.bats
@@ -43,3 +43,49 @@ EOF
     [ "$status" -eq 1 ]
     [[ "$output" == *"INTERFACE must be set"* ]]
 }
+
+@test "deauth with valid MAC execs hostapd_cli deauthenticate" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    run "${BATS_TEST_DIRNAME}/../clients.sh" deauth aa:bb:cc:dd:ee:ff
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"stub hostapd_cli: -p ${CTRL_IFACE_DIR} -i wlan0 deauthenticate aa:bb:cc:dd:ee:ff"* ]]
+}
+
+@test "deauth accepts uppercase MAC" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    run "${BATS_TEST_DIRNAME}/../clients.sh" deauth AA:BB:CC:DD:EE:FF
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"deauthenticate AA:BB:CC:DD:EE:FF"* ]]
+}
+
+@test "deauth with invalid MAC is rejected" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    run "${BATS_TEST_DIRNAME}/../clients.sh" deauth not-a-mac
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"[Error] Invalid MAC address 'not-a-mac'"* ]]
+    [[ "$output" != *"stub hostapd_cli"* ]]
+}
+
+@test "deauth without MAC argument prints usage and exits non-zero" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    run "${BATS_TEST_DIRNAME}/../clients.sh" deauth
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Usage: clients.sh"* ]]
+}
+
+@test "unknown subcommand prints usage and exits non-zero" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    run "${BATS_TEST_DIRNAME}/../clients.sh" bogus
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Usage: clients.sh"* ]]
+}


### PR DESCRIPTION
## Summary

- Add `deauth <mac>` subcommand to `clients.sh`: validates the MAC format (case-insensitive `aa:bb:cc:dd:ee:ff`) and invokes `hostapd_cli deauthenticate <mac>`.
- No subcommand keeps the existing behavior (`hostapd_cli all_sta`); unknown subcommands and missing MAC argument print usage and exit non-zero.
- Shares the existing control-interface pre-check/error UX (missing socket dir message unchanged).
- Update docs/operations.md Client Inspection section with deauth usage.

Closes #166

## Test plan

- 6 new bats tests in tests/clients.bats: valid MAC exec, uppercase MAC accepted, invalid MAC rejected with clear error and no hostapd_cli invocation, missing MAC arg usage error, unknown subcommand usage error.
- Full suite green (260 tests).
