### PR TITLE
fix(ipv6): handle sysctl failure in enable_ipv6_forwarding gracefully

### DIFF
--- a/lib/ipv6.sh
+++ b/lib/ipv6.sh
@@ -23,9 +23,14 @@ compute_dnsmasq_ipv6_conf() {
     echo "dhcp-range=::,constructor:${INTERFACE},ra-names,stateless"
 }
 
-# enable_ipv6_forwarding sets the forwarding sysctl via /proc.
+# enable_ipv6_forwarding sets the forwarding sysctl via /proc, tolerating
+# missing entries. IPV6_SYSCTL_BASE can be overridden in tests to point at
+# a stubbed procfs tree.
+IPV6_SYSCTL_BASE="${IPV6_SYSCTL_BASE:-/proc/sys/net/ipv6}"
+
 enable_ipv6_forwarding() {
-    echo 1 > /proc/sys/net/ipv6/conf/all/forwarding
+    echo 1 > "${IPV6_SYSCTL_BASE}/conf/all/forwarding" 2>/dev/null \
+        || echo "[Warning] Cannot set net.ipv6.conf.all.forwarding" >&2
 }
 
 # apply_ipv6_rules adds ip6tables FORWARD rules mirroring the IPv4 ones.

--- a/tests/ipv6.bats
+++ b/tests/ipv6.bats
@@ -97,3 +97,19 @@ setup() {
     [[ "${output}" == *"ip6tables -A FORWARD -i eth0 -o wlan0"* ]]
     [[ "${output}" == *"ip6tables -A FORWARD -i wlan0 -o eth1 -j ACCEPT"* ]]
 }
+
+@test "enable_ipv6_forwarding writes 1 to forwarding sysctl" {
+    local base="${BATS_TEST_TMPDIR}/sysctl-ok/net/ipv6"
+    mkdir -p "${base}/conf/all"
+    IPV6_SYSCTL_BASE="${base}"
+    run enable_ipv6_forwarding
+    [ "$status" -eq 0 ]
+    [ "$(cat "${base}/conf/all/forwarding")" = "1" ]
+}
+
+@test "enable_ipv6_forwarding warns on missing sysctl without aborting" {
+    IPV6_SYSCTL_BASE="${BATS_TEST_TMPDIR}/nonexistent-ipv6-sysctl"
+    run enable_ipv6_forwarding
+    [ "$status" -eq 0 ]
+    [[ "${output}" == *"[Warning] Cannot set net.ipv6.conf.all.forwarding"* ]]
+}


### PR DESCRIPTION
## Summary

- `enable_ipv6_forwarding()` in `lib/ipv6.sh` now tolerates a missing/unwritable sysctl: it suppresses the raw shell redirection error and prints `[Warning] Cannot set net.ipv6.conf.all.forwarding` to stderr instead of aborting startup (mirrors the `set_sysctls` pattern in `lib/nat.sh`).
- Added overridable `IPV6_SYSCTL_BASE` (defaults to `/proc/sys/net/ipv6`) so tests can point at a stubbed procfs tree, like `SYSCTL_BASE` in nat.
- New bats tests: success path writes `1` to the stubbed forwarding sysctl; missing sysctl yields the clear warning with exit status 0.

Fixes #225

## Test results

- `bats tests/ipv6.bats`: 11/11 pass (2 new)
- Full suite `bats tests/`: 392/392 pass
