### PR TITLE
refactor(scripts): invoke get-version.sh with bash consistently

### DIFF
--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -59,7 +59,7 @@ case "${1:-}" in
         if [ -n "${WLANSTART_VERSION:-}" ] ; then
             echo "${WLANSTART_VERSION}"
         elif command -v jq >/dev/null 2>&1 && [ -f "$(dirname "$0")/scripts/get-version.sh" ] ; then
-            sh "$(dirname "$0")/scripts/get-version.sh" 2>/dev/null || echo "unknown"
+            bash "$(dirname "$0")/scripts/get-version.sh" 2>/dev/null || echo "unknown"
         else
             echo "unknown"
         fi


### PR DESCRIPTION
## Summary
- Invoke `scripts/get-version.sh` with `bash` in `wlanstart.sh` (was `sh`), matching its bash shebang and the rest of the codebase.
- Verified no other `sh` invocations of this script exist (Makefile and bats tests already call it directly via its shebang; CI only runs shellcheck on it).

Closes #195

## Test results
- Full bats suite: 302/302 pass (includes `version_flag.bats` and `version_sync.bats`)
- shellcheck: clean (only pre-existing SC1091 info notices for sourced lib files)
