### PR TITLE
fix(signals): defer teardown until multirun children have exited

### DIFF
--- a/tests/early_signal.bats
+++ b/tests/early_signal.bats
@@ -99,6 +99,44 @@ echo 'Starting dnsmasq and hostapd via multirun ...'
     [[ "$output" != *"Shutdown requested"* ]]
 }
 
+@test "teardown waits for multirun children to exit after signal (issue #183)" {
+    local events
+    events=$(mktemp)
+    run bash -c "
+$(extract_functions)
+EVENTS='${events}'
+iptables() { : ; }
+ip() { : ; }
+cleanup() {
+    if kill -0 \"\${_MULTIRUN_PID}\" 2>/dev/null ; then
+        echo 'CLEANUP_DURING_CHILD' >> \"\${EVENTS}\"
+    else
+        echo 'CLEANUP_AFTER_CHILD' >> \"\${EVENTS}\"
+    fi
+}
+trap handle_signal SIGINT SIGTERM SIGHUP
+multirun() {
+    # Simulate a child that takes a moment to die after multirun relays
+    sleep 0.3 &
+    CHILD_PID=\$!
+    _MULTIRUN_PID=\$!
+}
+export -f cleanup
+multirun
+kill -TERM \$_MULTIRUN_PID
+wait \${_MULTIRUN_PID} 2>/dev/null
+while kill -0 \${_MULTIRUN_PID} 2>/dev/null ; do
+    wait \${_MULTIRUN_PID} 2>/dev/null || true
+    sleep 0.1
+done
+cleanup
+"
+    [ "$status" -eq 0 ]
+    grep -q 'CLEANUP_AFTER_CHILD' "${events}"
+    ! grep -q 'CLEANUP_DURING_CHILD' "${events}"
+    rm -f "${events}"
+}
+
 @test "check_interrupted is called at each key point before multirun" {
     local ci_calls multi_line
     ci_calls=$(grep -n '^\s*check_interrupted\s*$' "${SCRIPT}" | tail -1 | cut -d: -f1)

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -362,6 +362,14 @@ _MULTIRUN_PID=$!
 wait "${_MULTIRUN_PID}"
 STATUS=$?
 
+# When a signal arrives, bash's wait returns immediately (status > 128)
+# before multirun has finished relaying the signal to its children.
+# Defer teardown until multirun has actually exited (#183).
+while kill -0 "${_MULTIRUN_PID}" 2>/dev/null ; do
+    wait "${_MULTIRUN_PID}" 2>/dev/null || true
+    sleep 0.1
+done
+
 cleanup
 
 if [ "${_SIGNALED}" = "1" ] ; then


### PR DESCRIPTION
## Summary

When a trapped SIGINT/SIGTERM arrives during `wait "${_MULTIRUN_PID}"`, bash returns immediately (status > 128) before multirun has finished relaying the signal to hostapd/dnsmasq. `cleanup()` then removes iptables rules and tears the interface down while daemons may still be running, leaving unclean state.

This adds a poll loop after the initial wait: while multirun is still alive (`kill -0`), keep waiting in short intervals until it has actually exited. The original `STATUS` from the first `wait` is preserved; subsequent waits discard their status and run under `|| true` so nothing trips error handling.

## Changes

- wlanstart.sh: after `wait "${_MULTIRUN_PID}"`, loop on `kill -0` + `wait ... || true` + `sleep 0.1` until multirun exits before calling cleanup (#183)
- tests/early_signal.bats: new test stubs a multirun that spawns a child which outlives the signal briefly, and asserts cleanup only runs after child PIDs are gone

## Test plan

- New bats test "teardown waits for multirun children to exit after signal (issue #183)" passes
- Full suite: 343/343 bats tests green
- shellcheck clean (info-level SC1091 only)
