### PR TITLE
feat(radio): add TX_POWER env var for transmit power control

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ docker run -d \
 | `DHCP_RANGE` | No | DHCP range (`start,end,mask,lease`). The `mask` field sets the subnet prefix used on the AP interface and NAT rules (e.g. `255.255.255.240` = `/28`) | Auto from SUBNET |
 | `DHCP_LEASE` | No | DHCP lease time (used with default range) | `12h` |
 | `MAX_STATIONS` | No | Max connected clients (`0` = unlimited) | `0` |
+| `TX_POWER` | No | Transmit power: integer dBm (fixed, e.g. `20`) or `auto`. Unset leaves the driver default. Must respect `COUNTRY_CODE` regulatory limits; startup is fatal if the value cannot be applied. See [Transmit Power](docs/configuration.md#transmit-power-optional) | unset |
 | `HIDE_SSID` | No | Hide SSID broadcast (`1` = hidden) | `0` |
 | `AP_ISOLATION` | No | Isolate clients from each other (`1` = enabled) | `0` |
 | `COUNTRY_CODE` | No | Regulatory domain (`US`/`CA`/`MX`: ch 1-11, `JP`: ch 1-14, others: ch 1-13). Sets `country_code` in hostapd.conf | `EU` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,6 +66,26 @@ Interpretation:
 
 If hostapd rejects your capability string, it shows up as a config error in `docker logs rpi-hostap` on start.
 
+## Transmit Power (optional)
+
+Regulatory-constrained deployments (labs, embedded products) may need to cap the AP's EIRP. Set `TX_POWER` to a fixed transmit power in dBm, or `auto` to restore driver/regulatory automatic power control:
+
+```bash
+docker run ... \
+  -e COUNTRY_CODE=ES \
+  -e TX_POWER=10 \
+  ...
+```
+
+- Unset (default): the driver default power is left untouched.
+- `TX_POWER=20`: applied at startup as `iw dev <iface> set txpower fixed 20`.
+- `TX_POWER=auto`: applied as `iw dev <iface> set txpower auto`.
+
+### Notes
+
+- The cap must respect your `COUNTRY_CODE` regulatory limits - `iw` rejects powers above the allowed EIRP for the configured domain. Setting a country code alone does not cap power; `TX_POWER` is the explicit limit.
+- Failure to apply is **fatal**: if you explicitly ask for a power cap and it cannot be set, the container exits with a clear error rather than silently transmitting at full power. Check the value against `iw reg` output on the host if startup fails.
+
 ## MAC Address Filtering (optional)
 
 MAC filtering is **off by default**; behavior is unchanged unless you set `MAC_FILTER`. When enabled:

--- a/lib/radio.sh
+++ b/lib/radio.sh
@@ -1,0 +1,44 @@
+# shellcheck shell=bash
+# Shared TX_POWER (transmit power) logic used by wlanstart.sh and tests.
+#
+# TX_POWER is optional: unset means leave the driver default. "auto"
+# restores driver/regulatory automatic power control; a positive integer
+# sets a fixed transmit power in dBm via `iw dev <iface> set txpower`.
+# The value must respect the regulatory limits of COUNTRY_CODE - iw will
+# reject powers above the allowed EIRP for the configured domain.
+#
+# validate_tx_power checks the value without touching the system
+# (used by --validate mode and before any system change).
+validate_tx_power() {
+    [ -z "${TX_POWER:-}" ] && return 0
+    case "${TX_POWER}" in
+        auto) return 0 ;;
+        ""|*[!0-9]*)
+            echo "[Error] Invalid TX_POWER '${TX_POWER}'. Must be 'auto' or an integer power in dBm." >&2
+            return 1
+            ;;
+    esac
+    return 0
+}
+
+# apply_tx_power applies TX_POWER to INTERFACE via iw. Fails fatally when
+# iw rejects the value: the operator asked explicitly for a power cap,
+# silently running at full power would violate that intent.
+apply_tx_power() {
+    [ -n "${TX_POWER:-}" ] || return 0
+    if ! command -v iw >/dev/null 2>&1 ; then
+        echo "[Error] TX_POWER set but 'iw' is not available on ${INTERFACE}" >&2
+        return 1
+    fi
+    case "${TX_POWER}" in
+        auto)
+            iw dev "${INTERFACE}" set txpower auto
+            ;;
+        *)
+            iw dev "${INTERFACE}" set txpower fixed "${TX_POWER}"
+            ;;
+    esac || {
+        echo "[Error] Failed to set txpower ${TX_POWER} on ${INTERFACE}. Check the value against your COUNTRY_CODE=${COUNTRY_CODE} regulatory limits." >&2
+        return 1
+    }
+}

