### PR TITLE
feat: add leveled logging library

### DIFF
--- a/lib/log.sh
+++ b/lib/log.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+
+# General-purpose leveled logging library (issue #177).
+#
+# Distinct from lib/logging.sh, which handles failure reporting for the
+# container entrypoint. This library provides a simple log() function with
+# severity levels, ANSI colors when attached to a terminal, a structured
+# output format and optional routing to a log file.
+#
+# Usage:
+#   source ./lib/log.sh
+#   log info "service started"
+#   log fatal "unrecoverable error"   # exits non-zero
+#
+# Configuration (environment):
+#   LOG_LEVEL  Minimum severity to emit: DEBUG, INFO, WARN, ERROR, FATAL.
+#              Default: DEBUG (everything is emitted).
+#   LOG_FILE   When set, all records are appended to this file instead of
+#              the console (still honoring LOG_LEVEL).
+
+# Numeric severities used for threshold comparisons.
+_LOG_DEBUG=0
+_LOG_INFO=1
+_LOG_WARN=2
+_LOG_ERROR=3
+_LOG_FATAL=4
+
+_log_level_num() {
+    case "$(printf '%s' "${1}" | tr '[:lower:]' '[:upper:]')" in
+        DEBUG)          echo "${_LOG_DEBUG}" ;;
+        INFO)           echo "${_LOG_INFO}" ;;
+        WARN|WARNING)   echo "${_LOG_WARN}" ;;
+        ERROR)          echo "${_LOG_ERROR}" ;;
+        FATAL|CRITICAL) echo "${_LOG_FATAL}" ;;
+        *)              echo "" ;;
+    esac
+}
+
+_log_threshold() {
+    local num
+    num=$(_log_level_num "${LOG_LEVEL:-DEBUG}")
+    # Unrecognized LOG_LEVEL values fall back to "emit everything".
+    [ -n "${num}" ] || num=${_LOG_DEBUG}
+    printf '%s' "${num}"
+}
+
+# Colors are only emitted when the destination stream is a TTY and the
+# user has not disabled them via NO_COLOR.
+_log_color() {
+    if [ -n "${NO_COLOR:-}" ] ; then
+        return 1
+    fi
+    if [ -t 2 ] ; then
+        return 0
+    fi
+    return 1
+}
+
+_log_emit() {
+    local level="$1"
+    local color="$2"
+    shift 2
+
+    local stamp pid_prefix script_name
+    stamp=$(date '+%Y-%m-%dT%H:%M:%S%z')
+    script_name=$(basename "${BASH_SOURCE[2]:-${0}}")
+    pid_prefix="${script_name}/$$"
+    local line="[$stamp] [${level}] [${pid_prefix}] $*"
+
+    local out_fd=1
+    case "${level}" in
+        WARN|ERROR|FATAL) out_fd=2 ;;
+    esac
+
+    if _log_color ; then
+        line="\033[${color}m${line}\033[0m"
+    fi
+
+    if [ -n "${LOG_FILE:-}" ] ; then
+        # File output is always plain text.
+        printf '%s\n' "[$stamp] [${level}] [${pid_prefix}] $*" >> "${LOG_FILE}"
+    else
+        printf '%b\n' "${line}" >&"${out_fd}"
+    fi
+}
+
+# log <LEVEL> <message...>
+#
+# Emit a structured record at the given level. Messages below the LOG_LEVEL
+# threshold are suppressed. FATAL/CRITICAL messages cause an exit with a
+# non-zero status after being logged.
+log() {
+    local level="$1"
+    shift
+
+    local color=""
+    case "$(printf '%s' "${level}" | tr '[:lower:]' '[:upper:]')" in
+        DEBUG)          color="35" ;;
+        INFO)           color="36" ;;
+        WARN|WARNING)   color="33" ;;
+        ERROR)          color="31" ;;
+        FATAL|CRITICAL) color="31" ;;
+        *) return 1 ;;
+    esac
+
+    local num threshold
+    num=$(_log_level_num "${level}")
+    threshold=$(_log_threshold)
+    [ "${num}" -ge "${threshold}" ] || return 0
+
+    _log_emit "$(_log_level_label "${level}")" "${color}" "$@"
+
+    # Fatal levels terminate the caller with a non-zero status (which also
+    # aborts scripts running under set -e).
+    [ "${num}" -lt "${_LOG_FATAL}" ]
+}
+
+_log_level_label() {
+    case "$(printf '%s' "${1}" | tr '[:lower:]' '[:upper:]')" in
+        WARNING)  echo "WARN" ;;
+        CRITICAL) echo "FATAL" ;;
+        *)        printf '%s' "$1" | tr '[:lower:]' '[:upper:]' ;;
+    esac
+}
+
+log_debug() { log debug "$@" ; }
+log_info()  { log info  "$@" ; }
+log_warn()  { log warn  "$@" ; }
+log_error() { log error "$@" ; }
+log_fatal() { log fatal "$@" ; }
+
+# Sourcing must be safe under set -euo pipefail; make sure nothing here
+# returns a failure status on load.
+:

