### PR TITLE
feat(dhcp): validate DHCP range order, subnet bounds and AP overlap

### DIFF
--- a/lib/dhcp.sh
+++ b/lib/dhcp.sh
@@ -19,11 +19,25 @@
 # The derived prefix is exported as DHCP_PREFIX for lib/interface.sh
 # and lib/nat.sh.
 #
+# Semantic validation (explicit DHCP_RANGE only): start must not exceed
+# end (numeric 32-bit compare), both endpoints must lie inside
+# ${SUBNET}/${prefix}, and the pool must not contain AP_ADDR. AP_ADDR
+# overlap is rejected outright rather than warned: the AP has a static
+# address, so a lease collision is always a configuration error.
+#
 # Prints the resulting range to stdout. Messages go to stderr.
 # Returns non-zero for invalid input.
 
 # shellcheck source=lib/validation.sh
 . "$(dirname "${BASH_SOURCE[0]}")/validation.sh"
+
+# ip_to_int converts a dotted-quad IPv4 address (already validated)
+# into its 32-bit integer value so ranges can be compared numerically.
+ip_to_int() {
+    local o1 o2 o3 o4
+    IFS=. read -r o1 o2 o3 o4 <<<"${1}"
+    echo $(( (o1 << 24) | (o2 << 16) | (o3 << 8) | o4 ))
+}
 
 # A dnsmasq lease time is a positive integer optionally followed by
 # h (hours), m (minutes) or s (seconds), e.g. 12h, 30m, 3600.
