### PR TITLE
feat(clients): add --json machine-readable station output

### DIFF
--- a/clients.sh
+++ b/clients.sh
@@ -2,12 +2,52 @@
 
 # Client management via hostapd_cli.
 #   clients.sh              list all associated stations (all_sta)
+#   clients.sh --json       list stations as a JSON array
 #   clients.sh deauth <mac> deauthenticate a station
 # Requires CTRL_INTERFACE=1 so hostapd.conf exposes ctrl_interface.
 set -euo pipefail
 
 usage() {
-    echo "Usage: clients.sh [deauth <mac>]" >&2
+    echo "Usage: clients.sh [--json] [deauth <mac>]" >&2
+}
+
+# Emit a JSON array of station objects parsed from hostapd_cli all_sta output.
+# Blocks start with the station MAC line, followed by key=value lines. Only a
+# fixed set of well-known fields (aid, signal, connected_time) are exposed as
+# strings; values are escaped conservatively.
+json_escape() {
+    local s="${1}"
+    s="${s//\\/\\\\}"
+    s="${s//\"/\\\"}"
+    printf '%s' "${s}"
+}
+
+emit_json() {
+    local line key value in_obj=0 sep=""
+    printf '['
+    while IFS= read -r line ; do
+        if [[ -z "${line}" ]] ; then
+            continue
+        fi
+        if [[ "${line}" != *=* ]] ; then
+            if [[ ${in_obj} -eq 1 ]] ; then
+                printf '}'
+            fi
+            printf '%s{"mac":"%s"' "${sep}" "$(json_escape "${line}")"
+            sep=","
+            in_obj=1
+        else
+            key="${line%%=*}"
+            value="${line#*=}"
+            case "${key}" in
+                aid|signal|connected_time)
+                    printf ',"%s":"%s"' "${key}" "$(json_escape "${value}")"
+                    ;;
+            esac
+        fi
+    done < <(hostapd_cli -p "${CTRL_IFACE_DIR}" -i "${INTERFACE}" all_sta)
+    [[ ${in_obj} -eq 1 ]] && printf '}'
+    printf ']\n'
 }
 
 if [[ -z "${INTERFACE:-}" ]] ; then
@@ -28,6 +68,9 @@ CMD="${1:-}"
 case "${CMD}" in
     "")
         exec hostapd_cli -p "${CTRL_IFACE_DIR}" -i "${INTERFACE}" all_sta
+        ;;
+    --json)
+        emit_json
         ;;
     deauth)
         if [[ $# -ne 2 ]] ; then

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -18,6 +18,18 @@ docker exec rpi-hostap clients.sh
 
 Output includes MAC address, signal, connected time and tx/rx rates per station (as reported by `hostapd_cli all_sta`). The control interface directory can be overridden with `CTRL_IFACE_DIR` (default `/var/run/hostapd`).
 
+For machine-readable output, pass `--json` to get a JSON array of station objects with `mac`, `aid`, `signal` and `connected_time` fields:
+
+```bash
+docker exec rpi-hostap clients.sh --json
+```
+
+Example output:
+
+```json
+[{"mac":"aa:bb:cc:dd:ee:ff","aid":"1","signal":"-45","connected_time":"120"}]
+```
+
 To deauthenticate a specific station, pass its MAC address as a `deauth` subcommand:
 
 ```bash

--- a/tests/clients.bats
+++ b/tests/clients.bats
@@ -89,3 +89,62 @@ EOF
     [ "$status" -ne 0 ]
     [[ "$output" == *"Usage: clients.sh"* ]]
 }
+
+@test "--json emits valid JSON array for stubbed all_sta output (issue #198)" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    cat > "${BATS_TEST_TMPDIR}/hostapd_cli" <<'EOF'
+#!/bin/bash
+cat <<'STA'
+aa:bb:cc:dd:ee:ff
+flags=0x0
+aid=1
+signal=-45
+connected_time=120
+rx_rate=54.0
+tx_rate=6.5
+
+11:22:33:44:55:66
+aid=2
+signal=-61
+connected_time=30
+STA
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/hostapd_cli"
+    run "${BATS_TEST_DIRNAME}/../clients.sh" --json
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(len(d), d[0]["mac"], d[0]["aid"], d[1]["signal"])')" = "2 aa:bb:cc:dd:ee:ff 1 -61" ]
+}
+
+@test "--json omits unknown fields and escapes quotes in MAC" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    cat > "${BATS_TEST_TMPDIR}/hostapd_cli" <<'EOF'
+#!/bin/bash
+cat <<'STA'
+we"ird:mac
+foo=bar
+connected_time=5
+STA
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/hostapd_cli"
+    run "${BATS_TEST_DIRNAME}/../clients.sh" --json
+    [ "$status" -eq 0 ]
+    [[ "$output" != *'"foo"'* ]]
+    [[ "$output" == *'"mac":"we\"ird:mac"'* ]]
+    [[ "$output" == *'"connected_time":"5"'* ]]
+}
+
+@test "--json with no stations emits empty array" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    printf '#!/bin/bash\nexit 0\n' > "${BATS_TEST_TMPDIR}/hostapd_cli"
+    chmod +x "${BATS_TEST_TMPDIR}/hostapd_cli"
+    run "${BATS_TEST_DIRNAME}/../clients.sh" --json
+    [ "$status" -eq 0 ]
+    [ "$output" = "[]" ]
+}
+


### PR DESCRIPTION
## Summary

- Add `clients.sh --json` flag that parses `hostapd_cli all_sta` output in pure bash and emits a JSON array of station objects (`mac`, `aid`, `signal`, `connected_time`)
- Default (non-flag) output is unchanged; no new package dependencies added to the Dockerfile
- Document the flag with example output in `docs/operations.md`
- Extend `tests/clients.bats` with stubbed-`hostapd_cli` tests covering valid JSON, field filtering/escaping, and empty station list

Closes #198

## Test plan

- [x] `bats tests/clients.bats` - 12/12 pass locally
- [x] `shellcheck clients.sh` clean
- [x] CI checks green
