### PR TITLE
fix: strengthen privileged-mode check beyond /sys writability

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -124,8 +124,9 @@ It runs on Alpine Linux for minimal footprint.
 
 - The container requires `--privileged` and `--net host`: it must manipulate
   host wireless interfaces, write sysctls and manage iptables/nftables rules.
-- Normal mode verifies privileged access at startup (writability of `/sys`)
-  and exits with an error otherwise.
+- Normal mode verifies privileged access at startup by probing
+  `iptables -t nat -L` (requires `CAP_NET_ADMIN`, which unprivileged
+  containers lack) and exits with an error otherwise.
 - Host prerequisites (documented in README): AP-mode capable adapter with host
   driver/firmware installed, `iw reg set` country code, and wpa_supplicant
   disabled to avoid driver conflicts.

--- a/tests/privileged_check.bats
+++ b/tests/privileged_check.bats
@@ -1,0 +1,37 @@
+#!/usr/bin/env bats
+
+# Tests for the iptables-based privileged-mode check (issue #228)
+
+SCRIPT="${BATS_TEST_DIRNAME}/../wlanstart.sh"
+
+setup() {
+    STUBDIR="${BATS_TEST_TMPDIR}/iptables-stubs"
+    mkdir -p "${STUBDIR}"
+}
+
+make_iptables_stub() {
+    printf '#!/bin/bash\n%b\n' "$1" > "${STUBDIR}/iptables"
+    chmod +x "${STUBDIR}/iptables"
+}
+
+@test "unprivileged mode (iptables probe fails) aborts before interface check" {
+    make_iptables_stub 'exit 3'
+    run bash -c "IPTABLES_BASE='${STUBDIR}/iptables' '${SCRIPT}' </dev/null 2>&1"
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Not running in privileged mode (cannot access iptables)."* ]]
+    [[ "$output" != *"An interface must be specified."* ]]
+}
+
+@test "privileged mode (iptables probe succeeds) passes the check" {
+    make_iptables_stub 'exit 0'
+    run bash -c "PATH='${STUBDIR}:/usr/bin:/bin' IPTABLES_BASE='${STUBDIR}/iptables' '${SCRIPT}' </dev/null 2>&1"
+    [[ "$output" != *"Not running in privileged mode"* ]]
+    # Proceeds past the check far enough to hit the next validator
+    [[ "$output" == *"An interface must be specified."* ]]
+}
+
+@test "--validate bypasses the iptables privileged-mode check" {
+    make_iptables_stub 'exit 3'
+    run bash -c "IPTABLES_BASE='${STUBDIR}/iptables' '${SCRIPT}' --validate </dev/null 2>&1"
+    [[ "$output" != *"Not running in privileged mode"* ]]
+}

--- a/tests/validate_mode.bats
+++ b/tests/validate_mode.bats
@@ -46,10 +46,10 @@ run_validate() {
     [[ "$output" != *"must not be called in validate mode"* ]]
 }
 
-@test "--validate bypasses privileged mode check (no /sys writability error)" {
+@test "--validate bypasses privileged mode check (no iptables probe error)" {
     run run_validate INTERFACE=wlan0 SSID=x WPA_PASSPHRASE=supersecret
     [ "$status" -eq 0 ]
-    [[ "$output" != *"Not running in privileged mode."* ]]
+    [[ "$output" != *"Not running in privileged mode"* ]]
 }
 
 @test "--validate rejects missing INTERFACE" {

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -78,9 +78,12 @@ if [ "${VALIDATE_ONLY}" != "1" ] ; then
     # period from the actual start (not host uptime via /proc/uptime).
     date +%s > /run/hostap-started 2>/dev/null || true
 
-    # Check if running in privileged mode
-    if [ ! -w "/sys" ] ; then
-        echo "[Error] Not running in privileged mode."
+    # Check if running in privileged mode. An iptables listing requires
+    # CAP_NET_ADMIN, which unprivileged containers lack and read-only /sys
+    # mounts do not affect. IPTABLES_BASE is overridable for tests.
+    IPTABLES_BASE="${IPTABLES_BASE:-iptables}"
+    if ! "${IPTABLES_BASE}" -t nat -L > /dev/null 2>&1 ; then
+        echo "[Error] Not running in privileged mode (cannot access iptables)." >&2
         exit 1
     fi
 


### PR DESCRIPTION
## Summary

Replace the privileged-mode check in `wlanstart.sh` (previously `[ ! -w /sys ]`) with an `iptables -t nat -L` probe.

- `/sys` writability was an unreliable proxy: false positives in unprivileged containers with writable /sys, false negatives with read-only /sys mounts.
- The iptables probe requires `CAP_NET_ADMIN`, which unprivileged containers lack, and is unaffected by /sys mount flags.
- Probe command overridable via `IPTABLES_BASE` (defaults to `iptables`), following the existing `SYSCTL_BASE` pattern in `lib/nat.sh`, for bats testing.
- Error message updated to be actionable: "[Error] Not running in privileged mode (cannot access iptables)."
- SPEC.md section 3.2 parenthetical updated to describe the new mechanism.
- New tests/privileged_check.bats: unprivileged rejection, privileged pass, --validate bypass. Updated tests/validate_mode.bats assertion for the new message.
- `--validate` mode still bypasses the check entirely.

Closes #228

## Test plan

- [x] Local full bats suite: 386/386 green
- [x] shellcheck clean on wlanstart.sh (only pre-existing SC1091 info notes)
- [x] CI checks pass
