### PR TITLE
chore(nat): replace deprecated iptables -m state with conntrack

### DIFF
--- a/lib/ipv6.sh
+++ b/lib/ipv6.sh
@@ -35,15 +35,15 @@ apply_ipv6_rules() {
         local int
         validate_outgoings || return 1
         for int in "${ints[@]}" ; do
-            ip6tables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
-            ip6tables -A FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT
+            ip6tables -D FORWARD -i "${int}" -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+            ip6tables -A FORWARD -i "${int}" -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 
             ip6tables -D FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT > /dev/null 2>&1 || true
             ip6tables -A FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT
         done
     else
-        ip6tables -D FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
-        ip6tables -A FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT
+        ip6tables -D FORWARD -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+        ip6tables -A FORWARD -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 
         ip6tables -D FORWARD -i "${INTERFACE}" -j ACCEPT > /dev/null 2>&1 || true
         ip6tables -A FORWARD -i "${INTERFACE}" -j ACCEPT
@@ -56,11 +56,11 @@ remove_ipv6_rules() {
         local int
         parse_outgoings
         for int in "${ints[@]}" ; do
-            ip6tables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+            ip6tables -D FORWARD -i "${int}" -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
             ip6tables -D FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT > /dev/null 2>&1 || true
         done
     else
-        ip6tables -D FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+        ip6tables -D FORWARD -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
         ip6tables -D FORWARD -i "${INTERFACE}" -j ACCEPT > /dev/null 2>&1 || true
     fi
 }

--- a/lib/nat.sh
+++ b/lib/nat.sh
@@ -47,8 +47,8 @@ apply_nat_rules() {
             iptables -t nat -D POSTROUTING -s "${SUBNET}/${DHCP_PREFIX:-24}" -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
             iptables -t nat -A POSTROUTING -s "${SUBNET}/${DHCP_PREFIX:-24}" -o "${int}" -j MASQUERADE
 
-            iptables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
-            iptables -A FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT
+            iptables -D FORWARD -i "${int}" -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+            iptables -A FORWARD -i "${int}" -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 
             iptables -D FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT > /dev/null 2>&1 || true
             iptables -A FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT
@@ -59,8 +59,8 @@ apply_nat_rules() {
         iptables -t nat -D POSTROUTING -s "${SUBNET}/${DHCP_PREFIX:-24}" -j MASQUERADE > /dev/null 2>&1 || true
         iptables -t nat -A POSTROUTING -s "${SUBNET}/${DHCP_PREFIX:-24}" -j MASQUERADE
 
-        iptables -D FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
-        iptables -A FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT
+        iptables -D FORWARD -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+        iptables -A FORWARD -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
 
         iptables -D FORWARD -i "${INTERFACE}" -j ACCEPT > /dev/null 2>&1 || true
         iptables -A FORWARD -i "${INTERFACE}" -j ACCEPT
@@ -103,13 +103,13 @@ remove_nat_rules() {
         for int in "${ints[@]}" ; do
             echo "Removing iptables for outgoing traffics on ${int}..."
             iptables -t nat -D POSTROUTING -s "${SUBNET}/${DHCP_PREFIX:-24}" -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true
-            iptables -D FORWARD -i "${int}" -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+            iptables -D FORWARD -i "${int}" -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
             iptables -D FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT > /dev/null 2>&1 || true
         done
     else
         echo "Removing iptables for outgoing traffics on all interfaces..."
         iptables -t nat -D POSTROUTING -s "${SUBNET}/${DHCP_PREFIX:-24}" -j MASQUERADE > /dev/null 2>&1 || true
-        iptables -D FORWARD -o "${INTERFACE}" -m state --state RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
+        iptables -D FORWARD -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
         iptables -D FORWARD -i "${INTERFACE}" -j ACCEPT > /dev/null 2>&1 || true
     fi
 }

--- a/tests/cleanup.bats
+++ b/tests/cleanup.bats
@@ -129,7 +129,7 @@ handle_signal
 @test "cleanup removes iptables rules without OUTGOINGS" {
     run run_cleanup_mocked
     [[ "$output" == *"iptables -t nat -D POSTROUTING -s 192.168.254.0/24 -j MASQUERADE"* ]]
-    [[ "$output" == *"iptables -D FORWARD -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT"* ]]
+    [[ "$output" == *"iptables -D FORWARD -o wlan0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT"* ]]
     [[ "$output" == *"iptables -D FORWARD -i wlan0 -j ACCEPT"* ]]
 }
 
@@ -137,7 +137,7 @@ handle_signal
     export OUTGOINGS="eth0"
     run run_cleanup_mocked
     [[ "$output" == *"iptables -t nat -D POSTROUTING -s 192.168.254.0/24 -o eth0 -j MASQUERADE"* ]]
-    [[ "$output" == *"iptables -D FORWARD -i eth0 -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT"* ]]
+    [[ "$output" == *"iptables -D FORWARD -i eth0 -o wlan0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT"* ]]
     [[ "$output" == *"iptables -D FORWARD -i wlan0 -o eth0 -j ACCEPT"* ]]
 }
 

--- a/tests/ipv6.bats
+++ b/tests/ipv6.bats
@@ -58,7 +58,7 @@ setup() {
     run apply_ipv6_rules
     [ "$status" -eq 0 ]
     [[ "${output}" == *"ip6tables -A FORWARD -i wlan0 -j ACCEPT"* ]]
-    [[ "${output}" == *"-o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT"* ]]
+    [[ "${output}" == *"-o wlan0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT"* ]]
 }
 
 @test "remove_ipv6_rules deletes generic rules" {
@@ -83,7 +83,7 @@ setup() {
     '
     [ "$status" -eq 0 ]
     grep -q -- "-D FORWARD -i wlan0 -o eth0 -j ACCEPT" "${log}"
-    grep -q -- "-D FORWARD -i eth1 -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT" "${log}"
+    grep -q -- "-D FORWARD -i eth1 -o wlan0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT" "${log}"
 }
 
 @test "apply_ipv6_rules works standalone with OUTGOINGS (no nat.sh loaded)" {

--- a/tests/nat.bats
+++ b/tests/nat.bats
@@ -38,7 +38,7 @@ setup() {
     [[ "${output}" == *"Setting iptables for outgoing traffics on eth0..."* ]]
     [[ "${output}" == *"iptables -t nat -A POSTROUTING -s 192.168.254.0/24 -o eth0 -j MASQUERADE"* ]]
     [[ "${output}" == *"iptables -t nat -A POSTROUTING -s 192.168.254.0/24 -o eth1 -j MASQUERADE"* ]]
-    [[ "${output}" == *"iptables -A FORWARD -i eth0 -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT"* ]]
+    [[ "${output}" == *"iptables -A FORWARD -i eth0 -o wlan0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT"* ]]
     [[ "${output}" == *"iptables -A FORWARD -i wlan0 -o eth1 -j ACCEPT"* ]]
 }
 
@@ -48,7 +48,7 @@ setup() {
     [ "$status" -eq 0 ]
     [[ "${output}" == *"Setting iptables for outgoing traffics on all interfaces..."* ]]
     [[ "${output}" == *"iptables -t nat -A POSTROUTING -s 192.168.254.0/24 -j MASQUERADE"* ]]
-    [[ "${output}" == *"iptables -A FORWARD -o wlan0 -m state --state RELATED,ESTABLISHED -j ACCEPT"* ]]
+    [[ "${output}" == *"iptables -A FORWARD -o wlan0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT"* ]]
     [[ "${output}" == *"iptables -A FORWARD -i wlan0 -j ACCEPT"* ]]
 }
 


### PR DESCRIPTION
# Replace deprecated iptables -m state with conntrack

Closes #226

The `state` match is a legacy compatibility alias for `conntrack`. This PR replaces every occurrence of `-m state --state` with `-m conntrack --ctstate`.

## Changes
- `lib/nat.sh`: updated both `-A` and paired `-D` FORWARD rules (per-interface and generic paths) in `apply_nat_rules` and `remove_nat_rules`
- `lib/ipv6.sh`: same replacement for `ip6tables` rules in `apply_ipv6_rules` and `remove_ipv6_rules`
- `tests/nat.bats`, `tests/ipv6.bats`, `tests/cleanup.bats`: assertions updated to the new syntax

Deletion rules were kept in sync with additions so teardown stays idempotent.

## Testing
- Full local bats suite passes: 390/390
- No remaining `-m state` uses in the repo (verified by grep)
