### PR TITLE
refactor: compute DHCP range once per startup to avoid duplicate warnings

### DIFF
--- a/tests/dhcp_range.bats
+++ b/tests/dhcp_range.bats
@@ -377,3 +377,27 @@ setup() {
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"AP_ADDR '10.0.0.1' is not inside SUBNET 192.168.0.0/16"* ]]
 }
+
+@test "default-range warning appears once when emit_dnsmasq_conf reuses computed range (#224)" {
+    # shellcheck disable=SC2016
+    run bash -c '
+        . "'"${REPO_ROOT}"'/lib/env.sh"
+        . "'"${REPO_ROOT}"'/lib/dhcp.sh"
+        wlanstart="'"${REPO_ROOT}"'/wlanstart.sh"
+        # Extract emit_dnsmasq_conf from wlanstart.sh (same pattern as
+        # tests/atomic_config.bats)
+        eval "$(sed -n "/^emit_dnsmasq_conf()/,/^}/p" "${wlanstart}")"
+        SUBNET="192.168.254.0" AP_ADDR="192.168.254.1" INTERFACE="wlan0"
+        PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
+        resolve_config_env
+        # Startup path: compute once, reuse in emit_dnsmasq_conf
+        DHCP_RANGE_COMPUTED=$(compute_dhcp_range 2> "'"${BATS_TEST_TMPDIR}"'/err1") || exit 1
+        export DHCP_RANGE_COMPUTED
+        emit_dnsmasq_conf > /dev/null 2> "'"${BATS_TEST_TMPDIR}"'/err2"
+    '
+    [ "$status" -eq 0 ]
+    local err1="${BATS_TEST_TMPDIR}/err1" err2="${BATS_TEST_TMPDIR}/err2"
+    grep -q "using default" "${err1}"
+    # emit_dnsmasq_conf must not warn again when the range is reused
+    [ "$(grep -c "using default" "${err2}")" = "0" ]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -212,7 +212,14 @@ EOF
 # Emit dnsmasq.conf to stdout from the current environment.
 emit_dnsmasq_conf() {
     local dhcp_range ipv6_conf=""
-    dhcp_range=$(compute_dhcp_range) || return 1
+    # Reuse the range computed at startup (DHCP_RANGE_COMPUTED) when
+    # available so compute_dhcp_range (and its warnings) runs only once;
+    # validation mode and tests without it still compute on demand.
+    if [ -n "${DHCP_RANGE_COMPUTED:-}" ] ; then
+        dhcp_range=${DHCP_RANGE_COMPUTED}
+    else
+        dhcp_range=$(compute_dhcp_range) || return 1
+    fi
     if [ "${IPV6:-0}" = "1" ] ; then
         ipv6_conf=$(compute_dnsmasq_ipv6_conf)
     fi
@@ -313,8 +320,11 @@ validate_ipv4_param PRI_DNS "${PRI_DNS}" || exit 1
 validate_ipv4_param SEC_DNS "${SEC_DNS}" || exit 1
 
 # Compute DHCP range early so the netmask-derived prefix (DHCP_PREFIX)
-# is available for setup_interface and apply_nat_rules.
-compute_dhcp_range > /dev/null || exit 1
+# is available for setup_interface and apply_nat_rules, and so the
+# computed range (and its warnings) is produced exactly once per startup;
+# emit_dnsmasq_conf reuses it below (#224).
+DHCP_RANGE_COMPUTED=$(compute_dhcp_range) || exit 1
+export DHCP_RANGE_COMPUTED
 
 # Always regenerate hostapd.conf so env var changes apply between runs.
 # Generated atomically so a failure leaves the old config intact (#157).


### PR DESCRIPTION
## Summary

`compute_dhcp_range` was invoked twice per normal startup: once at `wlanstart.sh:317` (to derive `DHCP_PREFIX`) and again inside `emit_dnsmasq_conf` when the dnsmasq config was written. This duplicated validation work and caused the default-range warning (`[Warning] DHCP_RANGE not set, using default: ...`) to print twice.

### Changes

- Normal startup now computes the range once into an exported variable:
  `DHCP_RANGE_COMPUTED=$(compute_dhcp_range) || exit 1`
- `emit_dnsmasq_conf` reuses `DHCP_RANGE_COMPUTED` when set, and still falls back to calling `compute_dhcp_range` itself so `run_validation_mode` (`--validate`) and direct callers behave exactly as before.
- No changes to `lib/dhcp.sh`; function semantics are untouched.

### Test results

- New bats test in `tests/dhcp_range.bats`: default-range warning appears from the startup compute, and `emit_dnsmasq_conf` emits no warning when reusing the computed range.
- Full suite: 393/393 green.

Closes #224
