### PR TITLE
fix(healthcheck): explicit error when HEALTHCHECK_DEEP lacks INTERFACE

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -62,6 +62,10 @@ fi
 # Note: DFS CAC can take 60s+ on radar channels; raise HEALTHCHECK_START_PERIOD
 # (e.g. 90) so this check doesn't fail during channel availability scan.
 if [[ -n "${HEALTHCHECK_DEEP:-}" ]]; then
+    if [[ -z "${INTERFACE:-}" ]]; then
+        echo "HEALTHCHECK_DEEP requires INTERFACE to be set" >&2
+        exit 1
+    fi
     HOSTAPD_STATUS="$(hostapd_cli -p /var/run/hostapd -i "${INTERFACE}" status 2>/dev/null || true)"
     if ! echo "${HOSTAPD_STATUS}" | grep -q "^state=ENABLED"; then
         echo "hostapd is not in ENABLED state" >&2

--- a/tests/healthcheck.bats
+++ b/tests/healthcheck.bats
@@ -221,6 +221,16 @@ EOF
     [[ "$output" == *"hostapd is not in ENABLED state"* ]]
 }
 
+@test "deep check fails with explicit error when INTERFACE is unset (issue #185)" {
+    export HEALTHCHECK_DEEP=1
+    unset INTERFACE
+    mock_bin pidof 'exit 0'
+    mock_bin hostapd_cli 'echo "state=ENABLED"; exit 0'
+    run ./healthcheck.sh
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"HEALTHCHECK_DEEP requires INTERFACE to be set"* ]]
+}
+
 @test "deep check is skipped by default (no HEALTHCHECK_DEEP)" {
     mock_bin pidof 'exit 0'
     mock_bin ip 'if [ "$1" = "link" ]; then echo "state UP"; fi; exit 0'


### PR DESCRIPTION
## Summary

- Guard the optional `HEALTHCHECK_DEEP` check in healthcheck.sh so an unset/empty `INTERFACE` produces an explicit error ("HEALTHCHECK_DEEP requires INTERFACE to be set") instead of a confusing `hostapd_cli -i ""` failure.
- Add a bats test covering the unset-INTERFACE case.

Fixes #185

## Test plan

- [x] New test "deep check fails with explicit error when INTERFACE is unset (issue #185)" passes
- [x] Full bats suite green (336 tests)
- [x] shellcheck clean
