### PR TITLE
refactor: deduplicate env plumbing shared by clients.sh and healthcheck.sh

### DIFF
--- a/clients.sh
+++ b/clients.sh
@@ -8,6 +8,10 @@
 # Requires CTRL_INTERFACE=1 so hostapd.conf exposes ctrl_interface.
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/client_env.sh
+source "${SCRIPT_DIR}/lib/client_env.sh"
+
 usage() {
     echo "Usage: clients.sh [--json] [count] [deauth <mac>]" >&2
 }
@@ -59,18 +63,8 @@ station_count() {
         | grep -cE '^([0-9a-fA-F]{2}:){5}' || true
 }
 
-if [[ -z "${INTERFACE:-}" ]] ; then
-    echo "[Error] INTERFACE must be set." >&2
-    exit 1
-fi
-
-CTRL_IFACE_DIR="${CTRL_IFACE_DIR:-/var/run/hostapd}"
-
-if [[ ! -d "${CTRL_IFACE_DIR}" ]] ; then
-    echo "[Error] Control interface not available at ${CTRL_IFACE_DIR}." >&2
-    echo "Restart the container with -e CTRL_INTERFACE=1 to enable it." >&2
-    exit 1
-fi
+require_interface
+require_ctrl_interface
 
 CMD="${1:-}"
 

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=lib/client_env.sh
+source "${SCRIPT_DIR}/lib/client_env.sh"
+
 # Health check script for rpi-hostap container
 # Checks if hostapd, dnsmasq are running and the interface is up
 
@@ -88,8 +92,8 @@ MIN_STATIONS="${HEALTHCHECK_MIN_STATIONS-}"
 if [[ -n "${MIN_STATIONS}" ]]; then
     if ! [[ "${MIN_STATIONS}" =~ ^[0-9]+$ ]]; then
         echo "[Warning] Invalid HEALTHCHECK_MIN_STATIONS '${MIN_STATIONS}', disabling check" >&2
-    elif [[ -d "${CTRL_IFACE_DIR:-/var/run/hostapd}" ]]; then
-        STATION_COUNT="$(hostapd_cli -p "${CTRL_IFACE_DIR:-/var/run/hostapd}" -i "${INTERFACE}" all_sta 2>/dev/null \
+    elif resolve_ctrl_iface_dir && [[ -d "${CTRL_IFACE_DIR}" ]]; then
+        STATION_COUNT="$(hostapd_cli -p "${CTRL_IFACE_DIR}" -i "${INTERFACE}" all_sta 2>/dev/null \
             | grep -cE '^([0-9a-fA-F]{2}:){5}' || true)"
         if (( STATION_COUNT < MIN_STATIONS )); then
             echo "station count below minimum: expected at least ${MIN_STATIONS}, got ${STATION_COUNT}" >&2

--- a/lib/client_env.sh
+++ b/lib/client_env.sh
@@ -1,0 +1,27 @@
+# shellcheck shell=bash
+# Shared env plumbing for scripts driving hostapd_cli (clients.sh,
+# healthcheck.sh). Issue #243: single implementation of INTERFACE /
+# CTRL_IFACE_DIR handling so behavior and error messages stay identical.
+
+# Fail with the canonical error when INTERFACE is unset or empty.
+require_interface() {
+    if [[ -z "${INTERFACE:-}" ]] ; then
+        echo "[Error] INTERFACE must be set." >&2
+        exit 1
+    fi
+}
+
+# Apply the default control-interface directory when CTRL_IFACE_DIR is unset.
+resolve_ctrl_iface_dir() {
+    CTRL_IFACE_DIR="${CTRL_IFACE_DIR:-/var/run/hostapd}"
+}
+
+# Fail when the resolved control interface directory does not exist.
+require_ctrl_interface() {
+    resolve_ctrl_iface_dir
+    if [[ ! -d "${CTRL_IFACE_DIR}" ]] ; then
+        echo "[Error] Control interface not available at ${CTRL_IFACE_DIR}." >&2
+        echo "Restart the container with -e CTRL_INTERFACE=1 to enable it." >&2
+        exit 1
+    fi
+}