--- a/tests/tx_power.bats
+++ b/tests/tx_power.bats
@@ -1,0 +1,109 @@
+#!/usr/bin/env bats
+
+# Shared TX_POWER logic from lib/radio.sh
+
+setup() {
+    unset TX_POWER
+    INTERFACE=wlan0
+    COUNTRY_CODE=EU
+    # shellcheck source=../lib/env.sh
+    . "$(dirname "$BATS_TEST_FILENAME")/../lib/env.sh"
+    resolve_config_env
+    # shellcheck source=../lib/radio.sh
+    . "$(dirname "$BATS_TEST_FILENAME")/../lib/radio.sh"
+}
+
+@test "unset TX_POWER validates OK" {
+    run validate_tx_power
+    [ "$status" -eq 0 ]
+}
+
+@test "TX_POWER=auto validates OK" {
+    TX_POWER=auto
+    run validate_tx_power
+    [ "$status" -eq 0 ]
+}
+
+@test "TX_POWER=20 (dBm) validates OK" {
+    TX_POWER=20
+    run validate_tx_power
+    [ "$status" -eq 0 ]
+}
+
+@test "TX_POWER=0 validates OK" {
+    TX_POWER=0
+    run validate_tx_power
+    [ "$status" -eq 0 ]
+}
+
+@test "invalid TX_POWER 'high' fails with error" {
+    TX_POWER=high
+    run validate_tx_power
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid TX_POWER"* ]]
+}
+
+@test "negative TX_POWER fails with error" {
+    TX_POWER=-5
+    run validate_tx_power
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid TX_POWER"* ]]
+}
+
+@test "non-numeric TX_POWER with digits mixed in fails" {
+    TX_POWER=10dbm
+    run validate_tx_power
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid TX_POWER"* ]]
+}
+
+@test "apply_tx_power is a no-op when unset" {
+    run apply_tx_power
+    [ "$status" -eq 0 ]
+}
+
+@test "apply_tx_power runs iw set txpower fixed for dBm values" {
+    TX_POWER=15
+    PATH="/usr/bin:/bin"
+    mkdir -p "$BATS_TMPDIR/fakebin"
+    printf '#!/bin/sh\necho "iw $@"\n' > "$BATS_TMPDIR/fakebin/iw"
+    chmod +x "$BATS_TMPDIR/fakebin/iw"
+    PATH="$BATS_TMPDIR/fakebin:$PATH" run apply_tx_power
+    rm -rf "$BATS_TMPDIR/fakebin"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"iw dev wlan0 set txpower fixed 15"* ]]
+}
+
+@test "apply_tx_power runs iw set txpower auto for auto" {
+    TX_POWER=auto
+    mkdir -p "$BATS_TMPDIR/fakebin"
+    printf '#!/bin/sh\necho "iw $@"\n' > "$BATS_TMPDIR/fakebin/iw"
+    chmod +x "$BATS_TMPDIR/fakebin/iw"
+    PATH="$BATS_TMPDIR/fakebin:$PATH" run apply_tx_power
+    rm -rf "$BATS_TMPDIR/fakebin"
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"iw dev wlan0 set txpower auto"* ]]
+}
+
+@test "iw failure makes apply_tx_power fatal" {
+    TX_POWER=15
+    mkdir -p "$BATS_TMPDIR/fakebin"
+    printf '#!/bin/sh\nexit 1\n' > "$BATS_TMPDIR/fakebin/iw"
+    chmod +x "$BATS_TMPDIR/fakebin/iw"
+    PATH="$BATS_TMPDIR/fakebin:$PATH" run apply_tx_power
+    rm -rf "$BATS_TMPDIR/fakebin"
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Failed to set txpower"* ]]
+}
+
+@test "invalid TX_POWER rejected by --validate before config output" {
+    run env -i PATH="${PATH}" HOME="${HOME}" INTERFACE=wlan0 SSID=x WPA_PASSPHRASE=supersecret TX_POWER=loud "${BATS_TEST_DIRNAME}/../wlanstart.sh" --validate
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid TX_POWER"* ]]
+    [[ "$output" != *"=== /etc/hostapd.conf ==="* ]]
+}
+
+@test "valid TX_POWER accepted by --validate" {
+    run env -i PATH="${PATH}" HOME="${HOME}" INTERFACE=wlan0 SSID=x WPA_PASSPHRASE=supersecret TX_POWER=20 "${BATS_TEST_DIRNAME}/../wlanstart.sh" --validate
+    [ "$status" -eq 0 ]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -150,6 +150,10 @@ resolve_config_env
 # Logic lives in lib/extra_opts.sh, shared with tests
 # shellcheck source=lib/extra_opts.sh
 . "$(dirname "$0")/lib/extra_opts.sh"
+# TX_POWER transmit power control
+# Logic lives in lib/radio.sh, shared with tests
+# shellcheck source=lib/radio.sh
+. "$(dirname "$0")/lib/radio.sh"
 # Atomic config file writing (temp file + mv)
 # Logic lives in lib/atomic.sh, shared with tests
 # shellcheck source=lib/atomic.sh
@@ -236,6 +240,7 @@ run_validation_mode() {
     validate_passphrase || errors=$((errors + 1))
     validate_ssid "${SSID}" || errors=$((errors + 1))
     validate_mac_filter || errors=$((errors + 1))
+    validate_tx_power || errors=$((errors + 1))
 
     if [ "${errors}" -ne 0 ] ; then
         echo "[Error] Validation failed with ${errors} error(s)." >&2
@@ -288,6 +293,9 @@ check_interrupted
 if ! validate_vht ; then
     exit 1
 fi
+if ! validate_tx_power ; then
+    exit 1
+fi
 
 validate_ipv4_param SUBNET "${SUBNET}" || exit 1
 validate_ipv4_param AP_ADDR "${AP_ADDR}" || exit 1
@@ -307,6 +315,10 @@ check_interrupted
 if ! setup_interface ; then
     exit 1
 fi
+check_interrupted
+
+# Optional transmit power cap (TX_POWER); fatal on failure (#236)
+apply_tx_power || exit 1
 check_interrupted
 
 # NAT settings


### PR DESCRIPTION
Closes #236

## Summary

New optional `TX_POWER` env var to cap the AP's transmit power (EIRP) for regulatory-constrained deployments.

- `TX_POWER=<dBm>`: applied at startup via `iw dev <iface> set txpower fixed <n>`
- `TX_POWER=auto`: restores driver/regulatory automatic power control
- Unset (default): unchanged - driver default power left untouched
- Validation lives in the testable `validate_tx_power` in new `lib/radio.sh`; wired into both normal and `--validate` paths so invalid values are rejected before any system changes
- `apply_tx_power` failure is fatal by design: an operator who explicitly asked for a power cap should never have the AP silently run at full power; error message points at COUNTRY_CODE regulatory limits

## Changes

- `lib/radio.sh`: `validate_tx_power` + `apply_tx_power`
- `wlanstart.sh`: source lib/radio.sh, validate early in both modes, apply after `setup_interface`
- `tests/tx_power.bats`: 13 bats tests (validation, iw invocation via stub, fatal-on-failure, --validate integration)
- `README.md`: TX_POWER row in environment variables table
- `docs/configuration.md`: "Transmit Power (optional)" section with regulatory note and fatal-failure rationale

## Test plan

- [x] `bats tests/tx_power.bats` - 13/13 green
- [x] Full suite `bats tests/` - 363/363 green
- [x] `make lint` passes
- [x] CI checks green
