### PR TITLE
feat(logging): retention/rotation for preserved failure logs

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -24,6 +24,24 @@ To test your configuration without touching the system, use [dry-run validation 
 
 If the container runs but is reported as `unhealthy`, see [Health Check](healthcheck.md).
 
+## Preserved failure logs
+
+When the container exits because a daemon failed to start, the full tagged
+daemon output is preserved so you can inspect it after exit. Each crash
+writes a timestamped copy to `FAILURE_LOG_DIR` (default `/var/log/hostap-failures/`),
+e.g. `/var/log/hostap-failures/hostap-failure-1756100000.log`, and only the
+newest `FAILURE_LOG_KEEP` copies (default 5) are retained - older ones are
+pruned automatically. The final error message names the exact file that was
+saved.
+
+Tune via environment variables:
+
+| Variable           | Default                     | Purpose                                  |
+|--------------------|-----------------------------|------------------------------------------|
+| `FAILURE_LOG_DIR`  | `/var/log/hostap-failures`  | Directory for timestamped failure logs   |
+| `FAILURE_LOG_KEEP` | `5`                         | Number of failure logs to retain         |
+| `FAILURE_LOG_PATH` | unset                       | Legacy fixed path (no rotation) if set   |
+
 ## IPv6: no connectivity or only link-local addresses
 
 If clients get no global IPv6 address, check that:

--- a/lib/logging.sh
+++ b/lib/logging.sh
@@ -7,15 +7,60 @@
 # "[name]" tag, the last tag seen in the captured output points at the
 # daemon that most likely failed to start.
 
-# Destination for the preserved daemon log when the container exits with
-# a failure (issue #162). Overridable for testing.
-FAILURE_LOG_PATH="${FAILURE_LOG_PATH:-/var/log/hostap-failure.log}"
+# Destination for preserved daemon logs when the container exits with a
+# failure (issue #162). Each crash writes a timestamped copy under
+# FAILURE_LOG_DIR (issue #199); only the newest FAILURE_LOG_KEEP copies are
+# retained. An explicit FAILURE_LOG_PATH is still honored verbatim for
+# backwards compatibility. All three are overridable for testing.
+FAILURE_LOG_PATH="${FAILURE_LOG_PATH:-}"
+FAILURE_LOG_DIR="${FAILURE_LOG_DIR:-/var/log/hostap-failures}"
+FAILURE_LOG_KEEP="${FAILURE_LOG_KEEP:-5}"
+
+# _failure_log_target
+#
+# Print the path the daemon log should be preserved at. When an explicit
+# FAILURE_LOG_PATH is set it is used as-is; otherwise a timestamped file
+# inside FAILURE_LOG_DIR is chosen (with a numeric suffix if two crashes
+# land in the same second).
+_failure_log_target() {
+    local epoch target n=0
+    if [ -n "${FAILURE_LOG_PATH}" ] ; then
+        printf '%s' "${FAILURE_LOG_PATH}"
+        return 0
+    fi
+    if ! mkdir -p "${FAILURE_LOG_DIR}" 2>/dev/null ; then
+        return 1
+    fi
+    epoch="$(date +%s)"
+    target="${FAILURE_LOG_DIR}/hostap-failure-${epoch}.log"
+    while [ -e "${target}" ] ; do
+        n=$((n + 1))
+        target="${FAILURE_LOG_DIR}/hostap-failure-${epoch}-${n}.log"
+    done
+    printf '%s' "${target}"
+}
+
+# _failure_log_prune
+#
+# Remove the oldest timestamped failure logs so at most FAILURE_LOG_KEEP
+# remain. No-op when an explicit FAILURE_LOG_PATH is set.
+_failure_log_prune() {
+    local old
+    if [ -n "${FAILURE_LOG_PATH}" ] ; then
+        return 0
+    fi
+    command ls -1t "${FAILURE_LOG_DIR}"/hostap-failure-*.log 2>/dev/null \
+        | tail -n +"$((FAILURE_LOG_KEEP + 1))" \
+        | while read -r old ; do
+            rm -f "${old}"
+        done
+}
 
 # report_failure <exit-status> [tagged-output-log]
 #
 # Print a final error pointing at the likely failing daemon based on the
 # last tagged line of captured daemon output. When a non-empty log is
-# given, it is preserved at FAILURE_LOG_PATH so operators can inspect the
+# given, it is preserved under FAILURE_LOG_DIR so operators can inspect the
 # full tagged output after exit.
 report_failure() {
     local status="$1"
@@ -44,18 +89,19 @@ report_failure() {
         # Copy, then verify the copy matches the source size so a late
         # background-tee write that raced the copy is retried once. If the
         # destination is unwritable (bad dir, permissions), warn and carry on.
-        local _try copied=1
+        local _try copied=1 dest
         for _try in 1 2 ; do
-            if ! cp "${log}" "${FAILURE_LOG_PATH}" 2>/dev/null ; then
-                echo "Warning: could not save daemon log to ${FAILURE_LOG_PATH}." >&2
+            if ! dest=$(_failure_log_target) || ! cp "${log}" "${dest}" 2>/dev/null ; then
+                echo "Warning: could not save daemon log to ${dest:-${FAILURE_LOG_DIR}}." >&2
                 copied=0
                 break
             fi
             [ "$(wc -c < "${log}" 2>/dev/null || echo 0)" = \
-              "$(wc -c < "${FAILURE_LOG_PATH}" 2>/dev/null || echo 0)" ] && break
+              "$(wc -c < "${dest}" 2>/dev/null || echo 0)" ] && break
             sleep 0.1
         done
-        [ "${copied}" = "1" ] && saved=" Full daemon log saved to ${FAILURE_LOG_PATH}."
+        _failure_log_prune
+        [ "${copied}" = "1" ] && saved=" Full daemon log saved to ${dest}."
     fi
 
     echo "[Error] Container exiting (status ${status}): check ${tag} lines above for startup failure.${saved}" >&2

--- a/tests/failure_report.bats
+++ b/tests/failure_report.bats
@@ -79,6 +79,61 @@ load_logging() {
     [[ "$output" != *"Full daemon log saved"* ]]
 }
 
+@test "successive failures create distinct timestamped files (#199)" {
+    load_logging
+    local dir log
+    dir=$(mktemp -d)
+    log=$(mktemp)
+    printf '[hostapd] driver missing\n' > "${log}"
+    FAILURE_LOG_PATH="" FAILURE_LOG_DIR="${dir}" run report_failure 1 "${log}"
+    [ "$status" -eq 0 ]
+    sleep 1
+    FAILURE_LOG_PATH="" FAILURE_LOG_DIR="${dir}" run report_failure 2 "${log}"
+    rm -f "${log}"
+    local count
+    count=$(find "${dir}" -name 'hostap-failure-*.log' | wc -l | tr -d ' ')
+    [ "${count}" -eq 2 ]
+    [[ "$output" == *"Full daemon log saved to ${dir}/hostap-failure-"* ]]
+}
+
+@test "pruning keeps only FAILURE_LOG_KEEP newest copies (#199)" {
+    load_logging
+    local dir log f t
+    dir=$(mktemp -d)
+    t=202401010001
+    for f in 1000 1500 2000 2500 3000 3500 ; do
+        printf '[hostapd] old %s\n' "${f}" > "${dir}/hostap-failure-${f}.log"
+        touch -t "${t}" "${dir}/hostap-failure-${f}.log"
+        t=$((t + 1))
+    done
+    log=$(mktemp)
+    printf '[hostapd] fresh\n' > "${log}"
+    FAILURE_LOG_PATH="" FAILURE_LOG_DIR="${dir}" FAILURE_LOG_KEEP=3 \
+        run report_failure 1 "${log}"
+    rm -f "${log}"
+    [ "$status" -eq 0 ]
+    local count
+    count=$(find "${dir}" -name 'hostap-failure-*.log' | wc -l | tr -d ' ')
+    [ "${count}" -eq 3 ]
+    [ ! -e "${dir}/hostap-failure-1000.log" ]
+    [ ! -e "${dir}/hostap-failure-1500.log" ]
+    [ -e "${dir}/hostap-failure-3500.log" ]
+    find "${dir}" -name 'hostap-failure-*.log' -newer "${dir}/hostap-failure-3500.log" -delete
+}
+
+@test "explicit FAILURE_LOG_PATH is still honored verbatim (#199)" {
+    load_logging
+    local log dest
+    log=$(mktemp)
+    dest="$(mktemp -d)/fixed-name.log"
+    printf '[hostapd] driver missing\n' > "${log}"
+    FAILURE_LOG_PATH="${dest}" FAILURE_LOG_KEEP=5 run report_failure 1 "${log}"
+    rm -f "${log}"
+    [ -f "${dest}" ]
+    grep -q '\[hostapd\] driver missing' "${dest}"
+    rm -rf "$(dirname "${dest}")"
+}
+
 @test "wlanstart reports failing daemon on non-signal exit" {
     grep -q 'report_failure "${STATUS}"' "${SCRIPT}"
 }

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -360,7 +360,7 @@ if [ "${_SIGNALED}" = "1" ] ; then
 fi
 if [ "${STATUS}" -ne 0 ] ; then
     # Preserve the full tagged daemon log for post-mortem (issue #162);
-    # report_failure copies it to FAILURE_LOG_PATH and mentions the path.
+    # report_failure preserves a timestamped copy and mentions the path.
     # The temp log is only removed on clean shutdown / signal exit.
     report_failure "${STATUS}" "${_DAEMON_LOG}"
 else


### PR DESCRIPTION
## Summary

Failure logs preserved on crash were previously overwritten at a fixed path
(`/var/log/hostap-failure.log`). This change adds retention/rotation:

- Each failure now writes a timestamped copy to
  `${FAILURE_LOG_DIR}/hostap-failure-<epoch>.log` (default dir
  `/var/log/hostap-failures/`, suffix `-1`, `-2`... if two crashes land in the
  same second).
- Oldest copies are pruned so at most `FAILURE_LOG_KEEP=${FAILURE_LOG_KEEP:-5}`
  remain.
- `report_failure` still prints the exact path of the newest saved log.
- Backwards compatibility: an explicit `FAILURE_LOG_PATH` is honored verbatim
  (no rotation), as before (#162).

Also updates the comment in `wlanstart.sh` and documents the new variables in
`docs/troubleshooting.md`.

## Changes

- `lib/logging.sh`: new `FAILURE_LOG_DIR` / `FAILURE_LOG_KEEP` variables,
  `_failure_log_target()` and `_failure_log_prune()` helpers; `report_failure`
  writes to the timestamped target and prunes after saving.
- `tests/failure_report.bats`: three new tests (distinct files per crash,
  pruning respects keep count, explicit path still works).
- `docs/troubleshooting.md`: new "Preserved failure logs" section with env var table.

## Acceptance criteria

- [x] Successive crashes produce timestamped files, not overwrites
- [x] Retention capped by `FAILURE_LOG_KEEP`
- [x] Explicit `FAILURE_LOG_PATH` still works
- [x] Bats tests added in `failure_report.bats`; docs updated

## Testing

- `bats tests/failure_report.bats`: 17/17 pass (14 existing + 3 new)
- Full suite: `bats tests/`: 286/286 pass
- `shellcheck lib/logging.sh`: clean

Closes #199
