### PR TITLE
docs(spec): record envsubst templating as future decision

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -162,4 +162,8 @@ The following are out of scope:
 Placeholder for additional future decisions. Items under consideration will be
 recorded here once decided:
 
-- TBD
+- If `hostapd.conf`/`dnsmasq.conf` generation via heredocs grows unwieldy
+  (many more options), consider switching to template files rendered with
+  `envsubst` instead of rewriting the entrypoint in another language. Bash
+  remains the right tool: the scripts are glue (env interpolation, iptables,
+  signal handling) and templates would be a low-cost upgrade.


### PR DESCRIPTION
## Summary

- Adds an entry to section 5 (Future Decisions) of SPEC.md recording the outcome of a design review on config generation.
- Documents that bash remains the right tool for the entrypoint (glue: env interpolation, iptables, signal handling), and that if heredoc-based hostapd.conf/dnsmasq.conf generation becomes unwieldy, the preferred upgrade path is template files rendered with `envsubst` rather than a rewrite in another language.

## Notes

- Docs-only change; no code, CI, or runtime behavior affected.

Closes: none (documentation of a future decision).
