### PR TITLE
docs: document failure-log env vars in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,9 @@ docker run -d \
 | `HEALTHCHECK_DEEP` | No | Opt-in deep healthcheck verifying the AP is actually beaconing via `hostapd_cli status`; see [Deep Healthcheck](docs/healthcheck.md#deep-healthcheck-optional) | unset |
 | `HEALTHCHECK_MIN_STATIONS` | No | Minimum number of associated stations required by the healthcheck (fails with expected vs actual count below the threshold). Opt-in; requires the control interface (`CTRL_INTERFACE` or `HEALTHCHECK_DEEP`). Note the DFS/CAC caveat in [docs/healthcheck.md](docs/healthcheck.md) | unset |
 | `HEALTHCHECK_STARTED_FILE` | No | Path to the file where the entrypoint records the container start time used by the healthcheck grace period (internal/testing hook) | `/run/hostap-started` |
+| `FAILURE_LOG_DIR` | No | Directory where daemon logs are preserved on crash; see [Preserved failure logs](docs/troubleshooting.md#preserved-failure-logs) | `/var/log/hostap-failures` |
+| `FAILURE_LOG_KEEP` | No | Number of crash logs retained (oldest pruned); see [Preserved failure logs](docs/troubleshooting.md#preserved-failure-logs) | `5` |
+| `FAILURE_LOG_PATH` | No | Explicit path for the preserved log (overrides dir/keep, no rotation); see [Preserved failure logs](docs/troubleshooting.md#preserved-failure-logs) | unset |
 
 Detailed topics and examples are split across the [docs/](docs/INDEX.md) folder: radio/security topics in [docs/configuration.md](docs/configuration.md), config validation in [docs/validation.md](docs/validation.md), and runtime diagnostics in [docs/operations.md](docs/operations.md).
 


### PR DESCRIPTION
## Summary

Adds the three failure-log environment variables (`FAILURE_LOG_DIR`, `FAILURE_LOG_KEEP`, `FAILURE_LOG_PATH`) to the README env var table, matching existing style. Defaults verified against `lib/logging.sh` (dir `/var/log/hostap-failures`, keep `5`, path unset). Each row cross-links to the [Preserved failure logs](docs/troubleshooting.md) section, which already documents these variables.

Closes #230