--- a/tests/client_env.bats
+++ b/tests/client_env.bats
@@ -1,0 +1,51 @@
+#!/usr/bin/env bats
+
+# Tests targeting the shared env helpers in lib/client_env.sh (issue #243).
+
+load_client_env() {
+    run bash -c 'set -euo pipefail; source lib/client_env.sh; '"$1"
+}
+
+setup() {
+    unset INTERFACE
+    unset CTRL_IFACE_DIR
+    cd "${BATS_TEST_DIRNAME}/.."
+}
+
+@test "require_interface exits 1 with canonical error when INTERFACE unset" {
+    load_client_env 'require_interface'
+    [ "$status" -eq 1 ]
+    [ "${lines[0]}" = "[Error] INTERFACE must be set." ]
+}
+
+@test "require_interface passes when INTERFACE is set" {
+    load_client_env 'INTERFACE=wlan0; require_interface; echo ok'
+    [ "$status" -eq 0 ]
+    [ "$output" = "ok" ]
+}
+
+@test "resolve_ctrl_iface_dir defaults to /var/run/hostapd" {
+    load_client_env 'resolve_ctrl_iface_dir; echo "$CTRL_IFACE_DIR"'
+    [ "$status" -eq 0 ]
+    [ "$output" = "/var/run/hostapd" ]
+}
+
+@test "resolve_ctrl_iface_dir preserves explicit value" {
+    load_client_env 'CTRL_IFACE_DIR=/custom/dir; resolve_ctrl_iface_dir; echo "$CTRL_IFACE_DIR"'
+    [ "$status" -eq 0 ]
+    [ "$output" = "/custom/dir" ]
+}
+
+@test "require_ctrl_interface errors with actionable hint when dir missing" {
+    load_client_env 'INTERFACE=wlan0; CTRL_IFACE_DIR=/nonexistent/hostapd; require_ctrl_interface'
+    [ "$status" -ne 0 ]
+    [ "${lines[0]}" = "[Error] Control interface not available at /nonexistent/hostapd." ]
+    [ "${lines[1]}" = "Restart the container with -e CTRL_INTERFACE=1 to enable it." ]
+}
+
+@test "require_ctrl_interface succeeds when dir exists and applies default path" {
+    local tmpdir="${BATS_TEST_TMPDIR}/hostapd"
+    mkdir -p "$tmpdir"
+    load_client_env "INTERFACE=wlan0; CTRL_IFACE_DIR=${tmpdir}; require_ctrl_interface && resolve_ctrl_iface_dir; echo \"\$CTRL_IFACE_DIR\""
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Extracts the environment plumbing shared by `clients.sh` and `healthcheck.sh` into a new `lib/client_env.sh` (issue #243):

- `require_interface()` - errors and exits when INTERFACE is unset
- `resolve_ctrl_iface_dir()` - applies the `/var/run/hostapd` default for CTRL_IFACE_DIR
- `require_ctrl_interface()` - verifies the control-interface directory exists with the actionable hint

Both scripts now source the library instead of inlining their own checks. Error messages are byte-identical. healthcheck.sh's deep-check keeps its specific "HEALTHCHECK_DEEP requires INTERFACE" message, and its min-stations check keeps its skip-when-dir-missing behavior while reusing `resolve_ctrl_iface_dir()` to remove the duplicated default.

## Changes

- New: `lib/client_env.sh`
- Modified: `clients.sh`, `healthcheck.sh` - source shared helpers
- New tests: `tests/client_env.bats` targeting the helpers directly

## Testing

- `bats tests/client_env.bats tests/clients.bats tests/healthcheck.bats`: 56/56 pass
- Full suite `bats tests/*.bats`: 415/415 pass

Closes #243
