### PR TITLE
fix(dhcp): add bind-dynamic to dnsmasq.conf to avoid host DHCP conflicts

### DIFF
--- a/tests/dhcp_range.bats
+++ b/tests/dhcp_range.bats
@@ -378,6 +378,26 @@ setup() {
     [[ "${lines[*]}" == *"AP_ADDR '10.0.0.1' is not inside SUBNET 192.168.0.0/16"* ]]
 }
 
+@test "generated dnsmasq.conf binds to AP interface only (#223)" {
+    # shellcheck disable=SC2016
+    run bash -c '
+        . "'"${REPO_ROOT}"'/lib/env.sh"
+        . "'"${REPO_ROOT}"'/lib/dhcp.sh"
+        wlanstart="'"${REPO_ROOT}"'/wlanstart.sh"
+        eval "$(sed -n "/^emit_dnsmasq_conf()/,/^}/p" "${wlanstart}")"
+        SUBNET="192.168.254.0" AP_ADDR="192.168.254.1" INTERFACE="wlan0"
+        PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
+        resolve_config_env
+        DHCP_RANGE_COMPUTED=$(compute_dhcp_range) || exit 1
+        export DHCP_RANGE_COMPUTED
+        emit_dnsmasq_conf
+    '
+    [ "$status" -eq 0 ]
+    [[ "${output}" == *'interface=wlan0'* ]]
+    [[ "${output}" == *'bind-dynamic'* ]]
+    [[ "${output}" == *'dhcp-authoritative'* ]]
+}
+
 @test "default-range warning appears once when emit_dnsmasq_conf reuses computed range (#224)" {
     # shellcheck disable=SC2016
     run bash -c '

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -226,6 +226,8 @@ emit_dnsmasq_conf() {
 
     cat <<EOF
 interface=${INTERFACE}
+bind-dynamic
+dhcp-authoritative
 dhcp-range=${dhcp_range}
 dhcp-option=option:router,${AP_ADDR}
 dhcp-option=option:dns-server,${PRI_DNS},${SEC_DNS}


### PR DESCRIPTION
## Summary

Fixes #223.

When run under `--net host`, dnsmasq previously bound ports 67/53 on all
interfaces, conflicting with host-side DHCP/DNS services (dnsmasq,
NetworkManager, systemd-resolved).

`emit_dnsmasq_conf` in `wlanstart.sh` now emits:

- `bind-dynamic`: restricts serving to the configured `interface=${INTERFACE}`
  while tolerating interface churn
- `dhcp-authoritative`: makes the AP DHCP server authoritative on its subnet

The existing `interface=${INTERFACE}` directive is retained, which gives
`bind-dynamic` effect.

## Test plan

- New bats test in `tests/dhcp_range.bats` asserts the generated config
  contains `interface=wlan0`, `bind-dynamic`, and `dhcp-authoritative`.
- Full local bats suite passes (394 tests).
