### PR TITLE
feat(hostapd): HOSTAPD_EXTRA_OPTS passthrough for extra config lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ docker run -d \
 | `HT_CAPAB` | No | 802.11n capabilities string (`ht_capab=` in hostapd.conf); requires `HT_ENABLED` | unset |
 | `VHT_ENABLED` | No | Enable 802.11ac Very High Throughput (`ieee80211ac=1`); requires 5 GHz (`HW_MODE=a`) | unset |
 | `VHT_CAPAB` | No | 802.11ac capabilities string (`vht_capab=` in hostapd.conf); requires `VHT_ENABLED` | unset |
+| `HOSTAPD_EXTRA_OPTS` | No | Extra hostapd.conf lines, newline-separated, appended verbatim after all generated lines. Unvalidated: invalid values surface as hostapd config errors in logs (e.g. `"auth_algs=3\nbeacon_int=100"`) | unset |
 | `HEALTHCHECK_START_PERIOD` | No | Grace period (seconds) after container start during which the healthcheck always passes. Measured from the container's own recorded start time (`/run/hostap-started`), not host uptime; see [Health Check](docs/healthcheck.md) | `15` |
 | `CTRL_INTERFACE` | No | Enable hostapd control interface (any non-empty value); allows `clients.sh` to list stations, see [Client Inspection](docs/operations.md#client-inspection-optional) | unset |
 | `CTRL_IFACE_DIR` | No | Control interface socket directory used by `clients.sh` | `/var/run/hostapd` |

--- a/lib/extra_opts.sh
+++ b/lib/extra_opts.sh
@@ -1,0 +1,17 @@
+# shellcheck shell=bash
+# Shared extra hostapd.conf options logic used by wlanstart.sh and tests.
+#
+# compute_extra_opts_lines reads HOSTAPD_EXTRA_OPTS from the environment
+# (newline-separated) and prints each non-empty line, one per output
+# line. Lines are appended verbatim to the end of the generated
+# hostapd.conf; invalid values surface as hostapd config errors in logs.
+compute_extra_opts_lines() {
+    [ -n "${HOSTAPD_EXTRA_OPTS:-}" ] || return 0
+    local line
+    while IFS= read -r line || [ -n "${line}" ] ; do
+        [ -n "${line}" ] && printf '%s\n' "${line}"
+    done <<EOF2
+${HOSTAPD_EXTRA_OPTS}
+EOF2
+    return 0
+}

--- a/tests/channel_validation.bats
+++ b/tests/channel_validation.bats
@@ -185,6 +185,7 @@ setup() {
     . "${BATS_TEST_DIRNAME}/../lib/ssid_hidden.sh"
     . "${BATS_TEST_DIRNAME}/../lib/mac_filter.sh"
     . "${BATS_TEST_DIRNAME}/../lib/ap_isolation.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/extra_opts.sh"
     run emit_hostapd_conf
     [ "$status" -eq 0 ]
     grep -qx 'channel=acs' <<< "$output"

--- a/tests/extra_opts.bats
+++ b/tests/extra_opts.bats
@@ -1,0 +1,77 @@
+#!/usr/bin/env bats
+
+setup() {
+    . "${BATS_TEST_DIRNAME}/../lib/extra_opts.sh"
+    unset HOSTAPD_EXTRA_OPTS
+}
+
+@test "HOSTAPD_EXTRA_OPTS unset produces no output" {
+    run compute_extra_opts_lines
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "HOSTAPD_EXTRA_OPTS empty string produces no output" {
+    HOSTAPD_EXTRA_OPTS=""
+    run compute_extra_opts_lines
+    [ "$status" -eq 0 ]
+    [ "$output" = "" ]
+}
+
+@test "HOSTAPD_EXTRA_OPTS single line is passed through verbatim" {
+    HOSTAPD_EXTRA_OPTS="auth_algs=3"
+    run compute_extra_opts_lines
+    [ "$status" -eq 0 ]
+    [ "$output" = "auth_algs=3" ]
+}
+
+@test "HOSTAPD_EXTRA_OPTS multiple lines are emitted in order" {
+    HOSTAPD_EXTRA_OPTS=$'auth_algs=3\nignore_broadcast_ssid=1\nbeacon_int=100'
+    run compute_extra_opts_lines
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "auth_algs=3" ]
+    [ "${lines[1]}" = "ignore_broadcast_ssid=1" ]
+    [ "${lines[2]}" = "beacon_int=100" ]
+}
+
+@test "HOSTAPD_EXTRA_OPTS blank lines are skipped" {
+    HOSTAPD_EXTRA_OPTS=$'auth_algs=3\n\n\nbeacon_int=100\n'
+    run compute_extra_opts_lines
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -eq 2 ]
+}
+
+@test "emit_hostapd_conf appends extra opts at end of config" {
+    export INTERFACE=wlan0 SSID=test WPA_PASSPHRASE=passw0rd
+    export HW_MODE=g CHANNEL=6 WPA_VERSION=2
+    export HOSTAPD_EXTRA_OPTS=$'auth_algs=3\nbeacon_int=100'
+    eval "$(sed -n '/^emit_hostapd_conf()/,/^}/p' "${BATS_TEST_DIRNAME}/../wlanstart.sh")"
+    . "${BATS_TEST_DIRNAME}/../lib/stations.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/ctrl_interface.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/wpa.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/ssid_hidden.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/mac_filter.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/ap_isolation.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/extra_opts.sh"
+    run emit_hostapd_conf
+    [ "$status" -eq 0 ]
+    [ "${#lines[@]}" -ge 2 ]
+    [ "${lines[${#lines[@]} - 1]}" = "beacon_int=100" ]
+    [ "${lines[${#lines[@]} - 2]}" = "auth_algs=3" ]
+}
+
+@test "unset HOSTAPD_EXTRA_OPTS leaves config unchanged (no extra trailing lines)" {
+    export INTERFACE=wlan0 SSID=test WPA_PASSPHRASE=passw0rd
+    export HW_MODE=g CHANNEL=6 WPA_VERSION=2
+    eval "$(sed -n '/^emit_hostapd_conf()/,/^}/p' "${BATS_TEST_DIRNAME}/../wlanstart.sh")"
+    . "${BATS_TEST_DIRNAME}/../lib/stations.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/ctrl_interface.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/wpa.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/ssid_hidden.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/mac_filter.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/ap_isolation.sh"
+    . "${BATS_TEST_DIRNAME}/../lib/extra_opts.sh"
+    run emit_hostapd_conf
+    [ "$status" -eq 0 ]
+    ! grep -q 'auth_algs=' <<< "$output"
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -160,6 +160,10 @@ fi
 # Logic lives in lib/dhcp.sh, shared with tests
 # shellcheck source=lib/dhcp.sh
 . "$(dirname "$0")/lib/dhcp.sh"
+# Extra hostapd.conf options (HOSTAPD_EXTRA_OPTS)
+# Logic lives in lib/extra_opts.sh, shared with tests
+# shellcheck source=lib/extra_opts.sh
+. "$(dirname "$0")/lib/extra_opts.sh"
 # Atomic config file writing (temp file + mv)
 # Logic lives in lib/atomic.sh, shared with tests
 # shellcheck source=lib/atomic.sh
@@ -201,6 +205,8 @@ ${HT_CAPAB+"ht_capab=${HT_CAPAB}"}
 ${VHT_ENABLED+"ieee80211ac=1"}
 ${VHT_CAPAB+"vht_capab=${VHT_CAPAB}"}
 EOF
+
+    compute_extra_opts_lines
 }
 
 # Emit dnsmasq.conf to stdout from the current environment.


### PR DESCRIPTION
# feat(hostapd): HOSTAPD_EXTRA_OPTS passthrough for extra config lines

Closes #196

## Summary

- New `HOSTAPD_EXTRA_OPTS` env var: newline-separated hostapd.conf lines appended verbatim after all generated lines in `emit_hostapd_conf`.
- New helper `lib/extra_opts.sh` (`compute_extra_opts_lines`), following the existing lib + bats pattern; sourced from `wlanstart.sh` alongside the other libs.
- Same trust model as `HT_CAPAB`: values are unvalidated; invalid lines surface as hostapd config errors in logs.
- Unset or empty value produces byte-identical config as before (helper emits nothing).

## Tests

- New `tests/extra_opts.bats`: 7 tests covering unset/empty behavior, verbatim single-line pass-through, multi-line ordering, blank-line skipping, extra opts appearing last in `emit_hostapd_conf`, and unchanged config when unset.
- Sourced `lib/extra_opts.sh` in the existing `emit_hostapd_conf` test in `tests/channel_validation.bats`.
- Full bats suite: 302 passing, 0 failing. Shellcheck clean (only pre-existing SC1091 info warnings).

## Docs

- README environment variable table documents `HOSTAPD_EXTRA_OPTS` with newline separator and default `unset`.
