### PR TITLE
refactor(env): centralize environment defaults into lib/env.sh

### DIFF
--- a/lib/channel.sh
+++ b/lib/channel.sh
@@ -2,13 +2,10 @@
 # Shared channel/hw_mode/country validation logic used by wlanstart.sh and tests.
 #
 # validate_channel reads HW_MODE, CHANNEL and COUNTRY_CODE from the
-# environment (applying the same defaults as wlanstart.sh) and returns
-# non-zero when the channel is not allowed. Messages go to stderr.
+# environment (defaults applied centrally by lib/env.sh, see issue
+# #237) and returns non-zero when the channel is not allowed.
+# Messages go to stderr.
 validate_channel() {
-    : "${HW_MODE:=g}"
-    : "${CHANNEL:=11}"
-    : "${COUNTRY_CODE:=EU}"
-
     # Automatic channel selection: skip numeric checks, driver decides.
     case "${HW_MODE}:${CHANNEL}" in
         *:[aA][cC][sS])
@@ -71,7 +68,6 @@ validate_channel() {
 # VHT (802.11ac) requires 5 GHz operation.
 # Reads VHT_ENABLED and HW_MODE from the environment.
 validate_vht() {
-    : "${HW_MODE:=g}"
     if [ -n "${VHT_ENABLED:-}" ] && [ "${HW_MODE}" != "a" ] ; then
         echo "[Error] VHT_ENABLED requires HW_MODE=a (5 GHz)." >&2
         return 1
@@ -84,7 +80,6 @@ validate_channel_strict() {
     if ! validate_channel ; then
         return 1
     fi
-    : "${HW_MODE:=g}"
     case "${HW_MODE}" in
         a|b|g) ;;
         *)

--- a/lib/dhcp.sh
+++ b/lib/dhcp.sh
@@ -72,7 +72,7 @@ validate_lease_time() {
 }
 
 compute_dhcp_range() {
-    : "${DHCP_LEASE:=12h}"
+    # DHCP_LEASE default is applied centrally by lib/env.sh (#237)
     if [ ! "${DHCP_LEASE}" ] || ! validate_lease_time "${DHCP_LEASE}" ; then
         echo "[Error] Invalid DHCP_LEASE: '${DHCP_LEASE}' is not a valid lease time." >&2
         echo "  Expected: integer optionally followed by h/m/s (e.g. 12h, 3600)"

--- a/lib/env.sh
+++ b/lib/env.sh
@@ -1,0 +1,40 @@
+# shellcheck shell=bash
+# Centralized environment defaults (issue #237).
+#
+# resolve_config_env() is the single place where default values are
+# applied for every configuration variable. It is called exactly once by
+# wlanstart.sh, before any validation or config emission, so that
+# normal mode and --validate mode always resolve identical configs.
+#
+# Precedence: an explicitly set environment variable always wins; the
+# defaults below only apply when the variable is unset or empty.
+# Library modules (lib/*.sh) read these variables and must NOT apply
+# their own defaults - they can assume resolve_config_env() has run.
+
+resolve_config_env() {
+    # Wireless hardware mode: b | g | a (see lib/channel.sh)
+    : "${HW_MODE:=g}"
+    # Channel; "acs" enables automatic channel selection
+    : "${CHANNEL:=11}"
+    # Regulatory domain. Warn when defaulted: channel availability
+    # differs per country (e.g. US allows 1-11, EU 1-13).
+    if [ -z "${COUNTRY_CODE+x}" ] ; then
+        echo "[Warning] COUNTRY_CODE not set, defaulting to 'EU' (ETSI: channels 1-13)." >&2
+        echo "          Set COUNTRY_CODE (e.g. US, CA, JP) to match your local regulations." >&2
+    fi
+    : "${COUNTRY_CODE:=EU}"
+    # Network layout
+    : "${SUBNET:=192.168.254.0}"
+    : "${AP_ADDR:=192.168.254.1}"
+    : "${PRI_DNS:=8.8.8.8}"
+    : "${SEC_DNS:=8.8.4.4}"
+    # DHCP pool lease time used when DHCP_RANGE is not set explicitly
+    : "${DHCP_LEASE:=12h}"
+    # Access point credentials
+    : "${SSID:=raspberry}"
+    : "${WPA_PASSPHRASE:=passw0rd}"
+    # WPA version: 2 | 3 | mixed (see lib/wpa.sh)
+    : "${WPA_VERSION:=2}"
+    # Maximum associated stations; 0 means hostapd default (unlimited)
+    : "${MAX_STATIONS:=0}"
+}

--- a/lib/stations.sh
+++ b/lib/stations.sh
@@ -1,11 +1,11 @@
 # shellcheck shell=bash
 # Shared MAX_STATIONS logic used by wlanstart.sh and tests.
 #
-# compute_max_sta_conf reads MAX_STATIONS from the environment and writes the
+# compute_max_sta_conf reads MAX_STATIONS from the environment (default
+# applied centrally by lib/env.sh, see issue #237) and writes the
 # hostapd max_num_sta line to stdout (empty when disabled). Errors go to
 # stderr. Returns non-zero for invalid MAX_STATIONS values.
 compute_max_sta_conf() {
-    : "${MAX_STATIONS:=0}"
     if [ "${MAX_STATIONS}" != "0" ] && ! [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
         echo "[Error] Invalid MAX_STATIONS '${MAX_STATIONS}'. Must be a non-negative integer." >&2
         return 1

--- a/lib/wpa.sh
+++ b/lib/wpa.sh
@@ -5,8 +5,8 @@
 # environment and writes the hostapd wpa_* block to stdout. Messages go to
 # stderr. Returns non-zero for invalid WPA_VERSION values.
 compute_wpa_conf() {
-    : "${HW_MODE:=g}"
-    : "${WPA_VERSION:=2}"
+    # Defaults (WPA_VERSION, HW_MODE, WPA_PASSPHRASE) are applied
+    # centrally by lib/env.sh (issue #237).
     case "${WPA_VERSION}" in
         2)
             _WPA_LEVEL="wpa=2"
@@ -38,7 +38,7 @@ ${_WPA_PAIRWISE}"
             ;;
     esac
     echo "${_WPA_LEVEL}
-wpa_passphrase=${WPA_PASSPHRASE:-passw0rd}
+wpa_passphrase=${WPA_PASSPHRASE}
 ${_WPA_KEY_MGMT}
 ${_WPA_PAIRWISE}"
 }

--- a/tests/channel_validation.bats
+++ b/tests/channel_validation.bats
@@ -5,6 +5,10 @@ setup() {
     unset HW_MODE
     unset CHANNEL
     unset COUNTRY_CODE
+    # shellcheck source=../lib/env.sh
+    . "${ROOT}/lib/env.sh"
+    # Defaults now live centrally in lib/env.sh (issue #237)
+    resolve_config_env
     # shellcheck source=../lib/channel.sh
     . "${ROOT}/lib/channel.sh"
 }
@@ -178,6 +182,7 @@ setup() {
 @test "emit_hostapd_conf emits channel=acs unchanged" {
     export INTERFACE=wlan0 SSID=test WPA_PASSPHRASE=passw0rd
     export HW_MODE=g CHANNEL=acs COUNTRY_CODE=EU WPA_VERSION=2
+    export MAX_STATIONS=0
     eval "$(sed -n '/^emit_hostapd_conf()/,/^}/p' "${BATS_TEST_DIRNAME}/../wlanstart.sh")"
     . "${BATS_TEST_DIRNAME}/../lib/stations.sh"
     . "${BATS_TEST_DIRNAME}/../lib/ctrl_interface.sh"
@@ -387,6 +392,7 @@ setup() {
 
 @test "strict: default hw_mode (g) passes" {
     unset HW_MODE
+    resolve_config_env
     CHANNEL="1"
     run validate_channel_strict
     [ "$status" -eq 0 ]
@@ -403,6 +409,7 @@ setup() {
 
 @test "VHT_ENABLED set with default HW_MODE fails" {
     unset HW_MODE
+    resolve_config_env
     VHT_ENABLED="1"
     run validate_vht
     [ "$status" -eq 1 ]

--- a/tests/dhcp_range.bats
+++ b/tests/dhcp_range.bats
@@ -2,6 +2,8 @@
 
 # Logic shared with wlanstart.sh
 REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+# shellcheck source=../lib/env.sh
+. "${REPO_ROOT}/lib/env.sh"
 # shellcheck source=../lib/dhcp.sh
 . "${REPO_ROOT}/lib/dhcp.sh"
 
@@ -13,6 +15,8 @@ setup() {
     export INTERFACE="wlan0"
     unset DHCP_RANGE
     unset DHCP_LEASE
+    # DHCP_LEASE default now applied centrally in lib/env.sh (issue #237)
+    resolve_config_env
 }
 
 @test "default DHCP_RANGE computed from SUBNET 192.168.254.0" {
@@ -189,9 +193,11 @@ setup() {
 @test "/28 DHCP_RANGE sets DHCP_PREFIX to 28" {
     # shellcheck disable=SC2016
     run bash -c '
+        . "'"${REPO_ROOT}"'/lib/env.sh"
         . "'"${REPO_ROOT}"'/lib/dhcp.sh"
         SUBNET="192.168.254.16" AP_ADDR="192.168.254.17" INTERFACE="wlan0"
-        PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4"
+        PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
+        resolve_config_env
         DHCP_RANGE="192.168.254.20,192.168.254.30,255.255.255.240,12h"
         compute_dhcp_range > /dev/null || exit 1
         echo "${DHCP_PREFIX}"
@@ -203,9 +209,11 @@ setup() {
 @test "default range sets DHCP_PREFIX to 24" {
     # shellcheck disable=SC2016
     run bash -c '
+        . "'"${REPO_ROOT}"'/lib/env.sh"
         . "'"${REPO_ROOT}"'/lib/dhcp.sh"
         SUBNET="192.168.254.0" AP_ADDR="192.168.254.1" INTERFACE="wlan0"
-        PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4"
+        PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
+        resolve_config_env
         compute_dhcp_range > /dev/null 2>&1 || exit 1
         echo "${DHCP_PREFIX}"
     '
@@ -216,9 +224,11 @@ setup() {
 @test "explicit /24 DHCP_RANGE sets DHCP_PREFIX to 24" {
     # shellcheck disable=SC2016
     run bash -c '
+        . "'"${REPO_ROOT}"'/lib/env.sh"
         . "'"${REPO_ROOT}"'/lib/dhcp.sh"
         SUBNET="10.10.10.0" AP_ADDR="10.10.10.1" INTERFACE="wlan0"
-        PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4"
+        PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
+        resolve_config_env
         DHCP_RANGE="10.10.10.50,10.10.10.150,255.255.255.0,12h"
         compute_dhcp_range > /dev/null || exit 1
         echo "${DHCP_PREFIX}"
@@ -230,9 +240,11 @@ setup() {
 @test "/16 DHCP_RANGE sets DHCP_PREFIX to 16" {
     # shellcheck disable=SC2016
     run bash -c '
+        . "'"${REPO_ROOT}"'/lib/env.sh"
         . "'"${REPO_ROOT}"'/lib/dhcp.sh"
         SUBNET="192.168.0.0" AP_ADDR="192.168.254.1" INTERFACE="wlan0"
-        PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4"
+        PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
+        resolve_config_env
         DHCP_RANGE="192.168.100.50,192.168.200.150,255.255.0.0,12h"
         compute_dhcp_range > /dev/null || exit 1
         echo "${DHCP_PREFIX}"

--- a/tests/env.bats
+++ b/tests/env.bats
@@ -1,0 +1,102 @@
+#!/usr/bin/env bats
+
+# Tests for resolve_config_env() in lib/env.sh - the single place where
+# environment defaults are applied (issue #237).
+
+setup() {
+    # Start from a clean slate for every defaulted variable
+    for var in HW_MODE CHANNEL COUNTRY_CODE SUBNET AP_ADDR PRI_DNS SEC_DNS \
+               DHCP_LEASE SSID WPA_PASSPHRASE WPA_VERSION MAX_STATIONS ; do
+        unset "${var}"
+    done
+    # shellcheck source=../lib/env.sh
+    . "${BATS_TEST_DIRNAME}/../lib/env.sh"
+}
+
+@test "resolve_config_env applies all defaults when env is empty" {
+    run bash -c '
+        . "'"${BATS_TEST_DIRNAME}"'/../lib/env.sh"
+        resolve_config_env 2>/dev/null
+        printf "%s\n" "${HW_MODE}" "${CHANNEL}" "${COUNTRY_CODE}" \
+            "${SUBNET}" "${AP_ADDR}" "${PRI_DNS}" "${SEC_DNS}" \
+            "${DHCP_LEASE}" "${SSID}" "${WPA_PASSPHRASE}" \
+            "${WPA_VERSION}" "${MAX_STATIONS}"
+    '
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "g" ]
+    [ "${lines[1]}" = "11" ]
+    [ "${lines[2]}" = "EU" ]
+    [ "${lines[3]}" = "192.168.254.0" ]
+    [ "${lines[4]}" = "192.168.254.1" ]
+    [ "${lines[5]}" = "8.8.8.8" ]
+    [ "${lines[6]}" = "8.8.4.4" ]
+    [ "${lines[7]}" = "12h" ]
+    [ "${lines[8]}" = "raspberry" ]
+    [ "${lines[9]}" = "passw0rd" ]
+    [ "${lines[10]}" = "2" ]
+    [ "${lines[11]}" = "0" ]
+}
+
+@test "resolve_config_env never overrides explicitly set variables" {
+    run bash -c '
+        . "'"${BATS_TEST_DIRNAME}"'/../lib/env.sh"
+        export HW_MODE=a CHANNEL=36 COUNTRY_CODE=US SUBNET=10.0.0.0 AP_ADDR=10.0.0.1
+        export PRI_DNS=1.1.1.1 SEC_DNS=1.0.0.1 DHCP_LEASE=24h SSID=myssid
+        export WPA_PASSPHRASE=supersecret WPA_VERSION=3 MAX_STATIONS=16
+        resolve_config_env 2>/dev/null
+        printf "%s\n" "${HW_MODE}" "${CHANNEL}" "${COUNTRY_CODE}" \
+            "${SUBNET}" "${AP_ADDR}" "${PRI_DNS}" "${SEC_DNS}" \
+            "${DHCP_LEASE}" "${SSID}" "${WPA_PASSPHRASE}" \
+            "${WPA_VERSION}" "${MAX_STATIONS}"
+    '
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "a" ]
+    [ "${lines[1]}" = "36" ]
+    [ "${lines[2]}" = "US" ]
+    [ "${lines[3]}" = "10.0.0.0" ]
+    [ "${lines[4]}" = "10.0.0.1" ]
+    [ "${lines[5]}" = "1.1.1.1" ]
+    [ "${lines[6]}" = "1.0.0.1" ]
+    [ "${lines[7]}" = "24h" ]
+    [ "${lines[8]}" = "myssid" ]
+    [ "${lines[9]}" = "supersecret" ]
+    [ "${lines[10]}" = "3" ]
+    [ "${lines[11]}" = "16" ]
+}
+
+@test "resolve_config_env warns when COUNTRY_CODE is not set" {
+    run resolve_config_env
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"COUNTRY_CODE not set, defaulting to 'EU'"* ]]
+}
+
+@test "resolve_config_env stays silent when COUNTRY_CODE is set" {
+    COUNTRY_CODE=JP
+    run resolve_config_env
+    [ "$status" = 0 ]
+    [ "$output" = "" ]
+}
+
+# Lib modules must not re-default their own vars (#237): sourcing only
+# the module and calling it with an empty environment must fail loudly
+# rather than silently resolving defaults.
+@test "compute_wpa_conf without resolved env does not apply defaults" {
+    . "${BATS_TEST_DIRNAME}/../lib/wpa.sh"
+    unset WPA_VERSION
+    run compute_wpa_conf
+    [ "$status" -ne 0 ]
+}
+
+@test "compute_max_sta_conf without MAX_STATIONS errors instead of defaulting" {
+    . "${BATS_TEST_DIRNAME}/../lib/stations.sh"
+    unset MAX_STATIONS
+    run compute_max_sta_conf
+    [ "$status" -ne 0 ]
+}
+
+@test "validate_channel with unresolved empty env fails loudly" {
+    . "${BATS_TEST_DIRNAME}/../lib/channel.sh"
+    unset HW_MODE CHANNEL COUNTRY_CODE
+    run validate_channel_strict
+    [ "$status" -ne 0 ]
+}

--- a/tests/extra_opts.bats
+++ b/tests/extra_opts.bats
@@ -44,6 +44,7 @@ setup() {
 @test "emit_hostapd_conf appends extra opts at end of config" {
     export INTERFACE=wlan0 SSID=test WPA_PASSPHRASE=passw0rd
     export HW_MODE=g CHANNEL=6 WPA_VERSION=2
+    export MAX_STATIONS=0
     export HOSTAPD_EXTRA_OPTS=$'auth_algs=3\nbeacon_int=100'
     eval "$(sed -n '/^emit_hostapd_conf()/,/^}/p' "${BATS_TEST_DIRNAME}/../wlanstart.sh")"
     . "${BATS_TEST_DIRNAME}/../lib/stations.sh"
@@ -63,6 +64,7 @@ setup() {
 @test "unset HOSTAPD_EXTRA_OPTS leaves config unchanged (no extra trailing lines)" {
     export INTERFACE=wlan0 SSID=test WPA_PASSPHRASE=passw0rd
     export HW_MODE=g CHANNEL=6 WPA_VERSION=2
+    export MAX_STATIONS=0
     eval "$(sed -n '/^emit_hostapd_conf()/,/^}/p' "${BATS_TEST_DIRNAME}/../wlanstart.sh")"
     . "${BATS_TEST_DIRNAME}/../lib/stations.sh"
     . "${BATS_TEST_DIRNAME}/../lib/ctrl_interface.sh"

--- a/tests/max_stations.bats
+++ b/tests/max_stations.bats
@@ -5,6 +5,10 @@
 setup() {
     unset MAX_STATIONS
     unset _MAX_STA_CONF
+    # shellcheck source=../lib/env.sh
+    . "$(dirname "$BATS_TEST_FILENAME")/../lib/env.sh"
+    # Default MAX_STATIONS now applied centrally in lib/env.sh (issue #237)
+    resolve_config_env
     # shellcheck source=../lib/stations.sh
     . "$(dirname "$BATS_TEST_FILENAME")/../lib/stations.sh"
 }

--- a/tests/wpa_version.bats
+++ b/tests/wpa_version.bats
@@ -10,6 +10,10 @@ setup() {
     unset _WPA_LEVEL
     unset _WPA_KEY_MGMT
     unset _WPA_PAIRWISE
+    # shellcheck source=../lib/env.sh
+    . "${BATS_TEST_DIRNAME}/../lib/env.sh"
+    # Defaults now live centrally in lib/env.sh (issue #237)
+    resolve_config_env
 }
 
 load_lib() {

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -91,30 +91,16 @@ if [ "${VALIDATE_ONLY}" != "1" ] ; then
     fi
 fi
 
-# Set HW_MODE and CHANNEL early for validation
-: "${HW_MODE:=g}"
-: "${CHANNEL:=11}"
-
-# Warn if COUNTRY_CODE was not explicitly set, then default to EU (ETSI)
-if [ -z "${COUNTRY_CODE+x}" ] ; then
-    echo "[Warning] COUNTRY_CODE not set, defaulting to 'EU' (ETSI: channels 1-13)."
-    echo "          Set COUNTRY_CODE (e.g. US, CA, JP) to match your local regulations."
-fi
-: "${COUNTRY_CODE:=EU}"
+# Apply all environment defaults in one place (issue #237).
+# Logic lives in lib/env.sh, shared with tests
+# shellcheck source=lib/env.sh
+. "$(dirname "$0")/lib/env.sh"
+resolve_config_env
 
 # Validate channel against regulatory domain and hardware mode
 # Logic lives in lib/channel.sh, shared with tests
 # shellcheck source=lib/channel.sh
 . "$(dirname "$0")/lib/channel.sh"
-
-# Default values
-: "${SUBNET:=192.168.254.0}"
-: "${AP_ADDR:=192.168.254.1}"
-: "${PRI_DNS:=8.8.8.8}"
-: "${SEC_DNS:=8.8.4.4}"
-: "${SSID:=raspberry}"
-: "${WPA_PASSPHRASE:=passw0rd}"
-: "${MAX_STATIONS:=0}"
 
 # IPv4 address validation (validate_ipv4)
 # Logic lives in lib/validation.sh, shared with tests


### PR DESCRIPTION
## Summary

Centralizes all environment variable defaults into a single place, `lib/env.sh`, exposing one entrypoint: `resolve_config_env()` (issue #237).

## Problem

Defaults were applied in two places with different timing:

- `wlanstart.sh` inline (`HW_MODE`, `CHANNEL`, `COUNTRY_CODE`, `SUBNET`, `AP_ADDR`, `PRI_DNS`, `SEC_DNS`, `SSID`, `WPA_PASSPHRASE`, `MAX_STATIONS`)
- Individual libs re-defaulting their own vars at call time (`lib/channel.sh` for HW_MODE/CHANNEL/COUNTRY_CODE, `lib/dhcp.sh` for DHCP_LEASE, `lib/wpa.sh` for HW_MODE/WPA_VERSION/WPA_PASSPHRASE, `lib/stations.sh` for MAX_STATIONS)

This meant validate mode and normal mode could resolve defaults at different points, and any default change had to be made in multiple files - a drift risk.

## Changes

- New `lib/env.sh` with `resolve_config_env()`: the single source of truth for every default (now also including `DHCP_LEASE` and `WPA_VERSION`), with documented precedence and the existing COUNTRY_CODE regulatory warning.
- `wlanstart.sh` sources `lib/env.sh` once and calls `resolve_config_env()` before validation/config emission; removed all inline defaults. Normal mode and `--validate` now resolve identical configs.
- `lib/channel.sh`, `lib/dhcp.sh`, `lib/wpa.sh`, `lib/stations.sh`: dropped internal `:=` re-defaults; modules assume vars are resolved.
- Tests:
  - New `tests/env.bats`: defaults applied, explicit env wins, COUNTRY_CODE warning behavior, and lib modules fail loudly when called without resolved env.
  - Updated `channel_validation.bats`, `wpa_version.bats`, `max_stations.bats`, `dhcp_range.bats`, `extra_opts.bats` to resolve env centrally instead of relying on per-module defaults.

## Testing

- Full bats suite locally: 350/350 pass.
- `shellcheck` clean on `wlanstart.sh` and all of `lib/`.
- Manual sanity check of `./wlanstart.sh --validate` output unchanged.

Closes #237
