### PR TITLE
feat(secrets): add secret-file inputs for SSID and WPA_PASSPHRASE

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,9 @@ docker run -d \
 |:--------:|:--------:|:-----------:|:-------:|
 | `INTERFACE` | Yes | Wireless interface to use | - |
 | `SSID` | No | Network name | `raspberry` |
+| `SSID_FILE` | No | Path to a file whose first line holds the SSID (Docker secrets `_FILE` convention). Overrides `SSID` when both are set. See [Secret-file inputs](docs/configuration.md#secret-file-inputs-optional) | unset |
 | `WPA_PASSPHRASE` | No | WiFi password (8-63 characters; newlines and control characters are rejected) | `passw0rd` |
+| `WPA_PASSPHRASE_FILE` | No | Path to a file whose first line holds the WPA passphrase (Docker secrets `_FILE` convention). Overrides `WPA_PASSPHRASE` when both are set. See [Secret-file inputs](docs/configuration.md#secret-file-inputs-optional) | unset |
 | `CHANNEL` | No | WiFi channel, or `acs` for automatic channel selection (requires driver support; startup may be delayed while scanning, and the `HEALTHCHECK_START_PERIOD` grace period applies since ACS can land on DFS/radar channels) | `11` |
 | `AP_ADDR` | No | Access point IP | `192.168.254.1` |
 | `SUBNET` | No | Network subnet | `192.168.254.0` |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,6 +110,30 @@ aa:bb:cc:dd:ee:ff
 
 See also: [client inspection](operations.md#client-inspection-optional) - use `clients.sh` to list associated stations and verify the filter allows/blocks the expected MACs.
 
+## Secret-File Inputs (optional)
+
+`SSID` and `WPA_PASSPHRASE` are normally passed with `docker run -e`, which makes them visible via `docker inspect` and shell history. Both support the `_FILE` convention (as used by Docker secrets, e.g. `docker secret` / Swarm / `docker compose` `secrets:`):
+
+- `SSID_FILE`: path to a file whose **first line** holds the SSID
+- `WPA_PASSPHRASE_FILE`: path to a file whose **first line** holds the passphrase
+
+```bash
+docker run -d --name hostap \
+  --privileged --net host \
+  -v /run/secrets:/run/secrets:ro \
+  -e INTERFACE=wlan0 \
+  -e SSID_FILE=/run/secrets/ssid \
+  -e WPA_PASSPHRASE_FILE=/run/secrets/wpa_passphrase \
+  sdelrio/rpi-hostap
+```
+
+Behavior:
+
+- Only the first line of the file is used; a trailing newline is stripped.
+- Values loaded from files go through the same validation as direct values (`validate_ssid`, `validate_passphrase`).
+- If both `VAR` and `VAR_FILE` are set, the `_FILE` value wins and a warning is printed to stderr.
+- Startup fails with `[Error] <VAR>_FILE '...' is not readable` if the file is missing or unreadable.
+
 ## WPA3 (SAE)
 
 ### WPA3-Only (`WPA_VERSION=3`)

--- a/lib/secret_file.sh
+++ b/lib/secret_file.sh
@@ -1,0 +1,27 @@
+# shellcheck shell=bash
+# Secret-file inputs for SSID and WPA_PASSPHRASE (issue #232).
+#
+# Docker secrets and similar mechanisms mount sensitive values as files,
+# so passing SSID/WPA_PASSPHRASE via -e exposes them in `docker inspect`.
+# The _FILE convention lets users point at a file whose first line holds
+# the value; the file path is the only thing visible in the environment.
+#
+# Precedence: when both VAR and VAR_FILE are set, the file wins and a
+# warning is emitted so misconfigurations are not silently ignored.
+
+load_from_file() {
+    local var=$1 file_var=$2
+    local f="${!file_var:-}"
+    [ -z "${f}" ] && return 0
+
+    if [ -n "${!var:-}" ] ; then
+        echo "[Warning] Both ${var} and ${file_var} are set; using value from ${file_var}." >&2
+    fi
+
+    if [ ! -r "${f}" ] ; then
+        echo "[Error] ${file_var} '${f}' is not readable" >&2
+        return 1
+    fi
+
+    printf -v "${var}" '%s' "$(head -n1 "${f}")"
+}

--- a/tests/secret_file.bats
+++ b/tests/secret_file.bats
@@ -1,0 +1,90 @@
+#!/usr/bin/env bats
+
+# Tests exercise load_from_file() from lib/secret_file.sh - the exact
+# code used by wlanstart.sh (no duplicated logic).
+
+setup() {
+    unset SSID SSID_FILE WPA_PASSPHRASE WPA_PASSPHRASE_FILE
+    SECRET_FILE="${BATS_TEST_TMPDIR}/secret.txt"
+}
+
+load_lib() {
+    . "${BATS_TEST_DIRNAME}/../lib/secret_file.sh"
+}
+
+@test "SSID_FILE loads value from first line of file" {
+    load_lib
+    printf 'myssid\notherline\n' > "${SECRET_FILE}"
+    SSID_FILE="${SECRET_FILE}"
+    load_from_file SSID SSID_FILE
+    [ "${SSID}" = "myssid" ]
+}
+
+@test "WPA_PASSPHRASE_FILE loads passphrase from file" {
+    load_lib
+    printf 'sup3rs3cret\n' > "${SECRET_FILE}"
+    WPA_PASSPHRASE_FILE="${SECRET_FILE}"
+    load_from_file WPA_PASSPHRASE WPA_PASSPHRASE_FILE
+    [ "${WPA_PASSPHRASE}" = "sup3rs3cret" ]
+}
+
+@test "_FILE wins when both direct var and _FILE are set" {
+    load_lib
+    printf 'fromfile\n' > "${SECRET_FILE}"
+    SSID=direct
+    SSID_FILE="${SECRET_FILE}"
+    load_from_file SSID SSID_FILE 2> "${BATS_TEST_TMPDIR}/stderr"
+    [ "${SSID}" = "fromfile" ]
+    grep -q "using value from SSID_FILE" "${BATS_TEST_TMPDIR}/stderr"
+}
+
+@test "warning is emitted when both var and _FILE are set" {
+    load_lib
+    printf 'fromfile\n' > "${SECRET_FILE}"
+    WPA_PASSPHRASE=direct
+    WPA_PASSPHRASE_FILE="${SECRET_FILE}"
+    run load_from_file WPA_PASSPHRASE WPA_PASSPHRASE_FILE
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[Warning] Both WPA_PASSPHRASE and WPA_PASSPHRASE_FILE are set"* ]]
+}
+
+@test "unset _FILE variable leaves target unchanged" {
+    load_lib
+    SSID=direct
+    unset SSID_FILE
+    run load_from_file SSID SSID_FILE
+    [ "$status" -eq 0 ]
+    [ "${SSID}" = "direct" ]
+}
+
+@test "missing file fails with clear error" {
+    load_lib
+    SSID_FILE="${BATS_TEST_TMPDIR}/does-not-exist"
+    run load_from_file SSID SSID_FILE
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"[Error] SSID_FILE '${BATS_TEST_TMPDIR}/does-not-exist' is not readable"* ]]
+}
+
+@test "unreadable file fails with clear error" {
+    load_lib
+    printf 'secret\n' > "${SECRET_FILE}"
+    chmod 000 "${SECRET_FILE}"
+    if [ -r "${SECRET_FILE}" ] ; then
+        skip "cannot make file unreadable (running as root)"
+    fi
+    WPA_PASSPHRASE_FILE="${SECRET_FILE}"
+    run load_from_file WPA_PASSPHRASE WPA_PASSPHRASE_FILE
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"is not readable"* ]]
+}
+
+@test "value loaded from file passes existing validation" {
+    load_lib
+    . "${BATS_TEST_DIRNAME}/../lib/passphrase.sh"
+    printf 'passw0rd-from-file\n' > "${SECRET_FILE}"
+    WPA_PASSPHRASE_FILE="${SECRET_FILE}"
+    load_from_file WPA_PASSPHRASE WPA_PASSPHRASE_FILE
+    [ "${WPA_PASSPHRASE}" = "passw0rd-from-file" ]
+    run validate_passphrase
+    [ "$status" -eq 0 ]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -97,6 +97,13 @@ fi
 . "$(dirname "$0")/lib/env.sh"
 resolve_config_env
 
+# Secret-file inputs for SSID/WPA_PASSPHRASE (_FILE convention, issue #232)
+# Logic lives in lib/secret_file.sh, shared with tests
+# shellcheck source=lib/secret_file.sh
+. "$(dirname "$0")/lib/secret_file.sh"
+load_from_file SSID SSID_FILE || exit 1
+load_from_file WPA_PASSPHRASE WPA_PASSPHRASE_FILE || exit 1
+
 # Validate channel against regulatory domain and hardware mode
 # Logic lives in lib/channel.sh, shared with tests
 # shellcheck source=lib/channel.sh


### PR DESCRIPTION
## Summary

Adds Docker-secrets-style `_FILE` inputs for the AP credentials, so `SSID` and `WPA_PASSPHRASE` no longer need to be passed via `-e` (where they are visible in `docker inspect`, `docker ps` and shell history).

Closes #232

## Changes

- New `lib/secret_file.sh` with `load_from_file()`: reads the first line of a file (trailing newline stripped) into the target variable. Follows the existing lib/ module convention shared with tests.
- `wlanstart.sh` sources it right after `resolve_config_env()` and applies:
  - `load_from_file SSID SSID_FILE`
  - `load_from_file WPA_PASSPHRASE WPA_PASSPHRASE_FILE`
- If both `VAR` and `VAR_FILE` are set, `_FILE` wins and a warning is emitted to stderr.
- Missing/unreadable files produce `[Error] <VAR>_FILE '<path>' is not readable` and abort startup.
- Values loaded from files pass through the existing `validate_ssid` / `validate_passphrase` unchanged.

## Docs

- README.md: added `SSID_FILE` / `WPA_PASSPHRASE_FILE` rows to the environment variable table.
- docs/configuration.md: new "Secret-File Inputs (optional)" section with usage example and behavior notes.

## Tests

New `tests/secret_file.bats` covering:

- SSID_FILE and WPA_PASSPHRASE_FILE load from the first line
- `_FILE` takes precedence over the direct variable, with warning
- Unset `_FILE` leaves the direct variable untouched
- Clear error for missing file; clear error for unreadable file (mode 000, skipped when running as root)
- File-loaded passphrase passes existing validation

Local: full suite green (`bats tests/`, 380 tests).
