### PR TITLE
fix(channel): validate 5 GHz channels against COUNTRY_CODE

### DIFF
--- a/lib/channel.sh
+++ b/lib/channel.sh
@@ -55,7 +55,18 @@ validate_channel() {
                 return 1
             fi
             case "${CHANNEL}" in
-                36|40|44|48|149|153|157|161|165)
+                36|40|44|48)
+                    ;;
+                149|153|157|161|165)
+                    # U-NII-3 high band is not legal in ETSI regions; only
+                    # allow it for countries where it is permitted (issue #221).
+                    case "${COUNTRY_CODE}" in
+                        US|CA|MX|JP) ;;
+                        *)
+                            echo "[Error] Channel ${CHANNEL} not allowed for country ${COUNTRY_CODE} (channels 149-165 require US/CA/MX/JP)" >&2
+                            return 1
+                            ;;
+                    esac
                     ;;
                 52|56|60|64|100|104|108|112|116|120|124|128|132|136|140|144)
                     if [ "${_DFS_WARNED:-0}" -eq 0 ]; then

--- a/tests/channel_validation.bats
+++ b/tests/channel_validation.bats
@@ -76,13 +76,47 @@ setup() {
 
 # --- a mode (5 GHz) ---
 
-@test "hw_mode=a with all non-DFS channels passes" {
+@test "hw_mode=a with non-DFS low band channels passes (any country)" {
     HW_MODE="a"
-    for ch in 36 40 44 48 149 153 157 161 165; do
+    for ch in 36 40 44 48; do
         CHANNEL="${ch}"
         run validate_channel
         [ "$status" -eq 0 ]
     done
+}
+
+@test "hw_mode=a with high band channels 149-165 passes in US/CA/MX/JP" {
+    HW_MODE="a"
+    for cc in US CA MX JP us ca mx jp; do
+        COUNTRY_CODE="${cc}"
+        for ch in 149 153 157 161 165; do
+            CHANNEL="${ch}"
+            run validate_channel
+            [ "$status" -eq 0 ]
+        done
+    done
+}
+
+@test "hw_mode=a rejects channel 149-165 in ETSI countries (issue #221)" {
+    HW_MODE="a"
+    for pair in "EU EU" "ES ES" "eu EU" "es ES" "ZZ ZZ"; do
+        set -- ${pair}
+        COUNTRY_CODE="$1"
+        for ch in 149 153 157 161 165; do
+            CHANNEL="${ch}"
+            run validate_channel
+            [ "$status" -eq 1 ]
+            [[ "$output" == *"Error"*"Channel ${ch} not allowed for country $2"* ]]
+        done
+    done
+}
+
+@test "hw_mode=a rejects channel 149 without COUNTRY_CODE (EU fallback)" {
+    HW_MODE="a"
+    CHANNEL="149"
+    run validate_channel
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error"*"not allowed for country"* ]]
 }
 
 @test "hw_mode=a with DFS channel 52 warns but passes" {

--- a/tests/validate_mode.bats
+++ b/tests/validate_mode.bats
@@ -65,6 +65,19 @@ run_validate() {
     [[ "$output" != *"=== /etc/hostapd.conf ==="* ]]
 }
 
+@test "--validate rejects channel 149 in ETSI region (issue #221)" {
+    run run_validate INTERFACE=wlan0 HW_MODE=a CHANNEL=149 COUNTRY_CODE=EU SSID=x WPA_PASSPHRASE=supersecret
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Channel 149 not allowed for country EU"* ]]
+    [[ "$output" != *"=== /etc/hostapd.conf ==="* ]]
+}
+
+@test "--validate accepts channel 149 in US (issue #221)" {
+    run run_validate INTERFACE=wlan0 HW_MODE=a CHANNEL=149 COUNTRY_CODE=US SSID=x WPA_PASSPHRASE=supersecret
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"=== /etc/hostapd.conf ==="* ]]
+}
+
 @test "--validate rejects short passphrase" {
     run run_validate INTERFACE=wlan0 WPA_PASSPHRASE=short SSID=x
     [ "$status" -ne 0 ]


### PR DESCRIPTION
## Summary

Fixes #221.

`validate_channel` in `lib/channel.sh` accepted any channel in the hardcoded
5 GHz non-DFS list for `HW_MODE=a`, regardless of `COUNTRY_CODE`. With
`COUNTRY_CODE=EU`, channels 149-165 (U-NII-3) are illegal in ETSI regions but
were silently accepted.

### Changes

- `lib/channel.sh`: channels 149/153/157/161/165 are now only allowed for
  `US|CA|MX|JP`; other country codes get an error. DFS channels remain
  warning-only, unchanged.
- Compares against the uppercase-normalized `COUNTRY_CODE` (issue #222
  normalization), so lowercase codes like `eu` are rejected too.
- Missing/unrecognized country codes fall back to the EU default and are
  rejected for these channels.

### Tests (`tests/channel_validation.bats`, `tests/validate_mode.bats`)

- ch. 149-165 rejected for EU/ES (and lowercase variants, unknown ZZ)
- ch. 149-165 accepted for US/CA/MX/JP (upper and lower case)
- ch. 36-48 still pass in any country; DFS behavior unchanged (warning only)
- `--validate` mode reflects the new errors: rejects ch. 149 with EU,
  accepts with US

Full local suite: 406 tests passing.
