### PR TITLE
fix(security): prevent config injection via WPA_PASSPHRASE/PRI_DNS/SEC_DNS

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ docker run -d \
 |:--------:|:--------:|:-----------:|:-------:|
 | `INTERFACE` | Yes | Wireless interface to use | - |
 | `SSID` | No | Network name | `raspberry` |
-| `WPA_PASSPHRASE` | No | WiFi password | `passw0rd` |
+| `WPA_PASSPHRASE` | No | WiFi password (8-63 characters; newlines and control characters are rejected) | `passw0rd` |
 | `CHANNEL` | No | WiFi channel, or `acs` for automatic channel selection (requires driver support; startup may be delayed while scanning, and the `HEALTHCHECK_START_PERIOD` grace period applies since ACS can land on DFS/radar channels) | `11` |
 | `AP_ADDR` | No | Access point IP | `192.168.254.1` |
 | `SUBNET` | No | Network subnet | `192.168.254.0` |
@@ -108,8 +108,8 @@ docker run -d \
 | `IPV6` | No | Enable IPv6 RA/DHCPv6 for clients (`1` = enabled) | `0` |
 | `MAC_FILTER` | No | MAC address filtering: `0` = off, `1` = allowlist (only listed MACs), `2` = denylist (listed MACs rejected). Requires `MAC_ACL_FILE` | `0` |
 | `MAC_ACL_FILE` | No | Path to MAC list file (one MAC per line, mounted volume); required when `MAC_FILTER` is `1` or `2` | unset |
