### PR TITLE
feat(clients): station count command and optional min-stations healthcheck

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ docker run -d \
 | `CTRL_INTERFACE` | No | Enable hostapd control interface (any non-empty value); allows `clients.sh` to list stations, see [Client Inspection](docs/operations.md#client-inspection-optional) | unset |
 | `CTRL_IFACE_DIR` | No | Control interface socket directory used by `clients.sh` | `/var/run/hostapd` |
 | `HEALTHCHECK_DEEP` | No | Opt-in deep healthcheck verifying the AP is actually beaconing via `hostapd_cli status`; see [Deep Healthcheck](docs/healthcheck.md#deep-healthcheck-optional) | unset |
+| `HEALTHCHECK_MIN_STATIONS` | No | Minimum number of associated stations required by the healthcheck (fails with expected vs actual count below the threshold). Opt-in; requires the control interface (`CTRL_INTERFACE` or `HEALTHCHECK_DEEP`). Note the DFS/CAC caveat in [docs/healthcheck.md](docs/healthcheck.md) | unset |
 | `HEALTHCHECK_STARTED_FILE` | No | Path to the file where the entrypoint records the container start time used by the healthcheck grace period (internal/testing hook) | `/run/hostap-started` |
 
 Detailed topics and examples are split across the [docs/](docs/INDEX.md) folder: radio/security topics in [docs/configuration.md](docs/configuration.md), config validation in [docs/validation.md](docs/validation.md), and runtime diagnostics in [docs/operations.md](docs/operations.md).

--- a/clients.sh
+++ b/clients.sh
@@ -3,12 +3,13 @@
 # Client management via hostapd_cli.
 #   clients.sh              list all associated stations (all_sta)
 #   clients.sh --json       list stations as a JSON array
+#   clients.sh count        print the number of associated stations
 #   clients.sh deauth <mac> deauthenticate a station
 # Requires CTRL_INTERFACE=1 so hostapd.conf exposes ctrl_interface.
 set -euo pipefail
 
 usage() {
-    echo "Usage: clients.sh [--json] [deauth <mac>]" >&2
+    echo "Usage: clients.sh [--json] [count] [deauth <mac>]" >&2
 }
 
 # Emit a JSON array of station objects parsed from hostapd_cli all_sta output.
@@ -50,6 +51,14 @@ emit_json() {
     printf ']\n'
 }
 
+# Count associated stations: number of MAC-address lines in all_sta output
+# (same parsing pattern as emit_json, which treats non-key=value lines as
+# station blocks starting with the MAC).
+station_count() {
+    hostapd_cli -p "${CTRL_IFACE_DIR}" -i "${INTERFACE}" all_sta \
+        | grep -cE '^([0-9a-fA-F]{2}:){5}' || true
+}
+
 if [[ -z "${INTERFACE:-}" ]] ; then
     echo "[Error] INTERFACE must be set." >&2
     exit 1
@@ -71,6 +80,9 @@ case "${CMD}" in
         ;;
     --json)
         emit_json
+        ;;
+    count)
+        station_count
         ;;
     deauth)
         if [[ $# -ne 2 ]] ; then

--- a/docs/healthcheck.md
+++ b/docs/healthcheck.md
@@ -32,8 +32,20 @@ docker run ... -e HEALTHCHECK_DEEP=1 -e HEALTHCHECK_START_PERIOD=90 ...
 
 Note: enabling [`CTRL_INTERFACE`](operations.md#client-inspection-optional) already emits the same config lines, so the two options are compatible - either one suffices for `hostapd_cli` to work.
 
+## Minimum Stations Check (optional)
+
+An AP that beacons and reports `state=ENABLED` may still accept no associations. Set `HEALTHCHECK_MIN_STATIONS=N` to opt in to a station-count check:
+
+```bash
+docker run ... -e CTRL_INTERFACE=1 -e HEALTHCHECK_MIN_STATIONS=1 ...
+```
+
+When enabled, after all other checks (and only once the grace period has elapsed), `healthcheck.sh` counts associated stations via `hostapd_cli all_sta` - the same count printed by [`clients.sh count`](operations.md#client-inspection-optional) - and fails with a message naming the expected vs actual count if fewer than `N` stations are connected, marking the container `unhealthy`. The check is skipped when the control interface socket directory does not exist.
+
+**DFS/CAC caveat**: the same [DFS](https://en.wikipedia.org/wiki/Dynamic_frequency_selection) caveat as the deep check applies here - on radar channels stations cannot join until beaconing starts after Channel Availability Check (CAC), which can take 60s+. Raise `HEALTHCHECK_START_PERIOD` accordingly or the min-stations check will fail during CAC even on a healthy AP.
+
 See also: [regional channel validation](configuration.md#regional-channel-validation) for which 5 GHz channels are [DFS](https://en.wikipedia.org/wiki/Dynamic_frequency_selection) and trigger CAC.
 
 ---
 
-_Last updated: 2026-08-24_
+_Last updated: 2026-08-25_

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -30,6 +30,14 @@ Example output:
 [{"mac":"aa:bb:cc:dd:ee:ff","aid":"1","signal":"-45","connected_time":"120"}]
 ```
 
+For a quick machine-friendly count of associated stations, use the `count` subcommand:
+
+```bash
+docker exec rpi-hostap clients.sh count
+```
+
+It prints a single integer (the number of station MAC blocks in `hostapd_cli all_sta` output), suitable for scripting and monitoring.
+
 To deauthenticate a specific station, pass its MAC address as a `deauth` subcommand:
 
 ```bash
@@ -42,4 +50,4 @@ See also: the [deep healthcheck](healthcheck.md#deep-healthcheck-optional) uses 
 
 ---
 
-_Last updated: 2026-08-24_
+_Last updated: 2026-08-25_

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -73,4 +73,23 @@ if [[ -n "${HEALTHCHECK_DEEP:-}" ]]; then
     fi
 fi
 
+# Optional station-count check: fail when fewer than HEALTHCHECK_MIN_STATIONS
+# stations are associated. Opt-in (unset = disabled). Requires the control
+# interface to exist (enabled via CTRL_INTERFACE or HEALTHCHECK_DEEP).
+# Note: on DFS channels stations cannot join until beaconing starts after CAC;
+# raise HEALTHCHECK_START_PERIOD accordingly (see docs/healthcheck.md).
+MIN_STATIONS="${HEALTHCHECK_MIN_STATIONS-}"
+if [[ -n "${MIN_STATIONS}" ]]; then
+    if ! [[ "${MIN_STATIONS}" =~ ^[0-9]+$ ]]; then
+        echo "[Warning] Invalid HEALTHCHECK_MIN_STATIONS '${MIN_STATIONS}', disabling check" >&2
+    elif [[ -d "${CTRL_IFACE_DIR:-/var/run/hostapd}" ]]; then
+        STATION_COUNT="$(hostapd_cli -p "${CTRL_IFACE_DIR:-/var/run/hostapd}" -i "${INTERFACE}" all_sta 2>/dev/null \
+            | grep -cE '^([0-9a-fA-F]{2}:){5}' || true)"
+        if (( STATION_COUNT < MIN_STATIONS )); then
+            echo "station count below minimum: expected at least ${MIN_STATIONS}, got ${STATION_COUNT}" >&2
+            exit 1
+        fi
+    fi
+fi
+
 exit 0

--- a/tests/clients.bats
+++ b/tests/clients.bats
@@ -148,3 +148,49 @@ EOF
     [ "$output" = "[]" ]
 }
 
+@test "count prints number of station MAC blocks" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    cat > "${BATS_TEST_TMPDIR}/hostapd_cli" <<'EOF'
+#!/bin/bash
+cat <<'STA'
+aa:bb:cc:dd:ee:ff
+aid=1
+signal=-45
+
+11:22:33:44:55:66
+aid=2
+
+AA:BB:CC:DD:EE:F0
+aid=3
+STA
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/hostapd_cli"
+    run "${BATS_TEST_DIRNAME}/../clients.sh" count
+    [ "$status" -eq 0 ]
+    [ "$output" = "3" ]
+}
+
+@test "count prints 0 when no stations are associated" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    printf '#!/bin/bash\nexit 0\n' > "${BATS_TEST_TMPDIR}/hostapd_cli"
+    chmod +x "${BATS_TEST_TMPDIR}/hostapd_cli"
+    run "${BATS_TEST_DIRNAME}/../clients.sh" count
+    [ "$status" -eq 0 ]
+    [ "$output" = "0" ]
+}
+
+@test "count does not count key=value lines as stations" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    printf '#!/bin/bash\nprintf "aid=1\\nsignal=-45\\nconnected_time=10\\n"\n' > "${BATS_TEST_TMPDIR}/hostapd_cli"
+    chmod +x "${BATS_TEST_TMPDIR}/hostapd_cli"
+    run "${BATS_TEST_DIRNAME}/../clients.sh" count
+    [ "$status" -eq 0 ]
+    [ "$output" = "0" ]
+}
+

--- a/tests/healthcheck.bats
+++ b/tests/healthcheck.bats
@@ -248,3 +248,74 @@ EOF
     run ./healthcheck.sh
     [ "$status" -eq 0 ]
 }
+
+@test "min-stations check is skipped when HEALTHCHECK_MIN_STATIONS is unset" {
+    unset HEALTHCHECK_MIN_STATIONS
+    mock_bin pidof 'exit 0'
+    mock_bin ip 'if [ "$1" = "link" ]; then echo "state UP"; fi; exit 0'
+    mock_bin hostapd_cli 'exit 1'
+    run ./healthcheck.sh
+    [ "$status" -eq 0 ]
+}
+
+@test "min-stations passes when count meets threshold (issue #234)" {
+    export HEALTHCHECK_MIN_STATIONS=2
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    mkdir -p "${CTRL_IFACE_DIR}"
+    mock_bin pidof 'exit 0'
+    mock_bin ip 'if [ "$1" = "link" ]; then echo "state UP"; fi; exit 0'
+    cat > "$BATS_TEST_TMPDIR/bin/hostapd_cli" <<'EOF'
+#!/bin/bash
+if [ "$5" = "all_sta" ]; then printf 'aa:bb:cc:dd:ee:01\naid=1\n\naa:bb:cc:dd:ee:02\naid=2\n'; exit 0; fi
+echo "state=ENABLED"
+EOF
+    chmod +x "$BATS_TEST_TMPDIR/bin/hostapd_cli"
+    run ./healthcheck.sh
+    [ "$status" -eq 0 ]
+}
+
+@test "min-stations fails below threshold naming expected vs actual (issue #234)" {
+    export HEALTHCHECK_MIN_STATIONS=3
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    mkdir -p "${CTRL_IFACE_DIR}"
+    mock_bin pidof 'exit 0'
+    mock_bin ip 'if [ "$1" = "link" ]; then echo "state UP"; fi; exit 0'
+    cat > "$BATS_TEST_TMPDIR/bin/hostapd_cli" <<'EOF'
+#!/bin/bash
+if [ "$5" = "all_sta" ]; then printf 'aa:bb:cc:dd:ee:01\naid=1\n'; exit 0; fi
+echo "state=ENABLED"
+EOF
+    chmod +x "$BATS_TEST_TMPDIR/bin/hostapd_cli"
+    run ./healthcheck.sh
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"expected at least 3"* ]]
+    [[ "$output" == *"got 1"* ]]
+}
+
+@test "min-stations is skipped when control interface dir does not exist" {
+    export HEALTHCHECK_MIN_STATIONS=1
+    mock_bin pidof 'exit 0'
+    mock_bin ip 'if [ "$1" = "link" ]; then echo "state UP"; fi; exit 0'
+    run env CTRL_IFACE_DIR="$BATS_TEST_TMPDIR/no-such-dir" ./healthcheck.sh
+    [ "$status" -eq 0 ]
+}
+
+@test "invalid HEALTHCHECK_MIN_STATIONS warns and disables the check" {
+    export HEALTHCHECK_MIN_STATIONS="abc"
+    mock_bin pidof 'exit 0'
+    mock_bin ip 'if [ "$1" = "link" ]; then echo "state UP"; fi; exit 0'
+    mock_bin hostapd_cli 'exit 1'
+    run ./healthcheck.sh
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[Warning] Invalid HEALTHCHECK_MIN_STATIONS 'abc', disabling check"* ]]
+}
+
+@test "min-stations respects start period grace" {
+    export HEALTHCHECK_MIN_STATIONS=5
+    export NOW_STAMP=1000
+    echo "$((NOW_STAMP - 5))" > "$HEALTHCHECK_STARTED_FILE"
+    export HEALTHCHECK_START_PERIOD=90
+    mock_bin hostapd_cli 'exit 1'
+    run ./healthcheck.sh
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
Closes #234

## Changes

### `clients.sh count` (clients.sh)
- New `count` subcommand prints a single integer: the number of associated stations, parsed as MAC-address blocks from `hostapd_cli all_sta` output using the same MAC-line pattern as `emit_json`.
- Extracted into a reusable `station_count()` function; works alongside the existing plain-list, `--json` and `deauth` subcommands.

### Optional min-stations healthcheck (healthcheck.sh)
- New opt-in `HEALTHCHECK_MIN_STATIONS=N` env var. Unset = disabled; behavior unchanged.
- After the grace period (and after all existing checks), when the control interface directory exists (`CTRL_IFACE_DIR` or default `/var/run/hostapd`), the healthcheck counts stations via `all_sta` and fails below `N` with a message naming expected vs actual count:
  `station count below minimum: expected at least N, got M`
- Non-numeric values warn and disable the check.

### Tests
- `tests/clients.bats`: count with multiple stations (mixed case MACs, blank separators), zero stations, key=value lines not counted.
- `tests/healthcheck.bats`: skipped when unset, passes at threshold, fails below threshold with expected vs actual in message, skipped without ctrl interface dir, invalid value warns/disables, respects start-period grace.

### Docs
- README env table: new `HEALTHCHECK_MIN_STATIONS` row.
- docs/operations.md: `clients.sh count` usage.
- docs/healthcheck.md: new "Minimum Stations Check" section incl. DFS/CAC caveat (stations cannot join until beaconing starts; raise `HEALTHCHECK_START_PERIOD`).

## Verification
- Full local suite green: `bats tests/` - 372 tests pass.
