### PR TITLE
docs(healthcheck): clarify Docker start-period vs HEALTHCHECK_START_PERIOD

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ docker run -d \
 | `VHT_ENABLED` | No | Enable 802.11ac Very High Throughput (`ieee80211ac=1`); requires 5 GHz (`HW_MODE=a`) | unset |
 | `VHT_CAPAB` | No | 802.11ac capabilities string (`vht_capab=` in hostapd.conf); requires `VHT_ENABLED` | unset |
 | `HOSTAPD_EXTRA_OPTS` | No | Extra hostapd.conf lines, newline-separated, appended verbatim after all generated lines. Unvalidated: invalid values surface as hostapd config errors in logs (e.g. `"auth_algs=3\nbeacon_int=100"`) | unset |
-| `HEALTHCHECK_START_PERIOD` | No | Grace period (seconds) after container start during which the healthcheck always passes. Measured from the container's own recorded start time (`/run/hostap-started`), not host uptime; see [Health Check](docs/healthcheck.md) | `15` |
+| `HEALTHCHECK_START_PERIOD` | No | Grace period (seconds) after container start during which the healthcheck always passes. Measured from the container's own recorded start time (`/run/hostap-started`), not host uptime; see [Health Check](docs/healthcheck.md) and [Script grace vs Docker start-period](docs/healthcheck.md#script-grace-vs-docker-start-period) | `15` |
 | `CTRL_INTERFACE` | No | Enable hostapd control interface (any non-empty value); allows `clients.sh` to list stations, see [Client Inspection](docs/operations.md#client-inspection-optional) | unset |
 | `CTRL_IFACE_DIR` | No | Control interface socket directory used by `clients.sh` | `/var/run/hostapd` |
 | `HEALTHCHECK_DEEP` | No | Opt-in deep healthcheck verifying the AP is actually beaconing via `hostapd_cli status`; see [Deep Healthcheck](docs/healthcheck.md#deep-healthcheck-optional) | unset |

--- a/docs/healthcheck.md
+++ b/docs/healthcheck.md
@@ -12,7 +12,25 @@ The container defines a Docker `HEALTHCHECK` that runs `/bin/healthcheck.sh` eve
 
 If any check fails, the container is reported as `unhealthy`.
 
-**Script grace vs Docker start-period**: there are two independent grace mechanisms. `HEALTHCHECK_START_PERIOD` (env var) controls the *script-side* grace window measured from the recorded start time. The Dockerfile's `HEALTHCHECK --start-period=15s` is the Docker-side outer bound during which failing checks do not count towards the `unhealthy` transition. If you raise the env var (e.g. `HEALTHCHECK_START_PERIOD=60`), the script keeps passing for 60s after start regardless of the Docker setting; the Dockerfile start-period only affects when Docker itself starts counting failures.
+## Script grace vs Docker start-period
+
+There are two independent grace mechanisms. `HEALTHCHECK_START_PERIOD` (env var) controls the *script-side* grace window measured from the recorded start time. The Dockerfile's `HEALTHCHECK --start-period=15s` is the Docker-side outer bound during which failing checks do not count towards the `unhealthy` transition. If you raise the env var (e.g. `HEALTHCHECK_START_PERIOD=60`), the script keeps passing for 60s after start regardless of the Docker setting; the Dockerfile start-period only affects when Docker itself starts counting failures.
+
+**Why `--start-period` cannot be set via env var**: `HEALTHCHECK` instructions are evaluated at image build time and their flags (`--interval`, `--retries`, `--start-period`) do not expand runtime environment variables - there is no shell involved in parsing them. Writing something like `HEALTHCHECK --start-period=${HEALTHCHECK_START_PERIOD}s CMD ...` would pass the literal string `${...}` to the Docker engine and fail validation. Only the `CMD` payload runs at container runtime (and only via the shell if `CMD-SHELL` form is used), which is why this image parameterizes the *script-side* grace period instead: the script can read `$HEALTHCHECK_START_PERIOD`, but Docker's own knobs stay baked into the image.
+
+**Overriding interval/retries/start-period**: users who need different Docker-level values can override the whole healthcheck without rebuilding, e.g. with a `docker-compose.override.yml`:
+
+```yaml
+services:
+  hostapd:
+    healthcheck:
+      test: ["CMD", "/bin/healthcheck.sh"]
+      interval: 30s
+      retries: 3
+      start_period: 90s
+```
+
+This replaces the image's `HEALTHCHECK` block entirely - useful for [DFS channels](#deep-healthcheck-optional), where CAC wait times exceed the default start period.
 
 ## Deep Healthcheck (optional)
 
@@ -48,4 +66,4 @@ See also: [regional channel validation](configuration.md#regional-channel-valida
 
 ---
 
-_Last updated: 2026-08-25_
+_Last updated: 2026-08-26_


### PR DESCRIPTION
## Summary

Completes #229 (docs-writing task).

- `docs/healthcheck.md`: promote the "Script grace vs Docker start-period" paragraph to a section and extend it with:
  - why the Docker-level `--start-period` cannot be parameterized via env var in a plain Dockerfile (`HEALTHCHECK` flags are evaluated at build time, no shell/env expansion),
  - a `docker-compose.override.yml` example overriding `interval` / `retries` / `start_period`, with a DFS/CAC cross-reference.
- `README.md`: `HEALTHCHECK_START_PERIOD` table row now links directly to the new [Script grace vs Docker start-period](docs/healthcheck.md#script-grace-vs-docker-start-period) section, matching how other rows reference docs.

Closes #229
