### PR TITLE
chore(startup): label sysctl values in startup log

### DIFF
--- a/lib/nat.sh
+++ b/lib/nat.sh
@@ -62,6 +62,15 @@ set_sysctls() {
     done
 }
 
+# show_sysctls prints labeled values for the given ipv4 sysctls (#194).
+show_sysctls() {
+    local i val
+    for i in "$@" ; do
+        val="$(cat "${SYSCTL_BASE}/${i}" 2>/dev/null || echo '?')"
+        echo "${i}=${val}"
+    done
+}
+
 # remove_nat_rules deletes the rules added by apply_nat_rules.
 remove_nat_rules() {
     echo "Removing iptables rules..."

--- a/tests/nat.bats
+++ b/tests/nat.bats
@@ -132,6 +132,24 @@ setup() {
     [ "$(cat "${dir}/ip_forward")" = "1" ]
 }
 
+@test "show_sysctls prints labeled values" {
+    local dir="${BATS_TEST_TMPDIR}/proc"
+    mkdir -p "${dir}"
+    echo 1 > "${dir}/ip_dynaddr"
+    echo 0 > "${dir}/ip_forward"
+    SYSCTL_BASE="${dir}" run show_sysctls ip_dynaddr ip_forward
+    [ "$status" -eq 0 ]
+    [[ "${output}" == *"ip_dynaddr=1"* ]]
+    [[ "${output}" == *"ip_forward=0"* ]]
+}
+
+@test "show_sysctls prints ? for missing sysctl" {
+    local dir="${BATS_TEST_TMPDIR}/no-such-proc"
+    SYSCTL_BASE="${dir}" run show_sysctls ip_dynaddr
+    [ "$status" -eq 0 ]
+    [[ "${output}" == *"ip_dynaddr=?"* ]]
+}
+
 @test "set_sysctls warns when write fails on non-numeric value" {
     local dir="${BATS_TEST_TMPDIR}/proc"
     mkdir -p "${dir}"

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -314,13 +314,8 @@ fi
 check_interrupted
 
 # NAT settings
-echo "NAT settings ip_dynaddr, ip_forward"
-
-
 set_sysctls ip_dynaddr ip_forward
-
-cat /proc/sys/net/ipv4/ip_dynaddr 2>/dev/null
-cat /proc/sys/net/ipv4/ip_forward
+show_sysctls ip_dynaddr ip_forward
 
 apply_nat_rules
 


### PR DESCRIPTION
## Summary

Replaces the bare `cat /proc/sys/net/ipv4/ip_dynaddr` / `ip_forward` calls in `wlanstart.sh` with a new `show_sysctls` helper in `lib/nat.sh` that prints labeled values:

```
ip_dynaddr=0
ip_forward=1
```

Missing/unreadable sysctls print `?` instead of silently vanishing. No functional change - `set_sysctls` behavior is untouched.

Closes #194

## Changes

- lib/nat.sh: add `show_sysctls` (honors existing `SYSCTL_BASE` test override)
- wlanstart.sh: drop "NAT settings" header and bare cats, call `show_sysctls ip_dynaddr ip_forward`
- tests/nat.bats: add tests for labeled output and missing-sysctl fallback

## Testing

- Full bats suite: 304/304 pass (includes 2 new tests)
- shellcheck: clean apart from pre-existing SC1091 info notes
