### PR TITLE
fix(healthcheck): guard HEALTHCHECK_START_PERIOD against non-numeric values

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -5,7 +5,11 @@ set -euo pipefail
 # Checks if hostapd, dnsmasq are running and the interface is up
 
 # Configurable start period via environment variable (default: 15s)
-START_PERIOD="${HEALTHCHECK_START_PERIOD:-15}"
+START_PERIOD="${HEALTHCHECK_START_PERIOD-15}"
+if ! [[ "${START_PERIOD}" =~ ^[0-9]+$ ]]; then
+    echo "[Warning] Invalid HEALTHCHECK_START_PERIOD '${START_PERIOD}', using 15" >&2
+    START_PERIOD=15
+fi
 
 # Grace period is measured from the container's own start time, recorded
 # by wlanstart.sh at boot (/proc/uptime reflects HOST uptime in Docker

--- a/tests/healthcheck.bats
+++ b/tests/healthcheck.bats
@@ -54,6 +54,33 @@ EOF
     [ "$status" -eq 0 ]
 }
 
+@test "invalid HEALTHCHECK_START_PERIOD falls back to 15 with warning" {
+    export HEALTHCHECK_START_PERIOD="abc"
+    echo "$((NOW_STAMP - 10))" > "$HEALTHCHECK_STARTED_FILE"
+    mock_bin pidof 'exit 1'
+    run ./healthcheck.sh
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[Warning] Invalid HEALTHCHECK_START_PERIOD 'abc', using 15"* ]]
+}
+
+@test "negative HEALTHCHECK_START_PERIOD falls back to 15 with warning" {
+    export HEALTHCHECK_START_PERIOD="-5"
+    echo "$((NOW_STAMP - 10))" > "$HEALTHCHECK_STARTED_FILE"
+    mock_bin pidof 'exit 1'
+    run ./healthcheck.sh
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[Warning] Invalid HEALTHCHECK_START_PERIOD '-5', using 15"* ]]
+}
+
+@test "empty HEALTHCHECK_START_PERIOD falls back to 15 with warning" {
+    export HEALTHCHECK_START_PERIOD=""
+    echo "$((NOW_STAMP - 10))" > "$HEALTHCHECK_STARTED_FILE"
+    mock_bin pidof 'exit 1'
+    run ./healthcheck.sh
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[Warning] Invalid HEALTHCHECK_START_PERIOD '', using 15"* ]]
+}
+
 @test "grace period works regardless of host uptime (issue #111)" {
     # Simulate a long-running host: even with huge host uptime, the check
     # must use the recorded start time, not /proc/uptime.


### PR DESCRIPTION
## Summary

- Validate `HEALTHCHECK_START_PERIOD` against `^[0-9]+$` before use in `healthcheck.sh`; on invalid value (non-numeric, negative, or empty) warn to stderr and fall back to 15.
- Prevents the arithmetic check `(( NOW - STARTED < START_PERIOD ))` from aborting the healthcheck under `set -e` with an opaque error.
- Unset variable still defaults to 15 silently (parameter expansion without `:`), while an explicitly empty string is treated as invalid.
- Added 3 bats cases: non-numeric, negative, and empty values all fall back to 15 with a warning.

Fixes #192

## Testing

- `bats tests/` - full suite green (315 tests)
- `shellcheck healthcheck.sh` - clean
