### PR TITLE
feat(channel): support CHANNEL=acs automatic channel selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ docker run -d \
 | `INTERFACE` | Yes | Wireless interface to use | - |
 | `SSID` | No | Network name | `raspberry` |
 | `WPA_PASSPHRASE` | No | WiFi password | `passw0rd` |
-| `CHANNEL` | No | WiFi channel | `11` |
+| `CHANNEL` | No | WiFi channel, or `acs` for automatic channel selection (requires driver support; startup may be delayed while scanning, and the `HEALTHCHECK_START_PERIOD` grace period applies since ACS can land on DFS/radar channels) | `11` |
 | `AP_ADDR` | No | Access point IP | `192.168.254.1` |
 | `SUBNET` | No | Network subnet | `192.168.254.0` |
 | `OUTGOINGS` | No | Comma-separated outgoing interfaces for NAT | All interfaces |

--- a/lib/channel.sh
+++ b/lib/channel.sh
@@ -9,6 +9,15 @@ validate_channel() {
     : "${CHANNEL:=11}"
     : "${COUNTRY_CODE:=EU}"
 
+    # Automatic channel selection: skip numeric checks, driver decides.
+    case "${HW_MODE}:${CHANNEL}" in
+        *:acs|*:ACS)
+            echo "[Warning] CHANNEL=acs enables automatic channel selection; requires driver support and may delay startup" >&2
+            echo "[Warning] ACS may select a DFS/radar channel; the HEALTHCHECK_START_PERIOD grace period applies while CAC completes" >&2
+            return 0
+            ;;
+    esac
+
     case "${COUNTRY_CODE}" in
         US|CA|MX) _MAX_CHANNEL=11 ;;
         JP)       _MAX_CHANNEL=14 ;;

--- a/lib/channel.sh
+++ b/lib/channel.sh
@@ -11,7 +11,7 @@ validate_channel() {
 
     # Automatic channel selection: skip numeric checks, driver decides.
     case "${HW_MODE}:${CHANNEL}" in
-        *:acs|*:ACS)
+        *:[aA][cC][sS])
             echo "[Warning] CHANNEL=acs enables automatic channel selection; requires driver support and may delay startup" >&2
             echo "[Warning] ACS may select a DFS/radar channel; the HEALTHCHECK_START_PERIOD grace period applies while CAC completes" >&2
             return 0

--- a/tests/channel_validation.bats
+++ b/tests/channel_validation.bats
@@ -129,6 +129,42 @@ setup() {
     [[ "$output" == *"Error"*"not allowed for hw_mode=a"* ]]
 }
 
+# --- ACS (automatic channel selection) ---
+
+@test "CHANNEL=acs passes with hw_mode=g and warns" {
+    HW_MODE="g"
+    CHANNEL="acs"
+    run validate_channel
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Warning"*"acs"* ]]
+}
+
+@test "CHANNEL=acs passes with hw_mode=a and warns" {
+    HW_MODE="a"
+    CHANNEL="acs"
+    run validate_channel
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Warning"*"HEALTHCHECK_START_PERIOD"* ]]
+}
+
+@test "CHANNEL=ACS (uppercase, case-insensitive) passes with any HW_MODE" {
+    for hw in b g a; do
+        HW_MODE="${hw}"
+        CHANNEL="ACS"
+        run validate_channel
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"Warning"*"acs"* ]]
+    done
+}
+
+@test "CHANNEL=acs passes strict validation" {
+    HW_MODE="g"
+    CHANNEL="acs"
+    run validate_channel_strict
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Warning"*"acs"* ]]
+}
+
 # --- non-numeric channel ---
 
 @test "non-numeric channel with hw_mode=g fails" {

--- a/tests/channel_validation.bats
+++ b/tests/channel_validation.bats
@@ -165,6 +165,31 @@ setup() {
     [[ "$output" == *"Warning"*"acs"* ]]
 }
 
+@test "CHANNEL=Acs and CHANNEL=aCS (mixed case) pass validation" {
+    for value in Acs aCS AcS; do
+        HW_MODE="g"
+        CHANNEL="${value}"
+        run validate_channel
+        [ "$status" -eq 0 ]
+        [[ "$output" == *"Warning"*"acs"* ]]
+    done
+}
+
+@test "emit_hostapd_conf emits channel=acs unchanged" {
+    export INTERFACE=wlan0 SSID=test WPA_PASSPHRASE=passw0rd
+    export HW_MODE=g CHANNEL=acs COUNTRY_CODE=EU WPA_VERSION=2
+    eval "$(sed -n '/^emit_hostapd_conf()/,/^}/p' "${BATS_TEST_DIRNAME}/../wlanstart.sh")"
+    . "${BATS_TEST_DIRNAME}/../lib/stations.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/ctrl_interface.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/wpa.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/ssid_hidden.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/mac_filter.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/ap_isolation.sh"
+    run emit_hostapd_conf
+    [ "$status" -eq 0 ]
+    grep -qx 'channel=acs' <<< "$output"
+}
+
 # --- non-numeric channel ---
 
 @test "non-numeric channel with hw_mode=g fails" {


### PR DESCRIPTION
## Summary

Adds support for `CHANNEL=acs` to enable hostapd automatic channel selection.

- `lib/channel.sh`: `validate_channel` (and the strict variant) now accepts `acs`/`ACS` (case-insensitive) for any `HW_MODE`, skipping numeric channel checks and emitting warnings that ACS requires driver support, may delay startup, and that the DFS/CAC grace period (`HEALTHCHECK_START_PERIOD`) applies since ACS can land on radar channels.
- `wlanstart.sh`: no change needed - `emit_hostapd_conf` already emits `channel=${CHANNEL}` unchanged, so `channel=acs` is written to hostapd.conf as-is.
- `README.md`: updated the `CHANNEL` env table row documenting `acs`.
- `tests/channel_validation.bats`: 5 new tests covering acs with each hw_mode, case-insensitivity, strict mode, and unchanged numeric behavior.

Closes #197

## Testing

- All bats tests pass locally: 293 ok / 0 failed (35 in channel_validation.bats).
- shellcheck: only pre-existing info-level SC1091 "Not following" notes; no new findings.