-| `PRI_DNS` | No | Primary DNS server advertised to DHCP clients | `8.8.8.8` |
-| `SEC_DNS` | No | Secondary DNS server advertised to DHCP clients | `8.8.4.4` |
+| `PRI_DNS` | No | Primary DNS server advertised to DHCP clients. Must be a valid IPv4 address (dotted quad, e.g. `8.8.8.8`) | `8.8.8.8` |
+| `SEC_DNS` | No | Secondary DNS server advertised to DHCP clients. Must be a valid IPv4 address (dotted quad, e.g. `8.8.4.4`) | `8.8.4.4` |
 | `DRIVER` | No | hostapd driver line override (e.g. `rtl871xdrv`); omit for the default `driver=nl80211`-based config | unset |
 | `HT_ENABLED` | No | Enable 802.11n High Throughput (`ieee80211n=1`). Set to any non-empty value to enable; see [HT/VHT tuning](docs/configuration.md#htvht-80211nac-tuning) | unset |
 | `HT_CAPAB` | No | 802.11n capabilities string (`ht_capab=` in hostapd.conf); requires `HT_ENABLED` | unset |

--- a/lib/passphrase.sh
+++ b/lib/passphrase.sh
@@ -8,6 +8,8 @@
 # stderr.
 validate_passphrase() {
     local len=${#WPA_PASSPHRASE}
+    # Pin the locale so the [[:cntrl:]] class behaves consistently.
+    local LC_ALL=C
     if [ "${len}" -lt 8 ] || [ "${len}" -gt 63 ] ; then
         echo "[Error] Invalid WPA_PASSPHRASE: must be 8-63 characters (got ${len})." >&2
         return 1

--- a/lib/passphrase.sh
+++ b/lib/passphrase.sh
@@ -3,11 +3,23 @@
 #
 # validate_passphrase reads WPA_PASSPHRASE from the environment and returns
 # non-zero if its length is outside the 8-63 character range required by
-# WPA-PSK/SAE. Messages go to stderr.
+# WPA-PSK/SAE or if it contains newlines/carriage returns/control
+# characters (which could inject hostapd.conf directives). Messages go to
+# stderr.
 validate_passphrase() {
     local len=${#WPA_PASSPHRASE}
     if [ "${len}" -lt 8 ] || [ "${len}" -gt 63 ] ; then
         echo "[Error] Invalid WPA_PASSPHRASE: must be 8-63 characters (got ${len})." >&2
+        return 1
+    fi
+
+    if [[ "${WPA_PASSPHRASE}" == *$'\n'* || "${WPA_PASSPHRASE}" == *$'\r'* ]] ; then
+        echo "[Error] Invalid WPA_PASSPHRASE: must not contain newlines." >&2
+        return 1
+    fi
+
+    if [[ "${WPA_PASSPHRASE}" =~ [[:cntrl:]] ]] ; then
+        echo "[Error] Invalid WPA_PASSPHRASE: must not contain control characters." >&2
         return 1
     fi
 }

--- a/tests/config_injection.bats
+++ b/tests/config_injection.bats
@@ -1,0 +1,58 @@
+#!/usr/bin/env bats
+
+# Tests for config injection guards (issue #184): WPA_PASSPHRASE with
+# embedded newlines/control characters, and non-IPv4 PRI_DNS/SEC_DNS.
+
+SCRIPT="${BATS_TEST_DIRNAME}/../wlanstart.sh"
+
+run_validate() {
+    env -i PATH="${PATH}" HOME="${HOME}" "$@" "${SCRIPT}" --validate
+}
+
+load_passphrase_lib() {
+    . "${BATS_TEST_DIRNAME}/../lib/passphrase.sh"
+}
+
+@test "passphrase with embedded newline is rejected (startup validator)" {
+    load_passphrase_lib
+    WPA_PASSPHRASE=$(printf 'goodpass\nwpa_pairwise=NONE')
+    run validate_passphrase
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid WPA_PASSPHRASE"* ]]
+    [[ "$output" == *"must not contain newlines"* ]]
+}
+
+@test "passphrase with carriage return is rejected (startup validator)" {
+    load_passphrase_lib
+    WPA_PASSPHRASE=$(printf 'goodpass\raaa')
+    run validate_passphrase
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid WPA_PASSPHRASE"* ]]
+}
+
+@test "passphrase with control character is rejected (startup validator)" {
+    load_passphrase_lib
+    WPA_PASSPHRASE=$(printf 'goodpass\tabc')
+    run validate_passphrase
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid WPA_PASSPHRASE"* ]]
+}
+
+@test "--validate rejects passphrase with embedded newline" {
+    run run_validate INTERFACE=wlan0 SSID=x "WPA_PASSPHRASE=$(printf 'goodpass\nwpa_pairwise=NONE')"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid WPA_PASSPHRASE"* ]]
+    [[ "$output" != *"wpa_pairwise=NONE"* ]]
+}
+
+@test "--validate rejects non-IPv4 PRI_DNS" {
+    run run_validate INTERFACE=wlan0 SSID=x WPA_PASSPHRASE=supersecret PRI_DNS="8.8.8.8 dhcp-option=option:router,0.0.0.0"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid PRI_DNS"* ]]
+}
+
+@test "--validate rejects non-IPv4 SEC_DNS" {
+    run run_validate INTERFACE=wlan0 SSID=x WPA_PASSPHRASE=supersecret SEC_DNS="not-an-ip"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid SEC_DNS"* ]]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -243,6 +243,8 @@ run_validation_mode() {
 
     validate_ipv4_param SUBNET "${SUBNET}" || errors=$((errors + 1))
     validate_ipv4_param AP_ADDR "${AP_ADDR}" || errors=$((errors + 1))
+    validate_ipv4_param PRI_DNS "${PRI_DNS}" || errors=$((errors + 1))
+    validate_ipv4_param SEC_DNS "${SEC_DNS}" || errors=$((errors + 1))
 
     emit_credential_warnings >&2 || true
     validate_passphrase || errors=$((errors + 1))
@@ -303,6 +305,8 @@ fi
 
 validate_ipv4_param SUBNET "${SUBNET}" || exit 1
 validate_ipv4_param AP_ADDR "${AP_ADDR}" || exit 1
+validate_ipv4_param PRI_DNS "${PRI_DNS}" || exit 1
+validate_ipv4_param SEC_DNS "${SEC_DNS}" || exit 1
 
 # Compute DHCP range early so the netmask-derived prefix (DHCP_PREFIX)
 # is available for setup_interface and apply_nat_rules.


### PR DESCRIPTION
## Summary

Prevents config injection through environment variables (#184):

- `lib/passphrase.sh`: `validate_passphrase` now rejects newlines, carriage returns, and control characters in addition to the 8-63 length check, so a crafted `WPA_PASSPHRASE` cannot inject hostapd.conf directives via the unquoted heredoc.
- `wlanstart.sh`: `PRI_DNS` and `SEC_DNS` are validated with the existing `validate_ipv4_param`, next to the `SUBNET`/`AP_ADDR` checks, in both normal startup and `run_validation_mode`, preventing arbitrary dnsmasq options.
- New bats tests in `tests/config_injection.bats` cover passphrase newline/CR/control-char rejection (validator level and `--validate`) and non-IPv4 `PRI_DNS`/`SEC_DNS` rejection in validate mode.
- README env table now documents accepted formats for `WPA_PASSPHRASE`, `PRI_DNS`, and `SEC_DNS`.

Fixes #184

## Test results

- Full bats suite: 342 tests green (`bats tests/`)
- shellcheck clean on modified files
- CI checks: see status below
