### PR TITLE
fix(stations): make invalid MAX_STATIONS fatal at validation

### DIFF
--- a/lib/stations.sh
+++ b/lib/stations.sh
@@ -2,12 +2,13 @@
 # Shared MAX_STATIONS logic used by wlanstart.sh and tests.
 #
 # compute_max_sta_conf reads MAX_STATIONS from the environment and writes the
-# hostapd max_num_sta line to stdout (empty when disabled). Warnings go to
-# stderr.
+# hostapd max_num_sta line to stdout (empty when disabled). Errors go to
+# stderr. Returns non-zero for invalid MAX_STATIONS values.
 compute_max_sta_conf() {
     : "${MAX_STATIONS:=0}"
     if [ "${MAX_STATIONS}" != "0" ] && ! [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
-        echo "[Warning] Invalid MAX_STATIONS '${MAX_STATIONS}'. Must be a non-negative integer. Ignoring." >&2
+        echo "[Error] Invalid MAX_STATIONS '${MAX_STATIONS}'. Must be a non-negative integer." >&2
+        return 1
     fi
     _MAX_STA_CONF=""
     if [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then

--- a/tests/max_stations.bats
+++ b/tests/max_stations.bats
@@ -36,18 +36,18 @@ setup() {
     [ "$output" = "" ]
 }
 
-@test "negative MAX_STATIONS produces warning and no config line" {
+@test "negative MAX_STATIONS fails with error and no config line" {
     MAX_STATIONS=-5
     run compute_max_sta_conf
-    [ "$status" -eq 0 ]
+    [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid MAX_STATIONS"* ]]
     [[ "$output" != *"max_num_sta"* ]]
 }
 
-@test "non-numeric MAX_STATIONS produces warning and no config line" {
+@test "non-numeric MAX_STATIONS fails with error and no config line" {
     MAX_STATIONS="abc"
     run compute_max_sta_conf
-    [ "$status" -eq 0 ]
+    [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid MAX_STATIONS"* ]]
     [[ "$output" != *"max_num_sta"* ]]
 }
@@ -64,4 +64,10 @@ setup() {
     run compute_max_sta_conf
     [ "$status" -eq 0 ]
     [[ "$output" != *"Invalid"* ]]
+}
+
+@test "invalid MAX_STATIONS aborts --validate" {
+    run env -i PATH="${PATH}" HOME="${HOME}" INTERFACE=wlan0 SSID=x WPA_PASSPHRASE=supersecret MAX_STATIONS=abc "${BATS_TEST_DIRNAME}/../wlanstart.sh" --validate
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid MAX_STATIONS"* ]]
 }

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -176,7 +176,7 @@ emit_hostapd_conf() {
     ap_isolation_conf=$(compute_ap_isolation_line)
     ssid_hidden_conf=$(compute_ssid_hidden_line)
     mac_filter_conf=$(compute_mac_filter_conf)
-    max_sta_conf=$(compute_max_sta_conf)
+    max_sta_conf=$(compute_max_sta_conf) || return 1
     ctrl_conf=$(compute_ctrl_interface_conf)
 
     cat <<EOF


### PR DESCRIPTION
## Summary

Invalid `MAX_STATIONS` values (negative or non-integer) previously only produced a warning and were silently ignored, inconsistent with all other validators which abort startup. This PR makes them fatal:

- `compute_max_sta_conf` in `lib/stations.sh` now returns non-zero with a clear `[Error] Invalid MAX_STATIONS ...` message
- The failure is propagated by `emit_hostapd_conf` in `wlanstart.sh`, so both the normal startup path and `run_validation_mode` (`--validate`) abort, matching `compute_wpa_conf` handling
- `MAX_STATIONS=0` still means unlimited and remains valid

Fixes #187

## Testing

- Updated `tests/max_stations.bats`: invalid values now assert non-zero exit status; added an end-to-end test that `--validate` aborts on `MAX_STATIONS=abc`
- Full bats suite: 335/335 passing
- shellcheck: clean (only pre-existing info-level SC1091 notes)
