### PR TITLE
fix(channel): normalize COUNTRY_CODE / HW_MODE case before validation

### DIFF
--- a/lib/channel.sh
+++ b/lib/channel.sh
@@ -6,6 +6,11 @@
 # #237) and returns non-zero when the channel is not allowed.
 # Messages go to stderr.
 validate_channel() {
+    # Normalize case so lowercase country codes and uppercase hw_mode
+    # values are validated correctly instead of falling through (issue #222).
+    COUNTRY_CODE="$(printf '%s' "${COUNTRY_CODE:-}" | tr '[:lower:]' '[:upper:]')"
+    HW_MODE="$(printf '%s' "${HW_MODE:-}" | tr '[:upper:]' '[:lower:]')"
+
     # Automatic channel selection: skip numeric checks, driver decides.
     case "${HW_MODE}:${CHANNEL}" in
         *:[aA][cC][sS])
@@ -74,6 +79,7 @@ validate_channel() {
 # VHT (802.11ac) requires 5 GHz operation.
 # Reads VHT_ENABLED and HW_MODE from the environment.
 validate_vht() {
+    HW_MODE="$(printf '%s' "${HW_MODE:-}" | tr '[:upper:]' '[:lower:]')"
     if [ -n "${VHT_ENABLED:-}" ] && [ "${HW_MODE}" != "a" ] ; then
         echo "[Error] VHT_ENABLED requires HW_MODE=a (5 GHz)." >&2
         return 1

--- a/tests/channel_validation.bats
+++ b/tests/channel_validation.bats
@@ -237,6 +237,63 @@ setup() {
     grep -qx 'channel=acs' <<< "$output"
 }
 
+# --- case normalization (issue #222) ---
+
+@test "lowercase country code 'us' limits channel to 11" {
+    COUNTRY_CODE="us"
+    HW_MODE="g"
+    CHANNEL="12"
+    run validate_channel
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"country US"* ]]
+}
+
+@test "lowercase country code 'jp' allows channel 14 with hw_mode=b" {
+    COUNTRY_CODE="jp"
+    HW_MODE="b"
+    CHANNEL="14"
+    run validate_channel
+    [ "$status" -eq 0 ]
+}
+
+@test "uppercase hw_mode 'G' validates like 'g'" {
+    HW_MODE="G"
+    CHANNEL="1"
+    run validate_channel_strict
+    [ "$status" -eq 0 ]
+}
+
+@test "uppercase hw_mode 'A' validates like 'a'" {
+    HW_MODE="A"
+    CHANNEL="36"
+    run validate_channel_strict
+    [ "$status" -eq 0 ]
+}
+
+@test "uppercase hw_mode 'B' allows JP channel 14" {
+    COUNTRY_CODE="JP"
+    HW_MODE="B"
+    CHANNEL="14"
+    run validate_channel_strict
+    [ "$status" -eq 0 ]
+}
+
+@test "VHT_ENABLED set with uppercase HW_MODE=A passes" {
+    HW_MODE="A"
+    VHT_ENABLED="1"
+    run validate_vht
+    [ "$status" -eq 0 ]
+}
+
+@test "validate_channel normalizes env for generated hostapd.conf" {
+    COUNTRY_CODE="us"
+    HW_MODE="G"
+    CHANNEL="6"
+    validate_channel || exit 1
+    [ "${HW_MODE}" = "g" ]
+    [ "${COUNTRY_CODE}" = "US" ]
+}
+
 # --- non-numeric channel ---
 
 @test "non-numeric channel with hw_mode=g fails" {


### PR DESCRIPTION
## Summary

Fixes #222

- `validate_channel` and `validate_vht` now normalize `COUNTRY_CODE` to uppercase and `HW_MODE` to lowercase before validation, so lowercase country codes (`us`) no longer silently fall into the ETSI branch and uppercase hw_mode values (`G`, `A`, `B`) validate like their lowercase forms.
- Normalization uses `tr` (portable with bash 3.2) instead of `${var^^}` parameter expansion.
- Since the validators mutate the environment in place and are called before config generation, the generated `hostapd.conf` uses the normalized values.
- Added 7 new bats tests covering lowercase country codes, uppercase hw_mode values, VHT with uppercase HW_MODE, and env normalization for config generation.

## Test results

- Full local suite: 401/401 passing
- shellcheck: clean on modified files

## CI

- To be confirmed via `gh pr checks`.