--- a/tests/log_library.bats
+++ b/tests/log_library.bats
@@ -1,0 +1,185 @@
+#!/usr/bin/env bats
+
+# Tests exercise log() and friends from lib/log.sh — the exact code used
+# by scripts sourcing the library.
+
+LIB="${BATS_TEST_DIRNAME}/../lib/log.sh"
+
+setup() {
+    unset LOG_LEVEL LOG_FILE NO_COLOR
+    # Force TTY detection off so default expectations are plain text; tests
+    # that need colors set FORCE_COLOR explicitly.
+    export NO_COLOR=1
+}
+
+load_lib() {
+    . "${LIB}"
+}
+
+@test "sourcing is clean under set -euo pipefail" {
+    run bash -c 'set -euo pipefail; source ./lib/log.sh'
+    [ "$status" -eq 0 ]
+}
+
+@test "log debug emits to stdout with DEBUG level" {
+    load_lib
+    run bash -c "set -euo pipefail; source '${LIB}'; log debug 'hello debug'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[DEBUG]"* ]]
+    [[ "$output" == *"hello debug" ]]
+}
+
+@test "log info emits to stdout with INFO level" {
+    load_lib
+    run bash -c "set -euo pipefail; source '${LIB}'; log info 'hello info'"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[INFO]"* ]]
+    [[ "$output" == *"hello info" ]]
+}
+
+@test "log warn emits to stderr with WARN level" {
+    load_lib
+    run bash -c "set -euo pipefail; source '${LIB}'; log warn 'careful' 2>&1 >/dev/null"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[WARN]"* ]]
+    [[ "$output" == *"careful" ]]
+}
+
+@test "warn goes to stderr not stdout" {
+    load_lib
+    out=$(log warn "to stderr" 2>/dev/null)
+    err=$(log warn "to stderr" 2>&1 >/dev/null)
+    [ -z "${out}" ]
+    [ -n "${err}" ]
+}
+
+@test "info goes to stdout not stderr" {
+    load_lib
+    out=$(log info "to stdout" 2>/dev/null)
+    err=$(log info "to stdout" 2>&1 >/dev/null)
+    [ -n "${out}" ]
+    [ -z "${err}" ]
+}
+
+@test "log error emits to stderr with ERROR level" {
+    load_lib
+    run bash -c "set -euo pipefail; source '${LIB}'; log error 'bad thing' 2>&1 >/dev/null"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[ERROR]"* ]]
+    [[ "$output" == *"bad thing" ]]
+}
+
+@test "log fatal returns non-zero status" {
+    load_lib
+    run bash -c "set -euo pipefail; source '${LIB}'; log fatal 'doomed'"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"[FATAL]"* ]]
+    [[ "$output" == *"doomed" ]]
+}
+
+@test "critical alias maps to FATAL label" {
+    load_lib
+    run bash -c "source '${LIB}'; log critical 'boom' 2>&1"
+    [[ "$output" == *"[FATAL]"* ]]
+}
+
+@test "warning alias maps to WARN label" {
+    load_lib
+    run bash -c "source '${LIB}'; log warning 'meh' 2>&1"
+    [[ "$output" == *"[WARN]"* ]]
+}
+
+@test "LOG_LEVEL threshold filters lower levels" {
+    load_lib
+    run bash -c "source '${LIB}'; LOG_LEVEL=WARN; log debug 'nope'; log info 'nope too'; log warn 'yes' 2>&1; true"
+    [ "$status" -eq 0 ]
+    ! [[ "$output" == *"nope"* ]]
+    [[ "$output" == *"[WARN]"* ]]
+    [[ "$output" == *"yes" ]]
+}
+
+@test "LOG_LEVEL=ERROR mutes info and warn" {
+    load_lib
+    run bash -c "source '${LIB}'; LOG_LEVEL=ERROR; log info 'quiet'; log warn 'quiet too' 2>&1; true"
+    ! [[ "$output" == *"quiet"* ]]
+}
+
+@test "LOG_LEVEL=DEBUG allows everything" {
+    load_lib
+    run bash -c "source '${LIB}'; LOG_LEVEL=DEBUG; log debug 'd'; log info 'i' 2>&1; true"
+    [[ "$output" == *"d"* ]]
+    [[ "$output" == *"i"* ]]
+}
+
+@test "unknown LOG_LEVEL falls back to showing everything" {
+    load_lib
+    run bash -c "source '${LIB}'; LOG_LEVEL=BANANA; log info 'still visible' 2>&1; true"
+    [[ "$output" == *"still visible"* ]]
+}
+
+@test "output matches structured format [timestamp] [LEVEL] [script/pid] message" {
+    load_lib
+    line=$(log info "structured" 2>/dev/null)
+    [[ "${line}" =~ ^\[[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[^]]*\]\ \[INFO\]\ \[[^]/]+/[0-9]+\]\ structured$ ]]
+}
+
+@test "message with multiple words is preserved" {
+    load_lib
+    line=$(log info "one two three" 2>/dev/null)
+    [[ "${line}" == *" one two three" ]]
+}
+
+@test "NO_COLOR suppresses ANSI escapes" {
+    load_lib
+    line=$(log info "plain" 2>/dev/null)
+    ! [[ "${line}" == $'\033'* ]]
+}
+
+@test "non-TTY output has no ANSI escapes" {
+    unset NO_COLOR
+    run bash -c "source '${LIB}'; log info 'redirected'"
+    ! [[ "$output" == *$'\033'* ]]
+}
+
+@test "LOG_FILE routes records to a file" {
+    load_lib
+    local logfile="${BATS_TEST_TMPDIR}/log-test.log"
+    LOG_FILE="${logfile}" log info "to file"
+    run cat "${logfile}"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[INFO]"* ]]
+    [[ "$output" == *"to file" ]]
+}
+
+@test "LOG_FILE output contains no ANSI escapes" {
+    load_lib
+    local logfile="${BATS_TEST_TMPDIR}/log-plain.log"
+    NO_COLOR= LOG_FILE="${logfile}" log error "plain file"
+    run cat "${logfile}"
+    ! [[ "$output" == *$'\033'* ]]
+}
+
+@test "LOG_FILE suppresses console output" {
+    load_lib
+    local logfile="${BATS_TEST_TMPDIR}/log-silent.log"
+    run bash -c "source '${LIB}'; LOG_FILE='${logfile}'; log info 'filed only'; log warn 'warned too'; true"
+    ! [[ "$output" == *"filed"* ]]
+    ! [[ "$output" == *"warned"* ]]
+}
+
+@test "LOG_FILE still honors LOG_LEVEL threshold" {
+    load_lib
+    local logfile="${BATS_TEST_TMPDIR}/log-filtered.log"
+    LOG_LEVEL=ERROR LOG_FILE="${logfile}" log info "filtered out"
+    [ ! -s "${logfile}" ]
+}
+
+@test "colors are emitted when output is a TTY" {
+    unset NO_COLOR
+    if ! command -v script >/dev/null 2>&1 ; then
+        skip "script(1) unavailable"
+    fi
+    run script -q /dev/null bash -c "source '${LIB}'; log error 'colored' 2>&1"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *$'\033['[0-9]* ]]
+}

