### PR TITLE
feat(dhcp): validate AP_ADDR lies inside SUBNET/mask

### DIFF
--- a/lib/dhcp.sh
+++ b/lib/dhcp.sh
@@ -24,6 +24,9 @@
 # ${SUBNET}/${prefix}, and the pool must not contain AP_ADDR. AP_ADDR
 # overlap is rejected outright rather than warned: the AP has a static
 # address, so a lease collision is always a configuration error.
+# Additionally AP_ADDR itself must lie inside ${SUBNET}/${prefix}
+# (AP_ADDR & netmask == SUBNET), otherwise clients would be handed an
+# unreachable gateway address.
 #
 # Prints the resulting range to stdout. Messages go to stderr.
 # Returns non-zero for invalid input.
@@ -37,6 +40,29 @@ ip_to_int() {
     local o1 o2 o3 o4
     IFS=. read -r o1 o2 o3 o4 <<<"${1}"
     echo $(( (o1 << 24) | (o2 << 16) | (o3 << 8) | o4 ))
+}
+
+# check_ap_addr_in_subnet verifies that AP_ADDR lies inside
+# ${SUBNET}/<prefix> for the given dotted-decimal netmask, i.e.
+# AP_ADDR & netmask == SUBNET. Emits an error on stderr and returns
+# non-zero otherwise. Skips silently when AP_ADDR or SUBNET is unset
+# or not a valid IPv4 address (those cases are reported elsewhere).
+check_ap_addr_in_subnet() {
+    local netmask=${1:-}
+    if [ -z "${AP_ADDR:-}" ] || [ -z "${SUBNET:-}" ] ; then
+        return 0
+    fi
+    if ! validate_ipv4 "${AP_ADDR}" || ! validate_ipv4 "${SUBNET}" ; then
+        return 0
+    fi
+    local m1 m2 m3 m4 ap_masked subnet_int
+    IFS=. read -r m1 m2 m3 m4 <<<"${netmask}"
+    ap_masked=$(( $(ip_to_int "${AP_ADDR}") & (m1 << 24 | m2 << 16 | m3 << 8 | m4) ))
+    subnet_int=$(ip_to_int "${SUBNET}")
+    if [ "${ap_masked}" -ne "${subnet_int}" ] ; then
+        echo "[Error] AP_ADDR '${AP_ADDR}' is not inside SUBNET ${SUBNET}/${DHCP_PREFIX}" >&2
+        return 1
+    fi
 }
 
 # A dnsmasq lease time is a positive integer optionally followed by
