### PR TITLE
fix(config): require HW_MODE=a when VHT_ENABLED is set

### DIFF
--- a/lib/channel.sh
+++ b/lib/channel.sh
@@ -68,6 +68,17 @@ validate_channel() {
     return 0
 }
 
+# VHT (802.11ac) requires 5 GHz operation.
+# Reads VHT_ENABLED and HW_MODE from the environment.
+validate_vht() {
+    : "${HW_MODE:=g}"
+    if [ -n "${VHT_ENABLED:-}" ] && [ "${HW_MODE}" != "a" ] ; then
+        echo "[Error] VHT_ENABLED requires HW_MODE=a (5 GHz)." >&2
+        return 1
+    fi
+    return 0
+}
+
 # Strict variant used by validation mode: unknown HW_MODE is an error.
 validate_channel_strict() {
     if ! validate_channel ; then

--- a/tests/channel_validation.bats
+++ b/tests/channel_validation.bats
@@ -398,3 +398,42 @@ setup() {
     run validate_channel_strict
     [ "$status" -eq 1 ]
 }
+
+# --- VHT_ENABLED requires HW_MODE=a ---
+
+@test "VHT_ENABLED set with default HW_MODE fails" {
+    unset HW_MODE
+    VHT_ENABLED="1"
+    run validate_vht
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[Error] VHT_ENABLED requires HW_MODE=a (5 GHz)."* ]]
+}
+
+@test "VHT_ENABLED set with HW_MODE=g fails" {
+    HW_MODE="g"
+    VHT_ENABLED="1"
+    run validate_vht
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error"* ]]
+}
+
+@test "VHT_ENABLED set with HW_MODE=b fails" {
+    HW_MODE="b"
+    VHT_ENABLED="1"
+    run validate_vht
+    [ "$status" -eq 1 ]
+}
+
+@test "VHT_ENABLED set with HW_MODE=a passes" {
+    HW_MODE="a"
+    VHT_ENABLED="1"
+    run validate_vht
+    [ "$status" -eq 0 ]
+}
+
+@test "VHT_ENABLED unset with HW_MODE=g passes" {
+    HW_MODE="g"
+    unset VHT_ENABLED
+    run validate_vht
+    [ "$status" -eq 0 ]
+}

--- a/tests/validate_mode.bats
+++ b/tests/validate_mode.bats
@@ -115,3 +115,15 @@ run_validate() {
     [ "$status" -ne 0 ]
     [[ "$output" == *"Unknown option"* ]]
 }
+
+@test "--validate rejects VHT_ENABLED without HW_MODE=a" {
+    run run_validate INTERFACE=wlan0 SSID=x WPA_PASSPHRASE=supersecret VHT_ENABLED=1
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"[Error] VHT_ENABLED requires HW_MODE=a (5 GHz)."* ]]
+}
+
+@test "--validate accepts VHT_ENABLED with HW_MODE=a" {
+    run run_validate INTERFACE=wlan0 SSID=x WPA_PASSPHRASE=supersecret VHT_ENABLED=1 HW_MODE=a CHANNEL=36
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ieee80211ac=1"* ]]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -239,6 +239,7 @@ run_validation_mode() {
     fi
 
     validate_channel_strict || errors=$((errors + 1))
+    validate_vht || errors=$((errors + 1))
 
     validate_ipv4_param SUBNET "${SUBNET}" || errors=$((errors + 1))
     validate_ipv4_param AP_ADDR "${AP_ADDR}" || errors=$((errors + 1))
@@ -292,6 +293,11 @@ fi
 check_interrupted
 
 if ! validate_channel ; then
+    exit 1
+fi
+check_interrupted
+
+if ! validate_vht ; then
     exit 1
 fi
 


### PR DESCRIPTION
## Summary

- Adds `validate_vht` to `lib/channel.sh`: fails with `[Error] VHT_ENABLED requires HW_MODE=a (5 GHz).` when `VHT_ENABLED` is set and `HW_MODE` is not `a`
- Enforces the check in both normal startup (`wlanstart.sh`, right after channel validation) and `run_validation_mode` (`--validate`)
- Valid combinations unchanged: `VHT_ENABLED` unset, or set together with `HW_MODE=a`

## Tests

- New unit cases in `tests/channel_validation.bats` (default/g/b fail; a passes; unset passes)
- New end-to-end cases in `tests/validate_mode.bats` (`--validate` rejects VHT without HW_MODE=a, accepts the valid combination)

Full bats suite: 319/319 green. shellcheck clean on `wlanstart.sh` and `lib/*.sh`.

Closes #191
