### PR TITLE
fix(wpa): emit ieee80211w PMF for WPA3-SAE and mixed mode

### DIFF
--- a/lib/wpa.sh
+++ b/lib/wpa.sh
@@ -7,6 +7,7 @@
 compute_wpa_conf() {
     # Defaults (WPA_VERSION, HW_MODE, WPA_PASSPHRASE) are applied
     # centrally by lib/env.sh (issue #237).
+    _PMF=""
     case "${WPA_VERSION}" in
         2)
             _WPA_LEVEL="wpa=2"
@@ -25,9 +26,11 @@ rsn_pairwise=CCMP"
             if [ "${WPA_VERSION}" = "3" ] ; then
                 echo "[Info] WPA3-SAE enabled. Requires client devices with SAE support (wpa_supplicant 2.7+)." >&2
                 _WPA_KEY_MGMT="wpa_key_mgmt=SAE"
+                _PMF="ieee80211w=2"
             else
                 echo "[Info] WPA2/WPA3 transition mode enabled. Legacy WPA2 clients allowed alongside SAE." >&2
                 _WPA_KEY_MGMT="wpa_key_mgmt=WPA-PSK SAE"
+                _PMF="ieee80211w=1"
                 _WPA_PAIRWISE="wpa_pairwise=CCMP
 ${_WPA_PAIRWISE}"
             fi
@@ -37,8 +40,11 @@ ${_WPA_PAIRWISE}"
             return 1
             ;;
     esac
+    _PMF_LINE=""
+    [ -n "${_PMF}" ] && _PMF_LINE="
+${_PMF}"
     echo "${_WPA_LEVEL}
 wpa_passphrase=${WPA_PASSPHRASE}
-${_WPA_KEY_MGMT}
+${_WPA_KEY_MGMT}${_PMF_LINE}
 ${_WPA_PAIRWISE}"
 }

--- a/tests/wpa_version.bats
+++ b/tests/wpa_version.bats
@@ -36,6 +36,7 @@ load_lib() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"wpa=3"* ]]
     [[ "$output" == *"wpa_key_mgmt=SAE"* ]]
+    [[ "$output" == *"ieee80211w=2"* ]]
     [[ "$output" == *"rsn_pairwise=CCMP"* ]]
 }
 
@@ -54,6 +55,7 @@ load_lib() {
     [ "$status" -eq 0 ]
     [[ "$output" == *"wpa=3"* ]]
     [[ "$output" == *"wpa_key_mgmt=WPA-PSK SAE"* ]]
+    [[ "$output" == *"ieee80211w=1"* ]]
     [[ "$output" == *"wpa_pairwise=CCMP"* ]]
     [[ "$output" == *"rsn_pairwise=CCMP"* ]]
 }
@@ -74,6 +76,14 @@ load_lib() {
     run compute_wpa_conf
     [ "$status" -eq 0 ]
     [[ "$output" != *"hw_mode=b"* ]]
+}
+
+@test "WPA_VERSION=2 does not include ieee80211w" {
+    load_lib
+    WPA_VERSION=2
+    run compute_wpa_conf
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"ieee80211w"* ]]
 }
 
 @test "invalid WPA_VERSION fails with error" {


### PR DESCRIPTION
## Summary

WPA3-SAE requires Protected Management Frames (PMF), but `compute_wpa_conf` emitted `wpa_key_mgmt=SAE` without ever setting `ieee80211w`, producing an invalid WPA3 configuration.

Fix in `lib/wpa.sh`:
- `WPA_VERSION=3`: emit `ieee80211w=2` (PMF required)
- `WPA_VERSION=mixed`: emit `ieee80211w=1` (PMF optional, transition mode)
- `WPA_VERSION=2`: output unchanged, no `ieee80211w` line

The PMF line is only appended when non-empty.

Closes #220

## Test results

- Updated `tests/wpa_version.bats`:
  - WPA3 asserts `ieee80211w=2`
  - mixed asserts `ieee80211w=1`
  - new test: WPA_VERSION=2 produces no `ieee80211w`
- Full bats suite: 407/407 passing
- shellcheck clean