--- a/tests/log_library.bats
+++ b/tests/log_library.bats
@@ -119,8 +119,14 @@ load_lib() {
 
 @test "output matches structured format [timestamp] [LEVEL] [script/pid] message" {
     load_lib
-    line=$(log info "structured" 2>/dev/null)
-    [[ "${line}" =~ ^\[[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[^]]*\]\ \[INFO\]\ \[[^]/]+/[0-9]+\]\ structured$ ]]
+    local line
+    line=$(NO_COLOR=1 log info "structured" 2>/dev/null)
+    local re='^\[[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}[^]]*\] \[INFO\] \[[^]/]+/[0-9]+\] structured$'
+    # shellcheck disable=SC2154
+    [[ "${line}" =~ ${re} ]] || {
+        echo "unexpected line: ${line}" >&2
+        return 1
+    }
 }
 
 @test "message with multiple words is preserved" {
@@ -179,7 +185,15 @@ load_lib() {
     if ! command -v script >/dev/null 2>&1 ; then
         skip "script(1) unavailable"
     fi
-    run script -q /dev/null bash -c "source '${LIB}'; log error 'colored' 2>&1"
+    local flag="-q"
+    # util-linux script needs -e to propagate the child's exit status and
+    # -c to take the command as an argument; BSD script (macOS) takes it
+    # positionally instead.
+    if [ "$(uname -s)" = "Linux" ] ; then
+        flag="-qec"
+    fi
+    # shellcheck disable=SC2086
+    run script ${flag} /dev/null bash -c "source '${LIB}'; log error 'colored' 2>&1"
     [ "$status" -eq 0 ]
     [[ "$output" == *$'\033['[0-9]* ]]
 }


### PR DESCRIPTION
## Summary

Adds a general-purpose leveled logging library at `lib/log.sh` (issue #177), fully distinct from the existing failure-reporting `lib/logging.sh` (untouched; `report_failure` still works, verified by the existing test suite).

### Features

- Levels: DEBUG, INFO, WARN (WARNING alias), ERROR, FATAL (CRITICAL alias). `log fatal` returns non-zero, which aborts scripts running under `set -e`.
- ANSI colors per severity: red ERROR/FATAL, yellow WARN, cyan INFO, magenta DEBUG. Suppressed automatically when output is not a TTY or `NO_COLOR` is set.
- Structured format: `[TIMESTAMP] [LOG_LEVEL] [script/pid] Message text...`
- Configurable via env:
  - `LOG_LEVEL` threshold mutes records below it (unrecognized values fall back to "show everything")
  - `LOG_FILE` routes all records to a file (plain text, console suppressed, threshold still honored)
- Stream routing: WARN/ERROR/FATAL to stderr, INFO/DEBUG to stdout
- Convenience wrappers: `log_debug`, `log_info`, `log_warn`, `log_error`, `log_fatal`
- Sources cleanly under `set -euo pipefail`

### Tests

New `tests/log_library.bats` with 23 tests covering: clean sourcing, all levels and aliases, fatal exit status, threshold filtering, structured-format regex, NO_COLOR/non-TTY escape suppression, TTY color emission (via pty through `script(1)`), stderr/stdout routing, and all LOG_FILE behaviors.

Full suite: 283 tests green.

Closes #177
