### PR TITLE
fix(interface): teardown removes only configured AP_ADDR, not all addresses

### DIFF
--- a/docs/networking.md
+++ b/docs/networking.md
@@ -15,6 +15,10 @@ Notes:
 - `SUBNET` must be the network address for that mask (host bits zero); e.g. for a `/28`, the last octet must be a multiple of 16.
 - When `DHCP_RANGE` is unset, the default range uses a `/24` layout, so `SUBNET` must end in `.0`.
 
+## Interface Address Handling
+
+At startup the container flushes existing addresses on `INTERFACE` and assigns `AP_ADDR/<prefix>` to it. On shutdown, only the address this container configured (`AP_ADDR`) is removed - a blanket `ip addr flush` is deliberately avoided so that unrelated host addresses are preserved. This matters with `--net host`, where the interface is shared with the host (e.g. a manually added `192.168.254.1/24` survives container teardown).
+
 ## NAT / IP Forwarding
 
 The container enables IP forwarding at runtime. For persistence across host reboots:

--- a/lib/interface.sh
+++ b/lib/interface.sh
@@ -17,11 +17,13 @@ setup_interface() {
     }
 }
 
-# teardown_interface flushes addresses and brings the link down.
+# teardown_interface removes only the AP address this container configured
+# (a blanket `ip addr flush` would wipe unrelated host addresses when running
+# with --net host) and brings the link down.
 teardown_interface() {
     if [ -n "${INTERFACE}" ] ; then
-        echo "Flushing interface ${INTERFACE}..."
-        ip addr flush dev "${INTERFACE}" 2>/dev/null || true
+        echo "Removing ${AP_ADDR}/${DHCP_PREFIX:-24} from interface ${INTERFACE}..."
+        ip addr del "${AP_ADDR}/${DHCP_PREFIX:-24}" dev "${INTERFACE}" 2>/dev/null || true
         ip link set "${INTERFACE}" down 2>/dev/null || true
     fi
 }

--- a/tests/cleanup.bats
+++ b/tests/cleanup.bats
@@ -34,6 +34,7 @@ wait() { _mock_log \"wait \$@\"; }
 . '$PWD/lib/ipv6.sh'
 $(sed -n '/^cleanup()/,/^}/p' wlanstart.sh)
 INTERFACE="$INTERFACE"
+AP_ADDR="${AP_ADDR:-192.168.254.1}"
 SUBNET="$SUBNET"
 OUTGOINGS="$OUTGOINGS"
 IPV6="${IPV6:-0}"
@@ -149,10 +150,29 @@ handle_signal
     [[ "$output" == *"iptables -t nat -D POSTROUTING -s 192.168.254.0/24 -o eth1 -j MASQUERADE"* ]]
 }
 
-@test "cleanup flushes interface address and brings link down" {
+@test "cleanup removes only configured AP address and brings link down" {
     run run_cleanup_mocked
-    [[ "$output" == *"ip addr flush dev wlan0"* ]]
+    [[ "$output" == *"ip addr del 192.168.254.1/24 dev wlan0"* ]]
     [[ "$output" == *"ip link set wlan0 down"* ]]
+}
+
+@test "cleanup teardown does not flush all interface addresses" {
+    run run_cleanup_mocked
+    [[ "$output" != *"ip addr flush"* ]]
+}
+
+@test "teardown_interface removes only AP_ADDR (issue #188)" {
+    . lib/interface.sh
+    INTERFACE="wlan0"
+    AP_ADDR="192.168.254.1"
+    DHCP_PREFIX=""
+    local log
+    log=$(mktemp)
+    ip() { echo "ip $@" >> "$log"; }
+    teardown_interface
+    grep -q "ip addr del 192.168.254.1/24 dev wlan0" "$log"
+    ! grep -q "addr flush" "$log"
+    rm -f "$log"
 }
 
 @test "cleanup skips interface teardown when INTERFACE unset" {


### PR DESCRIPTION
## Summary

- `teardown_interface` in `lib/interface.sh` now removes only the address this container configured (`ip addr del "${AP_ADDR}/${DHCP_PREFIX:-24}"`) instead of running `ip addr flush`, which with `--net host` wiped all addresses on the shared host interface.
- Setup flush is kept as-is (minimal change).
- Behavior documented in `docs/networking.md` under a new "Interface Address Handling" section.
- `tests/cleanup.bats` updated: asserts the targeted `addr del` call, no `addr flush` during teardown, plus a direct unit test for `teardown_interface`.

Fixes #188

## Test plan

- `bats tests/cleanup.bats tests/interface_prefix.bats`: 22/22 pass
- Full suite `bats tests/`: 334/334 pass
- `shellcheck lib/interface.sh wlanstart.sh`: clean (pre-existing SC1091 info notes only)