@@ -71,6 +97,9 @@ compute_dhcp_range() {
         DHCP_RANGE="${prefix}.100,${prefix}.200,255.255.255.0,${DHCP_LEASE}"
         DHCP_PREFIX=24
         export DHCP_PREFIX
+        if ! check_ap_addr_in_subnet "255.255.255.0" ; then
+            return 1
+        fi
         echo "[Warning] DHCP_RANGE not set, using default: $DHCP_RANGE" >&2
     else
         local COMMA_COUNT
@@ -136,6 +165,9 @@ compute_dhcp_range() {
                     return 1
                 fi
             done
+            if ! check_ap_addr_in_subnet "${netmask}" ; then
+                return 1
+            fi
         fi
         if [ -n "${AP_ADDR:-}" ] && validate_ipv4 "${AP_ADDR}" ; then
             local ap_int

--- a/tests/dhcp_range.bats
+++ b/tests/dhcp_range.bats
@@ -23,6 +23,7 @@ setup() {
 
 @test "default DHCP_RANGE computed from SUBNET 10.0.0.0" {
     SUBNET="10.0.0.0"
+    AP_ADDR="10.0.0.1"
     run compute_dhcp_range
     [ "$status" -eq 0 ]
     [ "${lines[@]: -1}" = "10.0.0.100,10.0.0.200,255.255.255.0,12h" ]
@@ -30,6 +31,7 @@ setup() {
 
 @test "default DHCP_RANGE computed from SUBNET 172.16.1.0" {
     SUBNET="172.16.1.0"
+    AP_ADDR="172.16.1.1"
     run compute_dhcp_range
     [ "$status" -eq 0 ]
     [ "${lines[@]: -1}" = "172.16.1.100,172.16.1.200,255.255.255.0,12h" ]
@@ -319,4 +321,47 @@ setup() {
     run compute_dhcp_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"contains AP_ADDR '192.168.254.17'"* ]]
+}
+
+# AP_ADDR must lie inside SUBNET/mask (issue #189).
+@test "AP_ADDR outside default subnet is rejected" {
+    SUBNET="192.168.254.0"
+    AP_ADDR="10.0.0.1"
+    run compute_dhcp_range
+    [ "$status" -eq 1 ]
+    [[ "${lines[*]}" == *"AP_ADDR '10.0.0.1' is not inside SUBNET 192.168.254.0/24"* ]]
+}
+
+@test "AP_ADDR outside explicit DHCP_RANGE subnet is rejected" {
+    AP_ADDR="10.0.0.1"
+    DHCP_RANGE="192.168.254.100,192.168.254.200,255.255.255.0,12h"
+    run compute_dhcp_range
+    [ "$status" -eq 1 ]
+    [[ "${lines[*]}" == *"AP_ADDR '10.0.0.1' is not inside SUBNET 192.168.254.0/24"* ]]
+}
+
+@test "AP_ADDR inside a non-/24 subnet is accepted" {
+    SUBNET="192.168.254.16"
+    AP_ADDR="192.168.254.17"
+    DHCP_RANGE="192.168.254.20,192.168.254.30,255.255.255.240,12h"
+    run compute_dhcp_range
+    [ "$status" -eq 0 ]
+}
+
+@test "AP_ADDR outside a non-/24 subnet is rejected" {
+    SUBNET="192.168.254.16"
+    AP_ADDR="10.0.0.1"
+    DHCP_RANGE="192.168.254.20,192.168.254.30,255.255.255.240,12h"
+    run compute_dhcp_range
+    [ "$status" -eq 1 ]
+    [[ "${lines[*]}" == *"AP_ADDR '10.0.0.1' is not inside SUBNET 192.168.254.16/28"* ]]
+}
+
+@test "AP_ADDR outside a /16 subnet is rejected" {
+    SUBNET="192.168.0.0"
+    AP_ADDR="10.0.0.1"
+    DHCP_RANGE="192.168.100.50,192.168.200.150,255.255.0.0,12h"
+    run compute_dhcp_range
+    [ "$status" -eq 1 ]
+    [[ "${lines[*]}" == *"AP_ADDR '10.0.0.1' is not inside SUBNET 192.168.0.0/16"* ]]
 }


### PR DESCRIPTION
## Summary

- Add `check_ap_addr_in_subnet` helper in `lib/dhcp.sh` that verifies `AP_ADDR & netmask == SUBNET` using the existing `ip_to_int` helper.
- Wire it into `compute_dhcp_range` for both branches:
  - default range: checks against the implied `255.255.255.0` (/24) mask
  - explicit `DHCP_RANGE`: checked inside the existing subnet-bounds block (reuses the already-computed mask context, no duplication)
- Error message: `[Error] AP_ADDR '10.0.0.1' is not inside SUBNET 192.168.254.0/24`
- Both startup and `--validate` are covered since both paths call `compute_dhcp_range`.
- Works for non-/24 masks via the `DHCP_RANGE` netmask field.

## Tests

New bats cases in `tests/dhcp_range.bats`:
- AP_ADDR outside default subnet rejected with specific error
- AP_ADDR outside explicit DHCP_RANGE subnet rejected
- AP_ADDR inside non-/24 (/28) subnet accepted
- AP_ADDR outside non-/24 (/28) and /16 subnets rejected with correct prefix in message
- Updated two pre-existing tests whose fixtures now legitimately conflict (AP_ADDR mismatched their SUBNET)

Full suite: 332/332 passing. Shellcheck clean (`shellcheck -x lib/dhcp.sh wlanstart.sh`).

Fixes #189
