### PR TITLE
feat(nat): validate OUTGOINGS interfaces exist before applying rules

### DIFF
--- a/lib/ipv6.sh
+++ b/lib/ipv6.sh
@@ -33,7 +33,7 @@ enable_ipv6_forwarding() {
 apply_ipv6_rules() {
     if [ "${OUTGOINGS}" ] ; then
         local int
-        parse_outgoings
+        validate_outgoings || return 1
         for int in "${ints[@]}" ; do
             ip6tables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
             ip6tables -A FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT

--- a/lib/nat.sh
+++ b/lib/nat.sh
@@ -13,11 +13,33 @@ parse_outgoings() {
     done
 }
 
+# IP_BASE can be overridden in tests to point at a stubbed ip tool
+# (e.g. when validating OUTGOINGS interfaces without real network tools).
+IP_BASE="${IP_BASE:-ip}"
+
+# interface_exists returns 0 when the given network interface exists.
+interface_exists() {
+    "${IP_BASE}" link show "$1" > /dev/null 2>&1
+}
+
+# validate_outgoings checks every parsed OUTGOINGS interface exists,
+# failing fast with an error naming the offending interface.
+validate_outgoings() {
+    local int
+    parse_outgoings
+    for int in "${ints[@]}" ; do
+        if ! interface_exists "${int}" ; then
+            echo "[Error] OUTGOINGS interface '${int}' does not exist" >&2
+            return 1
+        fi
+    done
+}
+
 # apply_nat_rules adds iptables MASQUERADE/FORWARD rules for outgoing traffic.
 apply_nat_rules() {
     if [ "${OUTGOINGS}" ] ; then
         local int
-        parse_outgoings
+        validate_outgoings || return 1
         for int in "${ints[@]}"
         do
             echo "Setting iptables for outgoing traffics on ${int}..."

--- a/tests/ipv6.bats
+++ b/tests/ipv6.bats
@@ -34,12 +34,22 @@ setup() {
     IPV6=1
     OUTGOINGS="eth0,eth1"
     parse_outgoings() { ints=("eth0" "eth1"); }
+    interface_exists() { return 0; }
     ip6tables() { echo "ip6tables $*"; }
     parse_outgoings
     run apply_ipv6_rules
     [ "$status" -eq 0 ]
     [[ "${output}" == *"ip6tables -A FORWARD -i eth0 -o wlan0"* ]]
     [[ "${output}" == *"ip6tables -A FORWARD -i wlan0 -o eth1"* ]]
+}
+
+@test "apply_ipv6_rules fails fast naming nonexistent OUTGOINGS interface" {
+    IPV6=1
+    OUTGOINGS="bogus9"
+    ip6tables() { echo "ip6tables $*"; }
+    run apply_ipv6_rules
+    [ "$status" -eq 1 ]
+    [[ "${output}" == *"[Error] OUTGOINGS interface 'bogus9' does not exist"* ]]
 }
 
 @test "apply_ipv6_rules without OUTGOINGS uses generic rules" {
@@ -79,6 +89,7 @@ setup() {
 @test "apply_ipv6_rules works standalone with OUTGOINGS (no nat.sh loaded)" {
     run bash -c '
         ip6tables() { echo "ip6tables $*" >&2; }
+        ip() { return 0; }
         . "'"${REPO_ROOT}"'/lib/ipv6.sh"
         INTERFACE="wlan0" OUTGOINGS="eth0,eth1" apply_ipv6_rules
     '

--- a/tests/nat.bats
+++ b/tests/nat.bats
@@ -30,6 +30,7 @@ setup() {
 
 @test "apply_nat_rules adds rules per interface with OUTGOINGS" {
     export OUTGOINGS="eth0,eth1"
+    ip() { return 0; }
     parse_outgoings
     iptables() { echo "iptables $*"; }
     run apply_nat_rules
@@ -49,6 +50,32 @@ setup() {
     [[ "${output}" == *"iptables -t nat -A POSTROUTING -s 192.168.254.0/24 -j MASQUERADE"* ]]
     [[ "${output}" == *"iptables -A FORWARD -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT"* ]]
     [[ "${output}" == *"iptables -A FORWARD -i wlan0 -j ACCEPT"* ]]
+}
+
+@test "apply_nat_rules fails fast naming nonexistent OUTGOINGS interface" {
+    export OUTGOINGS="eth0,doesnotexist0"
+    iptables() { echo "iptables $*"; }
+    run apply_nat_rules
+    [ "$status" -eq 1 ]
+    [[ "${output}" == *"[Error] OUTGOINGS interface 'doesnotexist0' does not exist"* ]]
+    [[ "${output}" != *"Setting iptables"* ]]
+}
+
+@test "apply_nat_rules proceeds when all OUTGOINGS interfaces exist (stubbed ip)" {
+    export OUTGOINGS="eth0"
+    ip() { return 0; }
+    iptables() { echo "iptables $*"; }
+    run apply_nat_rules
+    [ "$status" -eq 0 ]
+    [[ "${output}" == *"Setting iptables for outgoing traffics on eth0..."* ]]
+}
+
+@test "validate_outgoings fails for missing interface without real network tools" {
+    export OUTGOINGS="bogus9"
+    export IP_BASE="${BATS_TEST_TMPDIR}/no-ip"
+    run validate_outgoings
+    [ "$status" -eq 1 ]
+    [[ "${output}" == *"[Error] OUTGOINGS interface 'bogus9' does not exist"* ]]
 }
 
 @test "apply_nat_rules removes stale rule before adding (delete precedes append)" {


### PR DESCRIPTION
## Summary

Fixes #227

- Add `IP_BASE` overridable command variable and `interface_exists` / `validate_outgoings` helpers in `lib/nat.sh`, following the existing `SYSCTL_BASE` pattern
- `apply_nat_rules` now validates every OUTGOINGS interface before installing iptables rules, failing fast with `[Error] OUTGOINGS interface '<int>' does not exist`
- `apply_ipv6_rules` in `lib/ipv6.sh` gets the same validation for consistency
- `remove_nat_rules` behavior unchanged (removal is best-effort by design)
- Tests: new cases in `tests/nat.bats` (nonexistent interface fails fast with named error; existing interfaces proceed via stubbed `ip`; `validate_outgoings` testable without real network tools) and `tests/ipv6.bats` (fail-fast + stubbed success cases)

## Test results

- Full local bats suite: all green (no failures)
- `shellcheck lib/nat.sh lib/ipv6.sh`: clean