@@ -95,6 +109,44 @@ compute_dhcp_range() {
             return 1
         fi
         export DHCP_PREFIX
+
+        # Semantic checks on the parsed fields:
+        # 1. start must not come after end (numeric compare on the
+        #    full 32-bit address, so multi-octet ranges work too).
+        # 2. Both endpoints must lie inside ${SUBNET}/${prefix}
+        #    (mask arithmetic), otherwise dnsmasq would hand out
+        #    addresses outside the AP network.
+        # 3. The pool must not contain AP_ADDR itself: the access
+        #    point has a static address and a lease collision would
+        #    break connectivity. We reject outright rather than warn -
+        #    an overlapping pool is always a configuration error.
+        if [ "$(ip_to_int "${start_ip}")" -gt "$(ip_to_int "${end_ip}")" ] ; then
+            echo "[Error] Invalid DHCP_RANGE: field 1 '${start_ip}' is greater than field 2 '${end_ip}' (start must not exceed end)." >&2
+            return 1
+        fi
+        if [ -n "${SUBNET:-}" ] && validate_ipv4 "${SUBNET}" ; then
+            local subnet_int addr masked mask_int
+            subnet_int=$(ip_to_int "${SUBNET}")
+            IFS=. read -r m1 m2 m3 m4 <<<"${netmask}"
+            mask_int=$(( (m1 << 24) | (m2 << 16) | (m3 << 8) | m4 ))
+            for addr in "${start_ip}" "${end_ip}" ; do
+                masked=$(( $(ip_to_int "${addr}") & mask_int ))
+                if [ "${masked}" -ne "${subnet_int}" ] ; then
+                    echo "[Error] Invalid DHCP_RANGE: '${addr}' is outside subnet ${SUBNET}/${DHCP_PREFIX} (mask ${netmask})." >&2
+                    return 1
+                fi
+            done
+        fi
+        if [ -n "${AP_ADDR:-}" ] && validate_ipv4 "${AP_ADDR}" ; then
+            local ap_int
+            ap_int=$(ip_to_int "${AP_ADDR}")
+            if [ "${ap_int}" -ge "$(ip_to_int "${start_ip}")" ] \
+               && [ "${ap_int}" -le "$(ip_to_int "${end_ip}")" ] ; then
+                echo "[Error] Invalid DHCP_RANGE: '${start_ip}','${end_ip}' contains AP_ADDR '${AP_ADDR}' (the AP address must stay out of the DHCP pool)." >&2
+                return 1
+            fi
+        fi
+
         if ! validate_lease_time "${lease_time}" ; then
             echo "[Error] Invalid DHCP_RANGE: field 4 '${lease_time}' is not a valid lease time" >&2
             echo "  Expected: integer optionally followed by h/m/s (e.g. 12h, 3600)" >&2

--- a/tests/dhcp_range.bats
+++ b/tests/dhcp_range.bats
@@ -36,10 +36,10 @@ setup() {
 }
 
 @test "explicit DHCP_RANGE is preserved" {
-    DHCP_RANGE="10.10.10.50,10.10.10.150,255.255.255.0,24h"
+    DHCP_RANGE="192.168.254.50,192.168.254.150,255.255.255.0,24h"
     run compute_dhcp_range
     [ "$status" -eq 0 ]
-    [ "${lines[@]: -1}" = "10.10.10.50,10.10.10.150,255.255.255.0,24h" ]
+    [ "${lines[@]: -1}" = "192.168.254.50,192.168.254.150,255.255.255.0,24h" ]
 }
 
 @test "DHCP_LEASE used in default range" {
@@ -50,11 +50,11 @@ setup() {
 }
 
 @test "DHCP_LEASE ignored when DHCP_RANGE is explicit" {
-    DHCP_RANGE="10.0.0.50,10.0.0.150,255.255.255.0,48h"
+    DHCP_RANGE="192.168.254.50,192.168.254.150,255.255.255.0,48h"
     DHCP_LEASE="24h"
     run compute_dhcp_range
     [ "$status" -eq 0 ]
-    [ "${lines[@]: -1}" = "10.0.0.50,10.0.0.150,255.255.255.0,48h" ]
+    [ "${lines[@]: -1}" = "192.168.254.50,192.168.254.150,255.255.255.0,48h" ]
 }
 
 @test "invalid DHCP_RANGE with too few commas fails" {
@@ -138,17 +138,17 @@ setup() {
 }
 
 @test "plain integer lease time is accepted" {
-    DHCP_RANGE="10.10.10.50,10.10.10.150,255.255.255.0,3600"
+    DHCP_RANGE="192.168.254.50,192.168.254.150,255.255.255.0,3600"
     run compute_dhcp_range
     [ "$status" -eq 0 ]
-    [ "${lines[@]: -1}" = "10.10.10.50,10.10.10.150,255.255.255.0,3600" ]
+    [ "${lines[@]: -1}" = "192.168.254.50,192.168.254.150,255.255.255.0,3600" ]
 }
 
 @test "minutes and seconds lease suffixes are accepted" {
-    DHCP_RANGE="10.10.10.50,10.10.10.150,255.255.255.0,30m"
+    DHCP_RANGE="192.168.254.50,192.168.254.150,255.255.255.0,30m"
     run compute_dhcp_range
     [ "$status" -eq 0 ]
-    DHCP_RANGE="10.10.10.50,10.10.10.150,255.255.255.0,45s"
+    DHCP_RANGE="192.168.254.50,192.168.254.150,255.255.255.0,45s"
     run compute_dhcp_range
     [ "$status" -eq 0 ]
 }
@@ -261,4 +261,62 @@ setup() {
     run compute_dhcp_range
     [ "$status" -eq 0 ]
     [ "${lines[@]: -1}" = "192.168.254.20,192.168.254.30,255.255.255.240,12h" ]
+}
+
+# Semantic validation: order, subnet bounds, AP overlap.
+@test "inverted range (start > end) is rejected" {
+    DHCP_RANGE="192.168.254.200,192.168.254.100,255.255.255.0,12h"
+    run compute_dhcp_range
+    [ "$status" -eq 1 ]
+    [[ "${lines[*]}" == *"field 1 '192.168.254.200' is greater than field 2 '192.168.254.100'"* ]]
+}
+
+@test "start endpoint outside the subnet is rejected" {
+    DHCP_RANGE="192.168.253.50,192.168.254.150,255.255.255.0,12h"
+    run compute_dhcp_range
+    [ "$status" -eq 1 ]
+    [[ "${lines[*]}" == *"'192.168.253.50' is outside subnet 192.168.254.0/24"* ]]
+}
+
+@test "end endpoint outside the subnet is rejected" {
+    DHCP_RANGE="192.168.254.50,192.168.255.150,255.255.255.0,12h"
+    run compute_dhcp_range
+    [ "$status" -eq 1 ]
+    [[ "${lines[*]}" == *"'192.168.255.150' is outside subnet 192.168.254.0/24"* ]]
+}
+
+@test "endpoints outside a /16 subnet are accepted when inside that subnet" {
+    SUBNET="192.168.0.0"
+    AP_ADDR="192.168.0.1"
+    DHCP_RANGE="192.168.100.50,192.168.200.150,255.255.0.0,12h"
+    run compute_dhcp_range
+    [ "$status" -eq 0 ]
+}
+
+@test "range containing AP_ADDR is rejected" {
+    DHCP_RANGE="192.168.254.1,192.168.254.100,255.255.255.0,12h"
+    run compute_dhcp_range
+    [ "$status" -eq 1 ]
+    [[ "${lines[*]}" == *"contains AP_ADDR '192.168.254.1'"* ]]
+}
+
+@test "range ending exactly on AP_ADDR is rejected" {
+    DHCP_RANGE="192.168.254.50,192.168.254.1,255.255.255.0,12h"
+    run compute_dhcp_range
+    [ "$status" -eq 1 ]
+}
+
+@test "range just below and above AP_ADDR is accepted" {
+    DHCP_RANGE="192.168.254.2,192.168.254.100,255.255.255.0,12h"
+    run compute_dhcp_range
+    [ "$status" -eq 0 ]
+}
+
+@test "/28 range overlapping AP_ADDR in same subnet is rejected" {
+    SUBNET="192.168.254.16"
+    AP_ADDR="192.168.254.17"
+    DHCP_RANGE="192.168.254.17,192.168.254.30,255.255.255.240,12h"
+    run compute_dhcp_range
+    [ "$status" -eq 1 ]
+    [[ "${lines[*]}" == *"contains AP_ADDR '192.168.254.17'"* ]]
 }


### PR DESCRIPTION
## Summary

Implements semantic validation of `DHCP_RANGE` in `compute_dhcp_range` (`lib/dhcp.sh`), which previously only validated field formats.

After deriving the CIDR prefix from the netmask, three new checks run:

1. **Order**: start/end are compared numerically as 32-bit integers (new `ip_to_int` helper); `start > end` is rejected with a field-specific error.
2. **Subnet bounds**: both endpoints are checked against `${SUBNET}/${prefix}` using mask arithmetic; endpoints outside the subnet are rejected.
3. **AP overlap**: ranges containing `AP_ADDR` are **rejected outright** (documented choice in the file header). The AP has a static address, so a lease collision is always a configuration error - warning would leave a broken config live.

Error messages follow the existing per-field style and name the offending value.

### Test updates

Existing tests that paired `SUBNET=192.168.254.0` with `10.x.x.x` / `10.10.10.x` ranges were updated to use consistent subnets (they now legitimately fail the subnet-bounds check).

### New bats cases

- Inverted range rejected
- Start endpoint outside subnet rejected
- End endpoint outside subnet rejected
- Endpoints inside a /16 subnet accepted
- Range containing `AP_ADDR` rejected
- Range ending exactly on `AP_ADDR` rejected
- Range adjacent to (not containing) `AP_ADDR` accepted
- /28 range overlapping `AP_ADDR` rejected

Fixes #190
