### PR TITLE
refactor: enforce <module>_<verb> naming convention across lib/

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,10 @@
 
 - Never use the em dash "—". Use plain dash "-" instead.
 
+## Bash Function Naming Convention
+
+All functions in `lib/*.sh` must follow the `<module>_<verb>` convention, where `<module>` is the library filename without `.sh` (e.g. `nat_parse_outgoings`, `ipv6_apply_rules`, `validation_netmask_to_prefix`). Private helpers use a leading underscore plus the module prefix (e.g. `_log_emit`). The bare `log()` function in `lib/log.sh` is an accepted exception since it is the module's own namespace. Entry-point scripts at the repo root (`wlanstart.sh`, `clients.sh`, `healthcheck.sh`) follow the same rule for their helper functions (`clients_emit_json`, `wlanstart_cleanup`); small script-local handlers like `cleanup`, `handle_signal`, and `check_interrupted` are exempt. Do not create name collisions between modules.
+
 ## Temporary Files
 
 Write all temporary files (PR bodies, issue bodies, scratch files, etc.) to `<repo-root>/tmp/`, e.g. `tmp/pr-<slug>.md`. This directory is gitignored; never use `/tmp` or other system paths.

--- a/clients.sh
+++ b/clients.sh
@@ -12,7 +12,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=lib/client_env.sh
 source "${SCRIPT_DIR}/lib/client_env.sh"
 
-usage() {
+clients_show_usage() {
     echo "Usage: clients.sh [--json] [count] [deauth <mac>]" >&2
 }
 
@@ -20,14 +20,14 @@ usage() {
 # Blocks start with the station MAC line, followed by key=value lines. Only a
 # fixed set of well-known fields (aid, signal, connected_time) are exposed as
 # strings; values are escaped conservatively.
-json_escape() {
+clients_json_escape() {
     local s="${1}"
     s="${s//\\/\\\\}"
     s="${s//\"/\\\"}"
     printf '%s' "${s}"
 }
 
-emit_json() {
+clients_emit_json() {
     local line key value in_obj=0 sep=""
     printf '['
     while IFS= read -r line ; do
@@ -38,7 +38,7 @@ emit_json() {
             if [[ ${in_obj} -eq 1 ]] ; then
                 printf '}'
             fi
-            printf '%s{"mac":"%s"' "${sep}" "$(json_escape "${line}")"
+            printf '%s{"mac":"%s"' "${sep}" "$(clients_json_escape "${line}")"
             sep=","
             in_obj=1
         else
@@ -46,7 +46,7 @@ emit_json() {
             value="${line#*=}"
             case "${key}" in
                 aid|signal|connected_time)
-                    printf ',"%s":"%s"' "${key}" "$(json_escape "${value}")"
+                    printf ',"%s":"%s"' "${key}" "$(clients_json_escape "${value}")"
                     ;;
             esac
         fi
@@ -56,15 +56,15 @@ emit_json() {
 }
 
 # Count associated stations: number of MAC-address lines in all_sta output
-# (same parsing pattern as emit_json, which treats non-key=value lines as
+# (same parsing pattern as clients_emit_json, which treats non-key=value lines as
 # station blocks starting with the MAC).
-station_count() {
+clients_count_stations() {
     hostapd_cli -p "${CTRL_IFACE_DIR}" -i "${INTERFACE}" all_sta \
         | grep -cE '^([0-9a-fA-F]{2}:){5}' || true
 }
 
-require_interface
-require_ctrl_interface
+client_env_require_interface
+client_env_require_ctrl_interface
 
 CMD="${1:-}"
 
@@ -73,14 +73,14 @@ case "${CMD}" in
         exec hostapd_cli -p "${CTRL_IFACE_DIR}" -i "${INTERFACE}" all_sta
         ;;
     --json)
-        emit_json
+        clients_emit_json
         ;;
     count)
-        station_count
+        clients_count_stations
         ;;
     deauth)
         if [[ $# -ne 2 ]] ; then
-            usage
+            clients_show_usage
             exit 1
         fi
         MAC="${2}"
@@ -91,7 +91,7 @@ case "${CMD}" in
         exec hostapd_cli -p "${CTRL_IFACE_DIR}" -i "${INTERFACE}" deauthenticate "${MAC}"
         ;;
     *)
-        usage
+        clients_show_usage
         exit 1
         ;;
 esac

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -130,7 +130,7 @@ docker run -d --name hostap \
 Behavior:
 
 - Only the first line of the file is used; a trailing newline is stripped.
-- Values loaded from files go through the same validation as direct values (`validate_ssid`, `validate_passphrase`).
+- Values loaded from files go through the same validation as direct values (`validation_check_ssid`, `passphrase_validate`).
 - If both `VAR` and `VAR_FILE` are set, the `_FILE` value wins and a warning is printed to stderr.
 - Startup fails with `[Error] <VAR>_FILE '...' is not readable` if the file is missing or unreadable.
 

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -92,7 +92,7 @@ MIN_STATIONS="${HEALTHCHECK_MIN_STATIONS-}"
 if [[ -n "${MIN_STATIONS}" ]]; then
     if ! [[ "${MIN_STATIONS}" =~ ^[0-9]+$ ]]; then
         echo "[Warning] Invalid HEALTHCHECK_MIN_STATIONS '${MIN_STATIONS}', disabling check" >&2
-    elif resolve_ctrl_iface_dir && [[ -d "${CTRL_IFACE_DIR}" ]]; then
+    elif client_env_resolve_ctrl_iface_dir && [[ -d "${CTRL_IFACE_DIR}" ]]; then
         STATION_COUNT="$(hostapd_cli -p "${CTRL_IFACE_DIR}" -i "${INTERFACE}" all_sta 2>/dev/null \
             | grep -cE '^([0-9a-fA-F]{2}:){5}' || true)"
         if (( STATION_COUNT < MIN_STATIONS )); then

--- a/lib/ap_isolation.sh
+++ b/lib/ap_isolation.sh
@@ -1,9 +1,9 @@
 # shellcheck shell=bash
 # Shared AP isolation logic used by wlanstart.sh and tests.
 #
-# compute_ap_isolation_line reads AP_ISOLATION from the environment and
+# ap_isolation_compute_line reads AP_ISOLATION from the environment and
 # prints the hostapd `ap_isolate=` config line, or nothing if the variable
 # is unset.
-compute_ap_isolation_line() {
+ap_isolation_compute_line() {
     echo "${AP_ISOLATION+"ap_isolate=${AP_ISOLATION}"}"
 }

--- a/lib/atomic.sh
+++ b/lib/atomic.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 # Shared atomic config file writing used by wlanstart.sh and tests.
 #
-# write_atomic_config generates a file to a temporary location first and
+# atomic_write_config generates a file to a temporary location first and
 # only moves it into place if generation succeeded. A plain redirection
 # (emit_conf > /etc/hostapd.conf) truncates the target before the emit
 # function runs, so a validation failure would leave an empty/partial
@@ -11,11 +11,11 @@
 # mv(1) is a same-filesystem rename (atomic) rather than a cross-device
 # copy, and so the final file inherits the directory's ownership.
 #
-# Usage: write_atomic_config <emit_function> <target_path>
+# Usage: atomic_write_config <emit_function> <target_path>
 # Returns non-zero if temp file creation, generation or the move fails;
 # the target is left untouched on any failure.
 
-write_atomic_config() {
+atomic_write_config() {
     local emit_fn=$1
     local target=$2
     local tmp dir mode=644

--- a/lib/channel.sh
+++ b/lib/channel.sh
@@ -1,11 +1,11 @@
 # shellcheck shell=bash
 # Shared channel/hw_mode/country validation logic used by wlanstart.sh and tests.
 #
-# validate_channel reads HW_MODE, CHANNEL and COUNTRY_CODE from the
+# channel_validate reads HW_MODE, CHANNEL and COUNTRY_CODE from the
 # environment (defaults applied centrally by lib/env.sh, see issue
 # #237) and returns non-zero when the channel is not allowed.
 # Messages go to stderr.
-validate_channel() {
+channel_validate() {
     # Normalize case so lowercase country codes and uppercase hw_mode
     # values are validated correctly instead of falling through (issue #222).
     COUNTRY_CODE="$(printf '%s' "${COUNTRY_CODE:-}" | tr '[:lower:]' '[:upper:]')"
@@ -89,7 +89,7 @@ validate_channel() {
 
 # VHT (802.11ac) requires 5 GHz operation.
 # Reads VHT_ENABLED and HW_MODE from the environment.
-validate_vht() {
+channel_validate_vht() {
     HW_MODE="$(printf '%s' "${HW_MODE:-}" | tr '[:upper:]' '[:lower:]')"
     if [ -n "${VHT_ENABLED:-}" ] && [ "${HW_MODE}" != "a" ] ; then
         echo "[Error] VHT_ENABLED requires HW_MODE=a (5 GHz)." >&2
@@ -99,8 +99,8 @@ validate_vht() {
 }
 
 # Strict variant used by validation mode: unknown HW_MODE is an error.
-validate_channel_strict() {
-    if ! validate_channel ; then
+channel_validate_strict() {
+    if ! channel_validate ; then
         return 1
     fi
     case "${HW_MODE}" in

--- a/lib/client_env.sh
+++ b/lib/client_env.sh
@@ -4,7 +4,7 @@
 # CTRL_IFACE_DIR handling so behavior and error messages stay identical.
 
 # Fail with the canonical error when INTERFACE is unset or empty.
-require_interface() {
+client_env_require_interface() {
     if [[ -z "${INTERFACE:-}" ]] ; then
         echo "[Error] INTERFACE must be set." >&2
         exit 1
@@ -12,13 +12,13 @@ require_interface() {
 }
 
 # Apply the default control-interface directory when CTRL_IFACE_DIR is unset.
-resolve_ctrl_iface_dir() {
+client_env_resolve_ctrl_iface_dir() {
     CTRL_IFACE_DIR="${CTRL_IFACE_DIR:-/var/run/hostapd}"
 }
 
 # Fail when the resolved control interface directory does not exist.
-require_ctrl_interface() {
-    resolve_ctrl_iface_dir
+client_env_require_ctrl_interface() {
+    client_env_resolve_ctrl_iface_dir
     if [[ ! -d "${CTRL_IFACE_DIR}" ]] ; then
         echo "[Error] Control interface not available at ${CTRL_IFACE_DIR}." >&2
         echo "Restart the container with -e CTRL_INTERFACE=1 to enable it." >&2

--- a/lib/ctrl_interface.sh
+++ b/lib/ctrl_interface.sh
@@ -1,8 +1,8 @@
 # shellcheck shell=bash
-# compute_ctrl_interface_conf prints hostapd.conf lines enabling the
+# ctrl_interface_compute_conf prints hostapd.conf lines enabling the
 # control interface, when CTRL_INTERFACE or HEALTHCHECK_DEEP is set to a
 # non-empty value (the deep healthcheck needs it for hostapd_cli).
-compute_ctrl_interface_conf() {
+ctrl_interface_compute_conf() {
     if [ -n "${CTRL_INTERFACE:-}" ] || [ -n "${HEALTHCHECK_DEEP:-}" ] ; then
         echo "ctrl_interface=/var/run/hostapd"
         echo "ctrl_interface_group=0"

--- a/lib/dhcp.sh
+++ b/lib/dhcp.sh
@@ -34,20 +34,20 @@
 # shellcheck source=lib/validation.sh
 . "$(dirname "${BASH_SOURCE[0]}")/validation.sh"
 
-# ip_to_int converts a dotted-quad IPv4 address (already validated)
+# dhcp_ip_to_int converts a dotted-quad IPv4 address (already validated)
 # into its 32-bit integer value so ranges can be compared numerically.
-ip_to_int() {
+dhcp_ip_to_int() {
     local o1 o2 o3 o4
     IFS=. read -r o1 o2 o3 o4 <<<"${1}"
     echo $(( (o1 << 24) | (o2 << 16) | (o3 << 8) | o4 ))
 }
 
-# check_ap_addr_in_subnet verifies that AP_ADDR lies inside
+# dhcp_check_ap_addr_in_subnet verifies that AP_ADDR lies inside
 # ${SUBNET}/<prefix> for the given dotted-decimal netmask, i.e.
 # AP_ADDR & netmask == SUBNET. Emits an error on stderr and returns
 # non-zero otherwise. Skips silently when AP_ADDR or SUBNET is unset
 # or not a valid IPv4 address (those cases are reported elsewhere).
-check_ap_addr_in_subnet() {
+dhcp_check_ap_addr_in_subnet() {
     local netmask=${1:-}
     if [ -z "${AP_ADDR:-}" ] || [ -z "${SUBNET:-}" ] ; then
         return 0
@@ -57,8 +57,8 @@ check_ap_addr_in_subnet() {
     fi
     local m1 m2 m3 m4 ap_masked subnet_int
     IFS=. read -r m1 m2 m3 m4 <<<"${netmask}"
-    ap_masked=$(( $(ip_to_int "${AP_ADDR}") & (m1 << 24 | m2 << 16 | m3 << 8 | m4) ))
-    subnet_int=$(ip_to_int "${SUBNET}")
+    ap_masked=$(( $(dhcp_ip_to_int "${AP_ADDR}") & (m1 << 24 | m2 << 16 | m3 << 8 | m4) ))
+    subnet_int=$(dhcp_ip_to_int "${SUBNET}")
     if [ "${ap_masked}" -ne "${subnet_int}" ] ; then
         echo "[Error] AP_ADDR '${AP_ADDR}' is not inside SUBNET ${SUBNET}/${DHCP_PREFIX}" >&2
         return 1
@@ -67,13 +67,13 @@ check_ap_addr_in_subnet() {
 
 # A dnsmasq lease time is a positive integer optionally followed by
 # h (hours), m (minutes) or s (seconds), e.g. 12h, 30m, 3600.
-validate_lease_time() {
+dhcp_validate_lease_time() {
     [[ "${1:-}" =~ ^[0-9]+[hms]?$ ]]
 }
 
 compute_dhcp_range() {
     # DHCP_LEASE default is applied centrally by lib/env.sh (#237)
-    if [ ! "${DHCP_LEASE}" ] || ! validate_lease_time "${DHCP_LEASE}" ; then
+    if [ ! "${DHCP_LEASE}" ] || ! dhcp_validate_lease_time "${DHCP_LEASE}" ; then
         echo "[Error] Invalid DHCP_LEASE: '${DHCP_LEASE}' is not a valid lease time." >&2
         echo "  Expected: integer optionally followed by h/m/s (e.g. 12h, 3600)"
         return 1
@@ -97,7 +97,7 @@ compute_dhcp_range() {
         DHCP_RANGE="${prefix}.100,${prefix}.200,255.255.255.0,${DHCP_LEASE}"
         DHCP_PREFIX=24
         export DHCP_PREFIX
-        if ! check_ap_addr_in_subnet "255.255.255.0" ; then
+        if ! dhcp_check_ap_addr_in_subnet "255.255.255.0" ; then
             return 1
         fi
         echo "[Warning] DHCP_RANGE not set, using default: $DHCP_RANGE" >&2
@@ -127,13 +127,13 @@ compute_dhcp_range() {
         fi
         # Derive the CIDR prefix from the netmask; this propagates to the
         # interface address (${AP_ADDR}/<prefix>) and NAT rules.
-        if ! DHCP_PREFIX=$(netmask_to_prefix "${netmask}") ; then
+        if ! DHCP_PREFIX=$(validation_netmask_to_prefix "${netmask}") ; then
             echo "[Error] Invalid DHCP_RANGE: field 3 '${netmask}' is not a usable netmask" >&2
             return 1
         fi
         # SUBNET must be the network address for the configured mask.
         if [ -n "${SUBNET:-}" ] && validate_ipv4 "${SUBNET}" \
-           && ! is_network_address "${SUBNET}" "${netmask}" ; then
+           && ! validation_is_network_address "${SUBNET}" "${netmask}" ; then
             echo "[Error] Invalid SUBNET: '${SUBNET}' is not a network address for mask ${netmask} (host bits must be 0)." >&2
             return 1
         fi
@@ -149,37 +149,37 @@ compute_dhcp_range() {
         #    point has a static address and a lease collision would
         #    break connectivity. We reject outright rather than warn -
         #    an overlapping pool is always a configuration error.
-        if [ "$(ip_to_int "${start_ip}")" -gt "$(ip_to_int "${end_ip}")" ] ; then
+        if [ "$(dhcp_ip_to_int "${start_ip}")" -gt "$(dhcp_ip_to_int "${end_ip}")" ] ; then
             echo "[Error] Invalid DHCP_RANGE: field 1 '${start_ip}' is greater than field 2 '${end_ip}' (start must not exceed end)." >&2
             return 1
         fi
         if [ -n "${SUBNET:-}" ] && validate_ipv4 "${SUBNET}" ; then
             local subnet_int addr masked mask_int
-            subnet_int=$(ip_to_int "${SUBNET}")
+            subnet_int=$(dhcp_ip_to_int "${SUBNET}")
             IFS=. read -r m1 m2 m3 m4 <<<"${netmask}"
             mask_int=$(( (m1 << 24) | (m2 << 16) | (m3 << 8) | m4 ))
             for addr in "${start_ip}" "${end_ip}" ; do
-                masked=$(( $(ip_to_int "${addr}") & mask_int ))
+                masked=$(( $(dhcp_ip_to_int "${addr}") & mask_int ))
                 if [ "${masked}" -ne "${subnet_int}" ] ; then
                     echo "[Error] Invalid DHCP_RANGE: '${addr}' is outside subnet ${SUBNET}/${DHCP_PREFIX} (mask ${netmask})." >&2
                     return 1
                 fi
             done
-            if ! check_ap_addr_in_subnet "${netmask}" ; then
+            if ! dhcp_check_ap_addr_in_subnet "${netmask}" ; then
                 return 1
             fi
         fi
         if [ -n "${AP_ADDR:-}" ] && validate_ipv4 "${AP_ADDR}" ; then
             local ap_int
-            ap_int=$(ip_to_int "${AP_ADDR}")
-            if [ "${ap_int}" -ge "$(ip_to_int "${start_ip}")" ] \
-               && [ "${ap_int}" -le "$(ip_to_int "${end_ip}")" ] ; then
+            ap_int=$(dhcp_ip_to_int "${AP_ADDR}")
+            if [ "${ap_int}" -ge "$(dhcp_ip_to_int "${start_ip}")" ] \
+               && [ "${ap_int}" -le "$(dhcp_ip_to_int "${end_ip}")" ] ; then
                 echo "[Error] Invalid DHCP_RANGE: '${start_ip}','${end_ip}' contains AP_ADDR '${AP_ADDR}' (the AP address must stay out of the DHCP pool)." >&2
                 return 1
             fi
         fi
 
-        if ! validate_lease_time "${lease_time}" ; then
+        if ! dhcp_validate_lease_time "${lease_time}" ; then
             echo "[Error] Invalid DHCP_RANGE: field 4 '${lease_time}' is not a valid lease time" >&2
             echo "  Expected: integer optionally followed by h/m/s (e.g. 12h, 3600)" >&2
             return 1

--- a/lib/dhcp.sh
+++ b/lib/dhcp.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 # Shared DHCP_RANGE logic used by wlanstart.sh and tests.
 #
-# compute_dhcp_range reads SUBNET, DHCP_RANGE and DHCP_LEASE from the
+# dhcp_compute_range reads SUBNET, DHCP_RANGE and DHCP_LEASE from the
 # environment. If DHCP_RANGE is unset it computes a default from SUBNET
 # (.100 - .200 / 255.255.255.0). Otherwise each field of the explicit
 # DHCP_RANGE (start_ip,end_ip,netmask,lease_time) is validated: the first
@@ -52,7 +52,7 @@ dhcp_check_ap_addr_in_subnet() {
     if [ -z "${AP_ADDR:-}" ] || [ -z "${SUBNET:-}" ] ; then
         return 0
     fi
-    if ! validate_ipv4 "${AP_ADDR}" || ! validate_ipv4 "${SUBNET}" ; then
+    if ! validation_check_ipv4 "${AP_ADDR}" || ! validation_check_ipv4 "${SUBNET}" ; then
         return 0
     fi
     local m1 m2 m3 m4 ap_masked subnet_int
@@ -71,7 +71,7 @@ dhcp_validate_lease_time() {
     [[ "${1:-}" =~ ^[0-9]+[hms]?$ ]]
 }
 
-compute_dhcp_range() {
+dhcp_compute_range() {
     # DHCP_LEASE default is applied centrally by lib/env.sh (#237)
     if [ ! "${DHCP_LEASE}" ] || ! dhcp_validate_lease_time "${DHCP_LEASE}" ; then
         echo "[Error] Invalid DHCP_LEASE: '${DHCP_LEASE}' is not a valid lease time." >&2
@@ -84,7 +84,7 @@ compute_dhcp_range() {
             echo "[Error] SUBNET not set: cannot compute default DHCP_RANGE." >&2
             return 1
         fi
-        if ! validate_ipv4 "${SUBNET}" ; then
+        if ! validation_check_ipv4 "${SUBNET}" ; then
             echo "[Error] Invalid SUBNET: '${SUBNET}' is not a valid IPv4 address." >&2
             return 1
         fi
@@ -113,15 +113,15 @@ compute_dhcp_range() {
 
         local start_ip end_ip netmask lease_time
         IFS=',' read -r start_ip end_ip netmask lease_time <<<"${DHCP_RANGE}"
-        if ! validate_ipv4 "${start_ip}" ; then
+        if ! validation_check_ipv4 "${start_ip}" ; then
             echo "[Error] Invalid DHCP_RANGE: field 1 '${start_ip}' is not a valid IPv4 address" >&2
             return 1
         fi
-        if ! validate_ipv4 "${end_ip}" ; then
+        if ! validation_check_ipv4 "${end_ip}" ; then
             echo "[Error] Invalid DHCP_RANGE: field 2 '${end_ip}' is not a valid IPv4 address" >&2
             return 1
         fi
-        if ! validate_ipv4 "${netmask}" ; then
+        if ! validation_check_ipv4 "${netmask}" ; then
             echo "[Error] Invalid DHCP_RANGE: field 3 '${netmask}' is not a valid IPv4 address" >&2
             return 1
         fi
@@ -132,7 +132,7 @@ compute_dhcp_range() {
             return 1
         fi
         # SUBNET must be the network address for the configured mask.
-        if [ -n "${SUBNET:-}" ] && validate_ipv4 "${SUBNET}" \
+        if [ -n "${SUBNET:-}" ] && validation_check_ipv4 "${SUBNET}" \
            && ! validation_is_network_address "${SUBNET}" "${netmask}" ; then
             echo "[Error] Invalid SUBNET: '${SUBNET}' is not a network address for mask ${netmask} (host bits must be 0)." >&2
             return 1
@@ -153,7 +153,7 @@ compute_dhcp_range() {
             echo "[Error] Invalid DHCP_RANGE: field 1 '${start_ip}' is greater than field 2 '${end_ip}' (start must not exceed end)." >&2
             return 1
         fi
-        if [ -n "${SUBNET:-}" ] && validate_ipv4 "${SUBNET}" ; then
+        if [ -n "${SUBNET:-}" ] && validation_check_ipv4 "${SUBNET}" ; then
             local subnet_int addr masked mask_int
             subnet_int=$(dhcp_ip_to_int "${SUBNET}")
             IFS=. read -r m1 m2 m3 m4 <<<"${netmask}"
@@ -169,7 +169,7 @@ compute_dhcp_range() {
                 return 1
             fi
         fi
-        if [ -n "${AP_ADDR:-}" ] && validate_ipv4 "${AP_ADDR}" ; then
+        if [ -n "${AP_ADDR:-}" ] && validation_check_ipv4 "${AP_ADDR}" ; then
             local ap_int
             ap_int=$(dhcp_ip_to_int "${AP_ADDR}")
             if [ "${ap_int}" -ge "$(dhcp_ip_to_int "${start_ip}")" ] \

--- a/lib/env.sh
+++ b/lib/env.sh
@@ -1,7 +1,7 @@
 # shellcheck shell=bash
 # Centralized environment defaults (issue #237).
 #
-# resolve_config_env() is the single place where default values are
+# env_resolve_config_env() is the single place where default values are
 # applied for every configuration variable. It is called exactly once by
 # wlanstart.sh, before any validation or config emission, so that
 # normal mode and --validate mode always resolve identical configs.
@@ -9,9 +9,9 @@
 # Precedence: an explicitly set environment variable always wins; the
 # defaults below only apply when the variable is unset or empty.
 # Library modules (lib/*.sh) read these variables and must NOT apply
-# their own defaults - they can assume resolve_config_env() has run.
+# their own defaults - they can assume env_resolve_config_env() has run.
 
-resolve_config_env() {
+env_resolve_config_env() {
     # Wireless hardware mode: b | g | a (see lib/channel.sh)
     : "${HW_MODE:=g}"
     # Channel; "acs" enables automatic channel selection

--- a/lib/extra_opts.sh
+++ b/lib/extra_opts.sh
@@ -1,11 +1,11 @@
 # shellcheck shell=bash
 # Shared extra hostapd.conf options logic used by wlanstart.sh and tests.
 #
-# compute_extra_opts_lines reads HOSTAPD_EXTRA_OPTS from the environment
+# extra_opts_compute_lines reads HOSTAPD_EXTRA_OPTS from the environment
 # (newline-separated) and prints each non-empty line, one per output
 # line. Lines are appended verbatim to the end of the generated
 # hostapd.conf; invalid values surface as hostapd config errors in logs.
-compute_extra_opts_lines() {
+extra_opts_compute_lines() {
     [ -n "${HOSTAPD_EXTRA_OPTS:-}" ] || return 0
     local line
     while IFS= read -r line || [ -n "${line}" ] ; do

--- a/lib/interface.sh
+++ b/lib/interface.sh
@@ -1,8 +1,8 @@
 # shellcheck shell=bash
 # Shared interface bring-up/teardown logic used by wlanstart.sh and tests.
 
-# setup_interface brings the AP interface up and assigns the AP address.
-setup_interface() {
+# interface_setup brings the AP interface up and assigns the AP address.
+interface_setup() {
     ip link set "${INTERFACE}" up || {
         echo "[Error] Failed to bring up interface ${INTERFACE}" >&2
         return 1
@@ -17,10 +17,10 @@ setup_interface() {
     }
 }
 
-# teardown_interface removes only the AP address this container configured
+# interface_teardown removes only the AP address this container configured
 # (a blanket `ip addr flush` would wipe unrelated host addresses when running
 # with --net host) and brings the link down.
-teardown_interface() {
+interface_teardown() {
     if [ -n "${INTERFACE}" ] ; then
         echo "Removing ${AP_ADDR}/${DHCP_PREFIX:-24} from interface ${INTERFACE}..."
         ip addr del "${AP_ADDR}/${DHCP_PREFIX:-24}" dev "${INTERFACE}" 2>/dev/null || true

--- a/lib/ipv6.sh
+++ b/lib/ipv6.sh
@@ -9,9 +9,9 @@
 # compute_dnsmasq_ipv6_conf prints the extra dnsmasq.conf line (or nothing
 # when disabled). Messages go to stderr.
 
-# Ensure parse_outgoings (lib/nat.sh) is available so the rule functions
-# below are self-contained and can be called without apply_nat_rules first.
-if ! declare -F parse_outgoings > /dev/null 2>&1 ; then
+# Ensure nat_parse_outgoings (lib/nat.sh) is available so the rule functions
+# below are self-contained and can be called without nat_apply_rules first.
+if ! declare -F nat_parse_outgoings > /dev/null 2>&1 ; then
     # shellcheck source=lib/nat.sh
     . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/nat.sh"
 fi
@@ -23,22 +23,22 @@ compute_dnsmasq_ipv6_conf() {
     echo "dhcp-range=::,constructor:${INTERFACE},ra-names,stateless"
 }
 
-# enable_ipv6_forwarding sets the forwarding sysctl via /proc, tolerating
+# ipv6_enable_forwarding sets the forwarding sysctl via /proc, tolerating
 # missing entries. IPV6_SYSCTL_BASE can be overridden in tests to point at
 # a stubbed procfs tree.
 IPV6_SYSCTL_BASE="${IPV6_SYSCTL_BASE:-/proc/sys/net/ipv6}"
 
-enable_ipv6_forwarding() {
+ipv6_enable_forwarding() {
     echo 1 > "${IPV6_SYSCTL_BASE}/conf/all/forwarding" 2>/dev/null \
         || echo "[Warning] Cannot set net.ipv6.conf.all.forwarding" >&2
 }
 
-# apply_ipv6_rules adds ip6tables FORWARD rules mirroring the IPv4 ones.
+# ipv6_apply_rules adds ip6tables FORWARD rules mirroring the IPv4 ones.
 # shellcheck disable=SC2154
-apply_ipv6_rules() {
+ipv6_apply_rules() {
     if [ "${OUTGOINGS}" ] ; then
         local int
-        validate_outgoings || return 1
+        nat_validate_outgoings || return 1
         for int in "${ints[@]}" ; do
             ip6tables -D FORWARD -i "${int}" -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
             ip6tables -A FORWARD -i "${int}" -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT
@@ -55,11 +55,11 @@ apply_ipv6_rules() {
     fi
 }
 
-# remove_ipv6_rules deletes the ip6tables rules added by apply_ipv6_rules.
-remove_ipv6_rules() {
+# ipv6_remove_rules deletes the ip6tables rules added by ipv6_apply_rules.
+ipv6_remove_rules() {
     if [ "${OUTGOINGS}" ] ; then
         local int
-        parse_outgoings
+        nat_parse_outgoings
         for int in "${ints[@]}" ; do
             ip6tables -D FORWARD -i "${int}" -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT > /dev/null 2>&1 || true
             ip6tables -D FORWARD -i "${INTERFACE}" -o "${int}" -j ACCEPT > /dev/null 2>&1 || true

--- a/lib/ipv6.sh
+++ b/lib/ipv6.sh
@@ -6,7 +6,7 @@
 #   - dnsmasq announces RA/stateless DHCPv6 on the AP interface
 #   - ip6tables FORWARD rules mirror the IPv4 handling
 #
-# compute_dnsmasq_ipv6_conf prints the extra dnsmasq.conf line (or nothing
+# ipv6_compute_dnsmasq_conf prints the extra dnsmasq.conf line (or nothing
 # when disabled). Messages go to stderr.
 
 # Ensure nat_parse_outgoings (lib/nat.sh) is available so the rule functions
@@ -15,7 +15,7 @@ if ! declare -F nat_parse_outgoings > /dev/null 2>&1 ; then
     # shellcheck source=lib/nat.sh
     . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/nat.sh"
 fi
-compute_dnsmasq_ipv6_conf() {
+ipv6_compute_dnsmasq_conf() {
     if [ "${IPV6:-0}" != "1" ] ; then
         echo "[Info] IPV6 not enabled, skipping IPv6 RA/DHCPv6 configuration." >&2
         return 1

--- a/lib/logging.sh
+++ b/lib/logging.sh
@@ -56,13 +56,13 @@ _failure_log_prune() {
         done
 }
 
-# report_failure <exit-status> [tagged-output-log]
+# logging_report_failure <exit-status> [tagged-output-log]
 #
 # Print a final error pointing at the likely failing daemon based on the
 # last tagged line of captured daemon output. When a non-empty log is
 # given, it is preserved under FAILURE_LOG_DIR so operators can inspect the
 # full tagged output after exit.
-report_failure() {
+logging_report_failure() {
     local status="$1"
     local log="${2:-}"
     local tag="[daemon]"

--- a/lib/logging.sh
+++ b/lib/logging.sh
@@ -16,13 +16,13 @@ FAILURE_LOG_PATH="${FAILURE_LOG_PATH:-}"
 FAILURE_LOG_DIR="${FAILURE_LOG_DIR:-/var/log/hostap-failures}"
 FAILURE_LOG_KEEP="${FAILURE_LOG_KEEP:-5}"
 
-# _failure_log_target
+# _logging_failure_log_target
 #
 # Print the path the daemon log should be preserved at. When an explicit
 # FAILURE_LOG_PATH is set it is used as-is; otherwise a timestamped file
 # inside FAILURE_LOG_DIR is chosen (with a numeric suffix if two crashes
 # land in the same second).
-_failure_log_target() {
+_logging_failure_log_target() {
     local epoch target n=0
     if [ -n "${FAILURE_LOG_PATH}" ] ; then
         printf '%s' "${FAILURE_LOG_PATH}"
@@ -40,11 +40,11 @@ _failure_log_target() {
     printf '%s' "${target}"
 }
 
-# _failure_log_prune
+# _logging_failure_prune
 #
 # Remove the oldest timestamped failure logs so at most FAILURE_LOG_KEEP
 # remain. No-op when an explicit FAILURE_LOG_PATH is set.
-_failure_log_prune() {
+_logging_failure_prune() {
     local old
     if [ -n "${FAILURE_LOG_PATH}" ] ; then
         return 0
@@ -91,7 +91,7 @@ logging_report_failure() {
         # destination is unwritable (bad dir, permissions), warn and carry on.
         local _try copied=1 dest
         for _try in 1 2 ; do
-            if ! dest=$(_failure_log_target) || ! cp "${log}" "${dest}" 2>/dev/null ; then
+            if ! dest=$(_logging_failure_log_target) || ! cp "${log}" "${dest}" 2>/dev/null ; then
                 echo "Warning: could not save daemon log to ${dest:-${FAILURE_LOG_DIR}}." >&2
                 copied=0
                 break
@@ -100,7 +100,7 @@ logging_report_failure() {
               "$(wc -c < "${dest}" 2>/dev/null || echo 0)" ] && break
             sleep 0.1
         done
-        _failure_log_prune
+        _logging_failure_prune
         [ "${copied}" = "1" ] && saved=" Full daemon log saved to ${dest}."
     fi
 

--- a/lib/mac_filter.sh
+++ b/lib/mac_filter.sh
@@ -5,13 +5,13 @@
 #   1 = allowlist: only MACs listed in MAC_ACL_FILE may associate
 #   2 = denylist:  MACs listed in MAC_ACL_FILE are rejected
 #
-# compute_mac_filter_conf prints the extra hostapd.conf lines (or nothing
+# mac_filter_compute_conf prints the extra hostapd.conf lines (or nothing
 # when disabled). Messages go to stderr. Returns non-zero on fatal
 # validation errors (filter enabled without a file).
 
-# validate_mac_filter checks the MAC_FILTER/MAC_ACL_FILE combination.
+# mac_filter_validate checks the MAC_FILTER/MAC_ACL_FILE combination.
 # Returns 1 if the filter is enabled but no file is configured.
-validate_mac_filter() {
+mac_filter_validate() {
     case "${MAC_FILTER:-0}" in
         0)
             return 0
@@ -33,8 +33,8 @@ validate_mac_filter() {
     esac
 }
 
-# compute_mac_filter_conf prints hostapd.conf lines for MAC filtering.
-compute_mac_filter_conf() {
+# mac_filter_compute_conf prints hostapd.conf lines for MAC filtering.
+mac_filter_compute_conf() {
     case "${MAC_FILTER:-0}" in
         1)
             echo "macaddr_acl=1"

--- a/lib/nat.sh
+++ b/lib/nat.sh
@@ -1,9 +1,9 @@
 # shellcheck shell=bash
 # Shared IPv4 NAT logic used by wlanstart.sh and tests.
 #
-# parse_outgoings fills ints with the comma-separated OUTGOINGS interfaces.
+# nat_parse_outgoings fills ints with the comma-separated OUTGOINGS interfaces.
 
-parse_outgoings() {
+nat_parse_outgoings() {
     ints=()
     local -a raw
     local i
@@ -17,29 +17,29 @@ parse_outgoings() {
 # (e.g. when validating OUTGOINGS interfaces without real network tools).
 IP_BASE="${IP_BASE:-ip}"
 
-# interface_exists returns 0 when the given network interface exists.
-interface_exists() {
+# nat_interface_exists returns 0 when the given network interface exists.
+nat_interface_exists() {
     "${IP_BASE}" link show "$1" > /dev/null 2>&1
 }
 
-# validate_outgoings checks every parsed OUTGOINGS interface exists,
+# nat_validate_outgoings checks every parsed OUTGOINGS interface exists,
 # failing fast with an error naming the offending interface.
-validate_outgoings() {
+nat_validate_outgoings() {
     local int
-    parse_outgoings
+    nat_parse_outgoings
     for int in "${ints[@]}" ; do
-        if ! interface_exists "${int}" ; then
+        if ! nat_interface_exists "${int}" ; then
             echo "[Error] OUTGOINGS interface '${int}' does not exist" >&2
             return 1
         fi
     done
 }
 
-# apply_nat_rules adds iptables MASQUERADE/FORWARD rules for outgoing traffic.
-apply_nat_rules() {
+# nat_apply_rules adds iptables MASQUERADE/FORWARD rules for outgoing traffic.
+nat_apply_rules() {
     if [ "${OUTGOINGS}" ] ; then
         local int
-        validate_outgoings || return 1
+        nat_validate_outgoings || return 1
         for int in "${ints[@]}"
         do
             echo "Setting iptables for outgoing traffics on ${int}..."
@@ -67,12 +67,12 @@ apply_nat_rules() {
     fi
 }
 
-# set_sysctls enables the given ipv4 sysctls, tolerating missing entries
+# nat_set_sysctls enables the given ipv4 sysctls, tolerating missing entries
 # (e.g. kernels built without ip_dynaddr). SYSCTL_BASE can be overridden
 # in tests to point at a stubbed procfs tree.
 SYSCTL_BASE="${SYSCTL_BASE:-/proc/sys/net/ipv4}"
 
-set_sysctls() {
+nat_set_sysctls() {
     local i val
     for i in "$@" ; do
         val="$(cat "${SYSCTL_BASE}/${i}" 2>/dev/null || echo 0)"
@@ -84,8 +84,8 @@ set_sysctls() {
     done
 }
 
-# show_sysctls prints labeled values for the given ipv4 sysctls (#194).
-show_sysctls() {
+# nat_show_sysctls prints labeled values for the given ipv4 sysctls (#194).
+nat_show_sysctls() {
     local i val
     for i in "$@" ; do
         val="$(cat "${SYSCTL_BASE}/${i}" 2>/dev/null || echo '?')"
@@ -93,13 +93,13 @@ show_sysctls() {
     done
 }
 
-# remove_nat_rules deletes the rules added by apply_nat_rules.
-remove_nat_rules() {
+# nat_remove_rules deletes the rules added by nat_apply_rules.
+nat_remove_rules() {
     echo "Removing iptables rules..."
 
     if [ "${OUTGOINGS}" ] ; then
         local int
-        parse_outgoings
+        nat_parse_outgoings
         for int in "${ints[@]}" ; do
             echo "Removing iptables for outgoing traffics on ${int}..."
             iptables -t nat -D POSTROUTING -s "${SUBNET}/${DHCP_PREFIX:-24}" -o "${int}" -j MASQUERADE > /dev/null 2>&1 || true

--- a/lib/passphrase.sh
+++ b/lib/passphrase.sh
@@ -1,12 +1,12 @@
 # shellcheck shell=bash
 # Shared WPA passphrase validation logic used by wlanstart.sh and tests.
 #
-# validate_passphrase reads WPA_PASSPHRASE from the environment and returns
+# passphrase_validate reads WPA_PASSPHRASE from the environment and returns
 # non-zero if its length is outside the 8-63 character range required by
 # WPA-PSK/SAE or if it contains newlines/carriage returns/control
 # characters (which could inject hostapd.conf directives). Messages go to
 # stderr.
-validate_passphrase() {
+passphrase_validate() {
     local len=${#WPA_PASSPHRASE}
     # Pin the locale so the [[:cntrl:]] class behaves consistently.
     local LC_ALL=C

--- a/lib/radio.sh
+++ b/lib/radio.sh
@@ -7,9 +7,9 @@
 # The value must respect the regulatory limits of COUNTRY_CODE - iw will
 # reject powers above the allowed EIRP for the configured domain.
 #
-# validate_tx_power checks the value without touching the system
+# radio_validate_tx_power checks the value without touching the system
 # (used by --validate mode and before any system change).
-validate_tx_power() {
+radio_validate_tx_power() {
     [ -z "${TX_POWER:-}" ] && return 0
     case "${TX_POWER}" in
         auto) return 0 ;;
@@ -21,10 +21,10 @@ validate_tx_power() {
     return 0
 }
 
-# apply_tx_power applies TX_POWER to INTERFACE via iw. Fails fatally when
+# radio_apply_tx_power applies TX_POWER to INTERFACE via iw. Fails fatally when
 # iw rejects the value: the operator asked explicitly for a power cap,
 # silently running at full power would violate that intent.
-apply_tx_power() {
+radio_apply_tx_power() {
     [ -n "${TX_POWER:-}" ] || return 0
     if ! command -v iw >/dev/null 2>&1 ; then
         echo "[Error] TX_POWER set but 'iw' is not available on ${INTERFACE}" >&2

--- a/lib/secret_file.sh
+++ b/lib/secret_file.sh
@@ -9,7 +9,7 @@
 # Precedence: when both VAR and VAR_FILE are set, the file wins and a
 # warning is emitted so misconfigurations are not silently ignored.
 
-load_from_file() {
+secret_file_load() {
     local var=$1 file_var=$2
     local f="${!file_var:-}"
     [ -z "${f}" ] && return 0

--- a/lib/ssid_hidden.sh
+++ b/lib/ssid_hidden.sh
@@ -1,9 +1,9 @@
 # shellcheck shell=bash
 # Shared hidden SSID logic used by wlanstart.sh and tests.
 #
-# compute_ssid_hidden_line reads HIDE_SSID from the environment and
+# ssid_hidden_compute_line reads HIDE_SSID from the environment and
 # prints the hostapd `ssid_hidden=` config line, or nothing if the
 # variable is unset.
-compute_ssid_hidden_line() {
+ssid_hidden_compute_line() {
     echo "${HIDE_SSID+"ssid_hidden=${HIDE_SSID}"}"
 }

--- a/lib/stations.sh
+++ b/lib/stations.sh
@@ -1,11 +1,11 @@
 # shellcheck shell=bash
 # Shared MAX_STATIONS logic used by wlanstart.sh and tests.
 #
-# compute_max_sta_conf reads MAX_STATIONS from the environment (default
+# stations_compute_max_sta_conf reads MAX_STATIONS from the environment (default
 # applied centrally by lib/env.sh, see issue #237) and writes the
 # hostapd max_num_sta line to stdout (empty when disabled). Errors go to
 # stderr. Returns non-zero for invalid MAX_STATIONS values.
-compute_max_sta_conf() {
+stations_compute_max_sta_conf() {
     if [ "${MAX_STATIONS}" != "0" ] && ! [ "${MAX_STATIONS}" -gt 0 ] 2>/dev/null ; then
         echo "[Error] Invalid MAX_STATIONS '${MAX_STATIONS}'. Must be a non-negative integer." >&2
         return 1

--- a/lib/validation.sh
+++ b/lib/validation.sh
@@ -59,11 +59,11 @@ validate_ssid() {
     fi
 }
 
-# netmask_to_prefix converts a dotted-decimal netmask to its CIDR prefix
+# validation_netmask_to_prefix converts a dotted-decimal netmask to its CIDR prefix
 # length (e.g. 255.255.255.240 -> 28). The mask must be contiguous
 # (255s, then optionally one partial octet, then 0s). Pure bash so it can
 # be tested on macOS without network tools. Prints the prefix on stdout.
-netmask_to_prefix() {
+validation_netmask_to_prefix() {
     local mask=${1:-} octet prefix=0 seen_partial=0
     if ! validate_ipv4 "${mask}" ; then
         echo "[Error] Invalid netmask: '${mask}' is not a valid IPv4 address." >&2
@@ -98,9 +98,9 @@ netmask_to_prefix() {
     echo "${prefix}"
 }
 
-# is_network_address checks that addr has all host bits zero for the
+# validation_is_network_address checks that addr has all host bits zero for the
 # given dotted-decimal netmask (i.e. addr & mask == addr). Pure bash.
-is_network_address() {
+validation_is_network_address() {
     local addr=${1:-} mask=${2:-}
     local a1 a2 a3 a4 m1 m2 m3 m4
     IFS=. read -r a1 a2 a3 a4 <<<"${addr}"

--- a/lib/validation.sh
+++ b/lib/validation.sh
@@ -1,10 +1,10 @@
 # shellcheck shell=bash
 # Shared IPv4 address validation logic used by wlanstart.sh and tests.
 #
-# validate_ipv4 checks that its argument is a well-formed dotted-quad
+# validation_check_ipv4 checks that its argument is a well-formed dotted-quad
 # IPv4 address (four decimal octets 0-255). Pure bash so it can be
 # tested on macOS without network tools.
-validate_ipv4() {
+validation_check_ipv4() {
     local addr=${1:-}
     local octet
 
@@ -23,11 +23,11 @@ validate_ipv4() {
     done
 }
 
-# validate_ssid checks that its argument is a safe SSID:
+# validation_check_ssid checks that its argument is a safe SSID:
 # - 1-32 bytes (802.11 limit)
 # - no newlines, '#' comments, leading whitespace, or '=' (which could
 #   form a new key when written into the unquoted hostapd.conf heredoc)
-validate_ssid() {
+validation_check_ssid() {
     local ssid=${1:-}
     # Enforce the byte limit in the C locale so multibyte UTF-8
     # characters are counted per byte, matching the 802.11 limit.
@@ -65,7 +65,7 @@ validate_ssid() {
 # be tested on macOS without network tools. Prints the prefix on stdout.
 validation_netmask_to_prefix() {
     local mask=${1:-} octet prefix=0 seen_partial=0
-    if ! validate_ipv4 "${mask}" ; then
+    if ! validation_check_ipv4 "${mask}" ; then
         echo "[Error] Invalid netmask: '${mask}' is not a valid IPv4 address." >&2
         return 1
     fi
@@ -111,11 +111,11 @@ validation_is_network_address() {
     [ $(( a4 & m4 )) -eq "${a4}" ] || return 1
 }
 
-# validate_ipv4_param checks that a named parameter holds a valid IPv4
+# validation_check_ipv4_param checks that a named parameter holds a valid IPv4
 # address, printing the standard error message on failure.
-validate_ipv4_param() {
+validation_check_ipv4_param() {
     local name=${1:-} value=${2:-}
-    if ! validate_ipv4 "${value}" ; then
+    if ! validation_check_ipv4 "${value}" ; then
         echo "[Error] Invalid ${name}: '${value}' is not a valid IPv4 address." >&2
         return 1
     fi

--- a/lib/warnings.sh
+++ b/lib/warnings.sh
@@ -1,10 +1,10 @@
 # shellcheck shell=bash
 # Shared default-credential warning logic used by wlanstart.sh and tests.
 #
-# emit_credential_warnings reads SSID and WPA_PASSPHRASE from the
+# warnings_emit_credential_warnings reads SSID and WPA_PASSPHRASE from the
 # environment (already defaulted) and prints a warning for each value
 # still at its insecure default.
-emit_credential_warnings() {
+warnings_emit_credential_warnings() {
     if [ "${SSID}" = "raspberry" ] ; then
         echo "[Warning] Using default SSID 'raspberry'. Set SSID env var for production."
     fi

--- a/lib/wpa.sh
+++ b/lib/wpa.sh
@@ -1,10 +1,10 @@
 # shellcheck shell=bash
 # Shared WPA configuration logic used by wlanstart.sh and tests.
 #
-# compute_wpa_conf reads WPA_VERSION (2 | 3 | mixed) and HW_MODE from the
+# wpa_compute_conf reads WPA_VERSION (2 | 3 | mixed) and HW_MODE from the
 # environment and writes the hostapd wpa_* block to stdout. Messages go to
 # stderr. Returns non-zero for invalid WPA_VERSION values.
-compute_wpa_conf() {
+wpa_compute_conf() {
     # Defaults (WPA_VERSION, HW_MODE, WPA_PASSPHRASE) are applied
     # centrally by lib/env.sh (issue #237).
     _PMF=""

--- a/tests/ap_isolation.bats
+++ b/tests/ap_isolation.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# Tests exercise compute_ap_isolation_line() from lib/ap_isolation.sh —
+# Tests exercise ap_isolation_compute_line() from lib/ap_isolation.sh —
 # the exact code used by wlanstart.sh (no duplicated logic).
 
 setup() {
@@ -13,7 +13,7 @@ load_lib() {
 
 @test "AP_ISOLATION not set produces no config line" {
     load_lib
-    run compute_ap_isolation_line
+    run ap_isolation_compute_line
     [ "$status" -eq 0 ]
     [ "$output" = "" ]
 }
@@ -21,7 +21,7 @@ load_lib() {
 @test "AP_ISOLATION=1 produces ap_isolate=1" {
     load_lib
     AP_ISOLATION=1
-    run compute_ap_isolation_line
+    run ap_isolation_compute_line
     [ "$status" -eq 0 ]
     [ "$output" = "ap_isolate=1" ]
 }
@@ -29,7 +29,7 @@ load_lib() {
 @test "AP_ISOLATION=0 produces ap_isolate=0" {
     load_lib
     AP_ISOLATION=0
-    run compute_ap_isolation_line
+    run ap_isolation_compute_line
     [ "$status" -eq 0 ]
     [ "$output" = "ap_isolate=0" ]
 }
@@ -37,7 +37,7 @@ load_lib() {
 @test "AP_ISOLATION empty string produces ap_isolate with empty value" {
     load_lib
     AP_ISOLATION=""
-    run compute_ap_isolation_line
+    run ap_isolation_compute_line
     [ "$status" -eq 0 ]
     [ "$output" = "ap_isolate=" ]
 }

--- a/tests/atomic_config.bats
+++ b/tests/atomic_config.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# Tests exercise write_atomic_config() from lib/atomic.sh - the exact code
+# Tests exercise atomic_write_config() from lib/atomic.sh - the exact code
 # used by wlanstart.sh (no duplicated logic) - together with the real
 # emit_hostapd_conf/emit_dnsmasq_conf validators, covering the failure
 # paths from issue #157: failed config generation must leave any
@@ -27,8 +27,8 @@ load_emit_fns() {
 
 @test "invalid WPA_VERSION leaves pre-existing hostapd.conf untouched" {
     load_emit_fns
-    WPA_VERSION=1   # rejected by compute_wpa_conf
-    run write_atomic_config emit_hostapd_conf "${target}"
+    WPA_VERSION=1   # rejected by wpa_compute_conf
+    run atomic_write_config emit_hostapd_conf "${target}"
     [ "$status" -ne 0 ]
     [ "$(cat "${target}")" = "OLD-CONFIG" ]
 }
@@ -36,7 +36,7 @@ load_emit_fns() {
 @test "invalid DHCP_RANGE leaves pre-existing dnsmasq.conf untouched" {
     load_emit_fns
     DHCP_RANGE=not-an-ip,192.168.254.200,255.255.255.0,12h
-    run write_atomic_config emit_dnsmasq_conf "${target}"
+    run atomic_write_config emit_dnsmasq_conf "${target}"
     [ "$status" -ne 0 ]
     [ "$(cat "${target}")" = "OLD-CONFIG" ]
 }
@@ -46,7 +46,7 @@ load_emit_fns() {
     # emit_hostapd_conf/emit_dnsmasq_conf live in wlanstart.sh itself;
     # use a representative emitter to verify the atomic replace path.
     good_emit() { printf 'interface=wlan0\n'; }
-    run write_atomic_config good_emit "${target}"
+    run atomic_write_config good_emit "${target}"
     [ "$status" -eq 0 ]
     grep -q 'interface=wlan0' "${target}"
     ! grep -q 'OLD-CONFIG' "${target}"
@@ -56,7 +56,7 @@ load_emit_fns() {
     . "${LIB_DIR}/atomic.sh"
     chmod 640 "${target}"
     good_emit() { printf 'interface=wlan0\n'; }
-    run write_atomic_config good_emit "${target}"
+    run atomic_write_config good_emit "${target}"
     [ "$status" -eq 0 ]
     [ "$(stat -c '%a' "${target}" 2>/dev/null || stat -f '%Lp' "${target}")" = "640" ]
 }
@@ -67,7 +67,7 @@ load_emit_fns() {
     local_target="${local_dir}/hostapd.conf"
     printf 'OLD-CONFIG\n' > "${local_target}"
     good_emit() { printf 'interface=wlan0\n'; }
-    run write_atomic_config good_emit "${local_target}"
+    run atomic_write_config good_emit "${local_target}"
     [ "$status" -eq 0 ]
     grep -q 'interface=wlan0' "${local_target}"
     # no leftover temp files in the target directory

--- a/tests/channel_validation.bats
+++ b/tests/channel_validation.bats
@@ -10,7 +10,7 @@ setup() {
     # shellcheck source=../lib/env.sh
     . "${ROOT}/lib/env.sh"
     # Defaults now live centrally in lib/env.sh (issue #237)
-    resolve_config_env
+    env_resolve_config_env
     # shellcheck source=../lib/channel.sh
     . "${ROOT}/lib/channel.sh"
 }
@@ -524,7 +524,7 @@ setup() {
 
 @test "strict: default hw_mode (g) passes" {
     unset HW_MODE
-    resolve_config_env
+    env_resolve_config_env
     CHANNEL="1"
     run validate_channel_strict
     [ "$status" -eq 0 ]
@@ -541,7 +541,7 @@ setup() {
 
 @test "VHT_ENABLED set with default HW_MODE fails" {
     unset HW_MODE
-    resolve_config_env
+    env_resolve_config_env
     VHT_ENABLED="1"
     run validate_vht
     [ "$status" -eq 1 ]

--- a/tests/channel_validation.bats
+++ b/tests/channel_validation.bats
@@ -18,28 +18,28 @@ setup() {
 # --- g/b mode (2.4 GHz) ---
 
 @test "default values pass validation" {
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 0 ]
 }
 
 @test "hw_mode=g with channel 1 passes" {
     HW_MODE="g"
     CHANNEL="1"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 0 ]
 }
 
 @test "hw_mode=g with channel 13 passes (EU default)" {
     HW_MODE="g"
     CHANNEL="13"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 0 ]
 }
 
 @test "hw_mode=g with channel 14 fails (EU default)" {
     HW_MODE="g"
     CHANNEL="14"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
     [[ "$output" == *"Error"*"Channel 14 is only allowed in Japan"* ]]
 }
@@ -47,7 +47,7 @@ setup() {
 @test "hw_mode=g with channel 36 fails" {
     HW_MODE="g"
     CHANNEL="36"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
     [[ "$output" == *"Error"*"not allowed"* ]]
 }
@@ -55,21 +55,21 @@ setup() {
 @test "hw_mode=b with channel 1 passes" {
     HW_MODE="b"
     CHANNEL="1"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 0 ]
 }
 
 @test "hw_mode=b with channel 13 passes (EU default)" {
     HW_MODE="b"
     CHANNEL="13"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 0 ]
 }
 
 @test "hw_mode=b with channel 14 fails (EU default)" {
     HW_MODE="b"
     CHANNEL="14"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
     [[ "$output" == *"Error"*"Channel 14 is only allowed in Japan"* ]]
 }
@@ -80,7 +80,7 @@ setup() {
     HW_MODE="a"
     for ch in 36 40 44 48; do
         CHANNEL="${ch}"
-        run validate_channel
+        run channel_validate
         [ "$status" -eq 0 ]
     done
 }
@@ -91,7 +91,7 @@ setup() {
         COUNTRY_CODE="${cc}"
         for ch in 149 153 157 161 165; do
             CHANNEL="${ch}"
-            run validate_channel
+            run channel_validate
             [ "$status" -eq 0 ]
         done
     done
@@ -104,7 +104,7 @@ setup() {
         COUNTRY_CODE="$1"
         for ch in 149 153 157 161 165; do
             CHANNEL="${ch}"
-            run validate_channel
+            run channel_validate
             [ "$status" -eq 1 ]
             [[ "$output" == *"Error"*"Channel ${ch} not allowed for country $2"* ]]
         done
@@ -114,7 +114,7 @@ setup() {
 @test "hw_mode=a rejects channel 149 without COUNTRY_CODE (EU fallback)" {
     HW_MODE="a"
     CHANNEL="149"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
     [[ "$output" == *"Error"*"not allowed for country"* ]]
 }
@@ -123,7 +123,7 @@ setup() {
     HW_MODE="a"
     CHANNEL="52"
     COUNTRY_CODE="EU"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 0 ]
     [[ "$output" == *"Warning"*"DFS"* ]]
 }
@@ -131,7 +131,7 @@ setup() {
 @test "hw_mode=a with DFS channel 100 warns but passes" {
     HW_MODE="a"
     CHANNEL="100"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 0 ]
     [[ "$output" == *"Warning"*"DFS"* ]]
 }
@@ -139,7 +139,7 @@ setup() {
 @test "hw_mode=a with DFS channel 144 warns but passes" {
     HW_MODE="a"
     CHANNEL="144"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 0 ]
     [[ "$output" == *"Warning"*"DFS"* ]]
 }
@@ -148,7 +148,7 @@ setup() {
     HW_MODE="a"
     for ch in 15 34 50 145 1650; do
         CHANNEL="${ch}"
-        run validate_channel
+        run channel_validate
         [ "$status" -eq 1 ]
         [[ "$output" == *"Error"*"not allowed for hw_mode=a"* ]]
     done
@@ -157,7 +157,7 @@ setup() {
 @test "hw_mode=a rejects channel 11 (2.4 GHz only)" {
     HW_MODE="a"
     CHANNEL="11"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
     [[ "$output" == *"Error"*"not allowed for hw_mode=a"* ]]
 }
@@ -165,7 +165,7 @@ setup() {
 @test "hw_mode=a rejects channel 1 (2.4 GHz only)" {
     HW_MODE="a"
     CHANNEL="1"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
     [[ "$output" == *"Error"*"not allowed for hw_mode=a"* ]]
 }
@@ -175,7 +175,7 @@ setup() {
 @test "CHANNEL=acs passes with hw_mode=g and warns" {
     HW_MODE="g"
     CHANNEL="acs"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 0 ]
     [[ "$output" == *"Warning"*"acs"* ]]
 }
@@ -183,7 +183,7 @@ setup() {
 @test "CHANNEL=acs passes with hw_mode=a and warns" {
     HW_MODE="a"
     CHANNEL="acs"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 0 ]
     [[ "$output" == *"Warning"*"HEALTHCHECK_START_PERIOD"* ]]
 }
@@ -192,7 +192,7 @@ setup() {
     for hw in b g a; do
         HW_MODE="${hw}"
         CHANNEL="ACS"
-        run validate_channel
+        run channel_validate
         [ "$status" -eq 0 ]
     done
 }
@@ -200,7 +200,7 @@ setup() {
 @test "CHANNEL=acs passes strict validation" {
     HW_MODE="g"
     CHANNEL="acs"
-    run validate_channel_strict
+    run channel_validate_strict
     [ "$status" -eq 0 ]
     [[ "$output" == *"Warning"*"acs"* ]]
 }
@@ -209,7 +209,7 @@ setup() {
     for value in Acs aCS AcS; do
         HW_MODE="g"
         CHANNEL="${value}"
-        run validate_channel
+        run channel_validate
         [ "$status" -eq 0 ]
     done
 }
@@ -220,9 +220,9 @@ setup() {
     run bash -c '
         . "'"${ROOT}"'/lib/channel.sh"
         HW_MODE="g"; CHANNEL="acs"; COUNTRY_CODE="EU"
-        validate_channel || exit 1
-        validate_channel || exit 1
-        validate_channel_strict || exit 1
+        channel_validate || exit 1
+        channel_validate || exit 1
+        channel_validate_strict || exit 1
     '
     [ "$status" -eq 0 ]
     [ "$(printf '%s' "$output" | grep -c 'Warning')" -eq 2 ]
@@ -232,9 +232,9 @@ setup() {
     run bash -c '
         . "'"${ROOT}"'/lib/channel.sh"
         HW_MODE="a"; CHANNEL="52"; COUNTRY_CODE="EU"
-        validate_channel || exit 1
+        channel_validate || exit 1
         CHANNEL="100"
-        validate_channel || exit 1
+        channel_validate || exit 1
     '
     [ "$status" -eq 0 ]
     [ "$(printf '%s' "$output" | grep -c 'Warning')" -eq 1 ]
@@ -243,13 +243,13 @@ setup() {
 @test "errors print on every call even after warnings were deduped" {
     HW_MODE="a"
     CHANNEL="acs"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 0 ]
     CHANNEL="11"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
     [[ "$output" == *"Error"*"not allowed for hw_mode=a"* ]]
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
     [[ "$output" == *"Error"*"not allowed for hw_mode=a"* ]]
 }
@@ -277,7 +277,7 @@ setup() {
     COUNTRY_CODE="us"
     HW_MODE="g"
     CHANNEL="12"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
     [[ "$output" == *"country US"* ]]
 }
@@ -286,21 +286,21 @@ setup() {
     COUNTRY_CODE="jp"
     HW_MODE="b"
     CHANNEL="14"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 0 ]
 }
 
 @test "uppercase hw_mode 'G' validates like 'g'" {
     HW_MODE="G"
     CHANNEL="1"
-    run validate_channel_strict
+    run channel_validate_strict
     [ "$status" -eq 0 ]
 }
 
 @test "uppercase hw_mode 'A' validates like 'a'" {
     HW_MODE="A"
     CHANNEL="36"
-    run validate_channel_strict
+    run channel_validate_strict
     [ "$status" -eq 0 ]
 }
 
@@ -308,22 +308,22 @@ setup() {
     COUNTRY_CODE="JP"
     HW_MODE="B"
     CHANNEL="14"
-    run validate_channel_strict
+    run channel_validate_strict
     [ "$status" -eq 0 ]
 }
 
 @test "VHT_ENABLED set with uppercase HW_MODE=A passes" {
     HW_MODE="A"
     VHT_ENABLED="1"
-    run validate_vht
+    run channel_validate_vht
     [ "$status" -eq 0 ]
 }
 
-@test "validate_channel normalizes env for generated hostapd.conf" {
+@test "channel_validate normalizes env for generated hostapd.conf" {
     COUNTRY_CODE="us"
     HW_MODE="G"
     CHANNEL="6"
-    validate_channel || exit 1
+    channel_validate || exit 1
     [ "${HW_MODE}" = "g" ]
     [ "${COUNTRY_CODE}" = "US" ]
 }
@@ -333,7 +333,7 @@ setup() {
 @test "non-numeric channel with hw_mode=g fails" {
     HW_MODE="g"
     CHANNEL="foo"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
     [[ "$output" == *"Error"*"positive integer"* ]]
 }
@@ -341,7 +341,7 @@ setup() {
 @test "non-numeric channel with hw_mode=a fails" {
     HW_MODE="a"
     CHANNEL="bar"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
     [[ "$output" == *"Error"*"positive integer"* ]]
 }
@@ -349,7 +349,7 @@ setup() {
 @test "non-numeric channel with hw_mode=b fails" {
     HW_MODE="b"
     CHANNEL="baz"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
     [[ "$output" == *"Error"*"positive integer"* ]]
 }
@@ -359,7 +359,7 @@ setup() {
 @test "unknown hw_mode issues warning and passes" {
     HW_MODE="x"
     CHANNEL="1"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 0 ]
     [[ "$output" == *"Warning"*"Unknown hw_mode"* ]]
 }
@@ -370,10 +370,10 @@ setup() {
     COUNTRY_CODE="US"
     HW_MODE="g"
     CHANNEL="11"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 0 ]
     CHANNEL="12"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
     [[ "$output" == *"not allowed for country US"* ]]
 }
@@ -382,7 +382,7 @@ setup() {
     COUNTRY_CODE="CA"
     HW_MODE="g"
     CHANNEL="12"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
 }
 
@@ -390,7 +390,7 @@ setup() {
     COUNTRY_CODE="MX"
     HW_MODE="b"
     CHANNEL="13"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
 }
 
@@ -399,11 +399,11 @@ setup() {
     HW_MODE="g"
     for ch in 1 6 11 13; do
         CHANNEL="${ch}"
-        run validate_channel
+        run channel_validate
         [ "$status" -eq 0 ]
     done
     CHANNEL="14"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
     [[ "$output" == *"Channel 14 is only allowed in Japan"* ]]
 }
@@ -413,10 +413,10 @@ setup() {
         COUNTRY_CODE="${cc}"
         HW_MODE="g"
         CHANNEL="13"
-        run validate_channel
+        run channel_validate
         [ "$status" -eq 0 ]
         CHANNEL="14"
-        run validate_channel
+        run channel_validate
         [ "$status" -eq 1 ]
     done
 }
@@ -426,7 +426,7 @@ setup() {
     HW_MODE="b"
     for ch in 1 6 12 13 14; do
         CHANNEL="${ch}"
-        run validate_channel
+        run channel_validate
         [ "$status" -eq 0 ]
     done
 }
@@ -435,9 +435,9 @@ setup() {
     COUNTRY_CODE="JP"
     HW_MODE="b"
     CHANNEL="14"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 0 ]
-    run validate_channel_strict
+    run channel_validate_strict
     [ "$status" -eq 0 ]
 }
 
@@ -445,17 +445,17 @@ setup() {
     COUNTRY_CODE="ZZ"
     HW_MODE="g"
     CHANNEL="13"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 0 ]
     CHANNEL="14"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
 }
 
 @test "default region is EU (channel 14 rejected without COUNTRY_CODE)" {
     HW_MODE="g"
     CHANNEL="14"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
 }
 
@@ -463,10 +463,10 @@ setup() {
     COUNTRY_CODE="JP"
     HW_MODE="g"
     CHANNEL="14"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
     [[ "$output" == *"Channel 14 is only allowed in Japan (COUNTRY_CODE=JP) with hw_mode=b (802.11b)"* ]]
-    run validate_channel_strict
+    run channel_validate_strict
     [ "$status" -eq 1 ]
 }
 
@@ -474,7 +474,7 @@ setup() {
     COUNTRY_CODE="JP"
     HW_MODE="n"
     CHANNEL="14"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
 }
 
@@ -482,7 +482,7 @@ setup() {
     COUNTRY_CODE="US"
     HW_MODE="b"
     CHANNEL="14"
-    run validate_channel
+    run channel_validate
     [ "$status" -eq 1 ]
     [[ "$output" == *"Channel 14 is only allowed in Japan"* ]]
 }
@@ -494,10 +494,10 @@ setup() {
         HW_MODE="$2"
         unset CHANNEL
         CHANNEL="acs"
-        run validate_channel
+        run channel_validate
         [ "$status" -eq 0 ]
         CHANNEL="ACS"
-        run validate_channel
+        run channel_validate
         [ "$status" -eq 0 ]
     done
 }
@@ -507,7 +507,7 @@ setup() {
 @test "strict: unknown hw_mode fails with error" {
     HW_MODE="gn"
     CHANNEL="1"
-    run validate_channel_strict
+    run channel_validate_strict
     [ "$status" -eq 1 ]
     [[ "$output" == *"Error"*"Unknown hw_mode='gn'"* ]]
 }
@@ -517,7 +517,7 @@ setup() {
         set -- ${pair}
         HW_MODE="$1"
         CHANNEL="$2"
-        run validate_channel_strict
+        run channel_validate_strict
         [ "$status" -eq 0 ]
     done
 }
@@ -526,14 +526,14 @@ setup() {
     unset HW_MODE
     env_resolve_config_env
     CHANNEL="1"
-    run validate_channel_strict
+    run channel_validate_strict
     [ "$status" -eq 0 ]
 }
 
 @test "strict: channel errors still fail" {
     HW_MODE="g"
     CHANNEL="14"
-    run validate_channel_strict
+    run channel_validate_strict
     [ "$status" -eq 1 ]
 }
 
@@ -543,7 +543,7 @@ setup() {
     unset HW_MODE
     env_resolve_config_env
     VHT_ENABLED="1"
-    run validate_vht
+    run channel_validate_vht
     [ "$status" -eq 1 ]
     [[ "$output" == *"[Error] VHT_ENABLED requires HW_MODE=a (5 GHz)."* ]]
 }
@@ -551,7 +551,7 @@ setup() {
 @test "VHT_ENABLED set with HW_MODE=g fails" {
     HW_MODE="g"
     VHT_ENABLED="1"
-    run validate_vht
+    run channel_validate_vht
     [ "$status" -eq 1 ]
     [[ "$output" == *"Error"* ]]
 }
@@ -559,20 +559,20 @@ setup() {
 @test "VHT_ENABLED set with HW_MODE=b fails" {
     HW_MODE="b"
     VHT_ENABLED="1"
-    run validate_vht
+    run channel_validate_vht
     [ "$status" -eq 1 ]
 }
 
 @test "VHT_ENABLED set with HW_MODE=a passes" {
     HW_MODE="a"
     VHT_ENABLED="1"
-    run validate_vht
+    run channel_validate_vht
     [ "$status" -eq 0 ]
 }
 
 @test "VHT_ENABLED unset with HW_MODE=g passes" {
     HW_MODE="g"
     unset VHT_ENABLED
-    run validate_vht
+    run channel_validate_vht
     [ "$status" -eq 0 ]
 }

--- a/tests/cleanup.bats
+++ b/tests/cleanup.bats
@@ -44,25 +44,25 @@ cleanup
     rm -f "$mock_log"
 }
 
-@test "parse_outgoings parses comma-separated interfaces" {
+@test "nat_parse_outgoings parses comma-separated interfaces" {
     load_cleanup
-    OUTGOINGS="eth0,wlan0" parse_outgoings
+    OUTGOINGS="eth0,wlan0" nat_parse_outgoings
     [ "${#ints[@]}" -eq 2 ]
     [ "${ints[0]}" = "eth0" ]
     [ "${ints[1]}" = "wlan0" ]
 }
 
-@test "parse_outgoings collapses repeated commas" {
+@test "nat_parse_outgoings collapses repeated commas" {
     load_cleanup
-    OUTGOINGS="eth0,,wlan0," parse_outgoings
+    OUTGOINGS="eth0,,wlan0," nat_parse_outgoings
     [ "${#ints[@]}" -eq 2 ]
     [ "${ints[0]}" = "eth0" ]
     [ "${ints[1]}" = "wlan0" ]
 }
 
-@test "parse_outgoings yields empty array when OUTGOINGS unset" {
+@test "nat_parse_outgoings yields empty array when OUTGOINGS unset" {
     load_cleanup
-    OUTGOINGS="" parse_outgoings
+    OUTGOINGS="" nat_parse_outgoings
     [ "${#ints[@]}" -eq 0 ]
 }
 
@@ -161,7 +161,7 @@ handle_signal
     [[ "$output" != *"ip addr flush"* ]]
 }
 
-@test "teardown_interface removes only AP_ADDR (issue #188)" {
+@test "interface_teardown removes only AP_ADDR (issue #188)" {
     . lib/interface.sh
     INTERFACE="wlan0"
     AP_ADDR="192.168.254.1"
@@ -169,7 +169,7 @@ handle_signal
     local log
     log=$(mktemp)
     ip() { echo "ip $@" >> "$log"; }
-    teardown_interface
+    interface_teardown
     grep -q "ip addr del 192.168.254.1/24 dev wlan0" "$log"
     ! grep -q "addr flush" "$log"
     rm -f "$log"

--- a/tests/client_env.bats
+++ b/tests/client_env.bats
@@ -12,40 +12,40 @@ setup() {
     cd "${BATS_TEST_DIRNAME}/.."
 }
 
-@test "require_interface exits 1 with canonical error when INTERFACE unset" {
-    load_client_env 'require_interface'
+@test "client_env_require_interface exits 1 with canonical error when INTERFACE unset" {
+    load_client_env 'client_env_require_interface'
     [ "$status" -eq 1 ]
     [ "${lines[0]}" = "[Error] INTERFACE must be set." ]
 }
 
-@test "require_interface passes when INTERFACE is set" {
-    load_client_env 'INTERFACE=wlan0; require_interface; echo ok'
+@test "client_env_require_interface passes when INTERFACE is set" {
+    load_client_env 'INTERFACE=wlan0; client_env_require_interface; echo ok'
     [ "$status" -eq 0 ]
     [ "$output" = "ok" ]
 }
 
-@test "resolve_ctrl_iface_dir defaults to /var/run/hostapd" {
-    load_client_env 'resolve_ctrl_iface_dir; echo "$CTRL_IFACE_DIR"'
+@test "client_env_resolve_ctrl_iface_dir defaults to /var/run/hostapd" {
+    load_client_env 'client_env_resolve_ctrl_iface_dir; echo "$CTRL_IFACE_DIR"'
     [ "$status" -eq 0 ]
     [ "$output" = "/var/run/hostapd" ]
 }
 
-@test "resolve_ctrl_iface_dir preserves explicit value" {
-    load_client_env 'CTRL_IFACE_DIR=/custom/dir; resolve_ctrl_iface_dir; echo "$CTRL_IFACE_DIR"'
+@test "client_env_resolve_ctrl_iface_dir preserves explicit value" {
+    load_client_env 'CTRL_IFACE_DIR=/custom/dir; client_env_resolve_ctrl_iface_dir; echo "$CTRL_IFACE_DIR"'
     [ "$status" -eq 0 ]
     [ "$output" = "/custom/dir" ]
 }
 
-@test "require_ctrl_interface errors with actionable hint when dir missing" {
-    load_client_env 'INTERFACE=wlan0; CTRL_IFACE_DIR=/nonexistent/hostapd; require_ctrl_interface'
+@test "client_env_require_ctrl_interface errors with actionable hint when dir missing" {
+    load_client_env 'INTERFACE=wlan0; CTRL_IFACE_DIR=/nonexistent/hostapd; client_env_require_ctrl_interface'
     [ "$status" -ne 0 ]
     [ "${lines[0]}" = "[Error] Control interface not available at /nonexistent/hostapd." ]
     [ "${lines[1]}" = "Restart the container with -e CTRL_INTERFACE=1 to enable it." ]
 }
 
-@test "require_ctrl_interface succeeds when dir exists and applies default path" {
+@test "client_env_require_ctrl_interface succeeds when dir exists and applies default path" {
     local tmpdir="${BATS_TEST_TMPDIR}/hostapd"
     mkdir -p "$tmpdir"
-    load_client_env "INTERFACE=wlan0; CTRL_IFACE_DIR=${tmpdir}; require_ctrl_interface && resolve_ctrl_iface_dir; echo \"\$CTRL_IFACE_DIR\""
+    load_client_env "INTERFACE=wlan0; CTRL_IFACE_DIR=${tmpdir}; client_env_require_ctrl_interface && client_env_resolve_ctrl_iface_dir; echo \"\$CTRL_IFACE_DIR\""
     [ "$status" -eq 0 ]
 }

--- a/tests/clients.bats
+++ b/tests/clients.bats
@@ -72,7 +72,7 @@ EOF
     [[ "$output" != *"stub hostapd_cli"* ]]
 }
 
-@test "deauth without MAC argument prints usage and exits non-zero" {
+@test "deauth without MAC argument prints clients_show_usage and exits non-zero" {
     export INTERFACE=wlan0
     mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
     export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
@@ -81,7 +81,7 @@ EOF
     [[ "$output" == *"Usage: clients.sh"* ]]
 }
 
-@test "unknown subcommand prints usage and exits non-zero" {
+@test "unknown subcommand prints clients_show_usage and exits non-zero" {
     export INTERFACE=wlan0
     mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
     export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"

--- a/tests/config_injection.bats
+++ b/tests/config_injection.bats
@@ -16,7 +16,7 @@ load_passphrase_lib() {
 @test "passphrase with embedded newline is rejected (startup validator)" {
     load_passphrase_lib
     WPA_PASSPHRASE=$(printf 'goodpass\nwpa_pairwise=NONE')
-    run validate_passphrase
+    run passphrase_validate
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid WPA_PASSPHRASE"* ]]
     [[ "$output" == *"must not contain newlines"* ]]
@@ -25,7 +25,7 @@ load_passphrase_lib() {
 @test "passphrase with carriage return is rejected (startup validator)" {
     load_passphrase_lib
     WPA_PASSPHRASE=$(printf 'goodpass\raaa')
-    run validate_passphrase
+    run passphrase_validate
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid WPA_PASSPHRASE"* ]]
 }
@@ -33,7 +33,7 @@ load_passphrase_lib() {
 @test "passphrase with control character is rejected (startup validator)" {
     load_passphrase_lib
     WPA_PASSPHRASE=$(printf 'goodpass\tabc')
-    run validate_passphrase
+    run passphrase_validate
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid WPA_PASSPHRASE"* ]]
 }

--- a/tests/ctrl_interface.bats
+++ b/tests/ctrl_interface.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# Tests exercise compute_ctrl_interface_conf() from lib/ctrl_interface.sh —
+# Tests exercise ctrl_interface_compute_conf() from lib/ctrl_interface.sh —
 # the exact code used by wlanstart.sh (no duplicated logic).
 
 setup() {
@@ -14,7 +14,7 @@ load_lib() {
 
 @test "CTRL_INTERFACE not set produces no config line" {
     load_lib
-    run compute_ctrl_interface_conf
+    run ctrl_interface_compute_conf
     [ "$status" -eq 0 ]
     [ "$output" = "" ]
 }
@@ -22,7 +22,7 @@ load_lib() {
 @test "CTRL_INTERFACE empty string produces no config line" {
     load_lib
     CTRL_INTERFACE=""
-    run compute_ctrl_interface_conf
+    run ctrl_interface_compute_conf
     [ "$status" -eq 0 ]
     [ "$output" = "" ]
 }
@@ -30,7 +30,7 @@ load_lib() {
 @test "CTRL_INTERFACE=1 produces ctrl_interface lines" {
     load_lib
     CTRL_INTERFACE=1
-    run compute_ctrl_interface_conf
+    run ctrl_interface_compute_conf
     [ "$status" -eq 0 ]
     [ "${lines[0]}" = "ctrl_interface=/var/run/hostapd" ]
     [ "${lines[1]}" = "ctrl_interface_group=0" ]
@@ -39,7 +39,7 @@ load_lib() {
 @test "CTRL_INTERFACE=yes produces ctrl_interface lines" {
     load_lib
     CTRL_INTERFACE=yes
-    run compute_ctrl_interface_conf
+    run ctrl_interface_compute_conf
     [ "$status" -eq 0 ]
     [ "${lines[0]}" = "ctrl_interface=/var/run/hostapd" ]
     [ "${lines[1]}" = "ctrl_interface_group=0" ]
@@ -47,7 +47,7 @@ load_lib() {
 
 @test "HEALTHCHECK_DEEP not set produces no config line" {
     load_lib
-    run compute_ctrl_interface_conf
+    run ctrl_interface_compute_conf
     [ "$status" -eq 0 ]
     [ "$output" = "" ]
 }
@@ -55,7 +55,7 @@ load_lib() {
 @test "HEALTHCHECK_DEEP=1 produces ctrl_interface lines (issue #123)" {
     load_lib
     HEALTHCHECK_DEEP=1
-    run compute_ctrl_interface_conf
+    run ctrl_interface_compute_conf
     [ "$status" -eq 0 ]
     [ "${lines[0]}" = "ctrl_interface=/var/run/hostapd" ]
     [ "${lines[1]}" = "ctrl_interface_group=0" ]
@@ -64,7 +64,7 @@ load_lib() {
 @test "CTRL_INTERFACE unset with HEALTHCHECK_DEEP empty produces no config line" {
     load_lib
     HEALTHCHECK_DEEP=""
-    run compute_ctrl_interface_conf
+    run ctrl_interface_compute_conf
     [ "$status" -eq 0 ]
     [ "$output" = "" ]
 }

--- a/tests/dhcp_range.bats
+++ b/tests/dhcp_range.bats
@@ -16,7 +16,7 @@ setup() {
     unset DHCP_RANGE
     unset DHCP_LEASE
     # DHCP_LEASE default now applied centrally in lib/env.sh (issue #237)
-    resolve_config_env
+    env_resolve_config_env
 }
 
 @test "default DHCP_RANGE computed from SUBNET 192.168.254.0" {
@@ -197,7 +197,7 @@ setup() {
         . "'"${REPO_ROOT}"'/lib/dhcp.sh"
         SUBNET="192.168.254.16" AP_ADDR="192.168.254.17" INTERFACE="wlan0"
         PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
-        resolve_config_env
+        env_resolve_config_env
         DHCP_RANGE="192.168.254.20,192.168.254.30,255.255.255.240,12h"
         compute_dhcp_range > /dev/null || exit 1
         echo "${DHCP_PREFIX}"
@@ -213,7 +213,7 @@ setup() {
         . "'"${REPO_ROOT}"'/lib/dhcp.sh"
         SUBNET="192.168.254.0" AP_ADDR="192.168.254.1" INTERFACE="wlan0"
         PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
-        resolve_config_env
+        env_resolve_config_env
         compute_dhcp_range > /dev/null 2>&1 || exit 1
         echo "${DHCP_PREFIX}"
     '
@@ -228,7 +228,7 @@ setup() {
         . "'"${REPO_ROOT}"'/lib/dhcp.sh"
         SUBNET="10.10.10.0" AP_ADDR="10.10.10.1" INTERFACE="wlan0"
         PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
-        resolve_config_env
+        env_resolve_config_env
         DHCP_RANGE="10.10.10.50,10.10.10.150,255.255.255.0,12h"
         compute_dhcp_range > /dev/null || exit 1
         echo "${DHCP_PREFIX}"
@@ -244,7 +244,7 @@ setup() {
         . "'"${REPO_ROOT}"'/lib/dhcp.sh"
         SUBNET="192.168.0.0" AP_ADDR="192.168.254.1" INTERFACE="wlan0"
         PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
-        resolve_config_env
+        env_resolve_config_env
         DHCP_RANGE="192.168.100.50,192.168.200.150,255.255.0.0,12h"
         compute_dhcp_range > /dev/null || exit 1
         echo "${DHCP_PREFIX}"
@@ -387,7 +387,7 @@ setup() {
         eval "$(sed -n "/^emit_dnsmasq_conf()/,/^}/p" "${wlanstart}")"
         SUBNET="192.168.254.0" AP_ADDR="192.168.254.1" INTERFACE="wlan0"
         PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
-        resolve_config_env
+        env_resolve_config_env
         DHCP_RANGE_COMPUTED=$(compute_dhcp_range) || exit 1
         export DHCP_RANGE_COMPUTED
         emit_dnsmasq_conf
@@ -409,7 +409,7 @@ setup() {
         eval "$(sed -n "/^emit_dnsmasq_conf()/,/^}/p" "${wlanstart}")"
         SUBNET="192.168.254.0" AP_ADDR="192.168.254.1" INTERFACE="wlan0"
         PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
-        resolve_config_env
+        env_resolve_config_env
         # Startup path: compute once, reuse in emit_dnsmasq_conf
         DHCP_RANGE_COMPUTED=$(compute_dhcp_range 2> "'"${BATS_TEST_TMPDIR}"'/err1") || exit 1
         export DHCP_RANGE_COMPUTED

--- a/tests/dhcp_range.bats
+++ b/tests/dhcp_range.bats
@@ -20,7 +20,7 @@ setup() {
 }
 
 @test "default DHCP_RANGE computed from SUBNET 192.168.254.0" {
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 0 ]
     [ "${lines[@]: -1}" = "192.168.254.100,192.168.254.200,255.255.255.0,12h" ]
 }
@@ -28,7 +28,7 @@ setup() {
 @test "default DHCP_RANGE computed from SUBNET 10.0.0.0" {
     SUBNET="10.0.0.0"
     AP_ADDR="10.0.0.1"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 0 ]
     [ "${lines[@]: -1}" = "10.0.0.100,10.0.0.200,255.255.255.0,12h" ]
 }
@@ -36,21 +36,21 @@ setup() {
 @test "default DHCP_RANGE computed from SUBNET 172.16.1.0" {
     SUBNET="172.16.1.0"
     AP_ADDR="172.16.1.1"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 0 ]
     [ "${lines[@]: -1}" = "172.16.1.100,172.16.1.200,255.255.255.0,12h" ]
 }
 
 @test "explicit DHCP_RANGE is preserved" {
     DHCP_RANGE="192.168.254.50,192.168.254.150,255.255.255.0,24h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 0 ]
     [ "${lines[@]: -1}" = "192.168.254.50,192.168.254.150,255.255.255.0,24h" ]
 }
 
 @test "DHCP_LEASE used in default range" {
     DHCP_LEASE="24h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 0 ]
     [ "${lines[@]: -1}" = "192.168.254.100,192.168.254.200,255.255.255.0,24h" ]
 }
@@ -58,117 +58,117 @@ setup() {
 @test "DHCP_LEASE ignored when DHCP_RANGE is explicit" {
     DHCP_RANGE="192.168.254.50,192.168.254.150,255.255.255.0,48h"
     DHCP_LEASE="24h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 0 ]
     [ "${lines[@]: -1}" = "192.168.254.50,192.168.254.150,255.255.255.0,48h" ]
 }
 
 @test "invalid DHCP_RANGE with too few commas fails" {
     DHCP_RANGE="10.0.0.50,10.0.0.150"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
 }
 
 @test "invalid DHCP_RANGE with too many commas fails" {
     DHCP_RANGE="10.0.0.50,10.0.0.150,255.255.255.0,12h,extra"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
 }
 
 @test "invalid DHCP_RANGE with no commas fails" {
     DHCP_RANGE="not-a-valid-range"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
 }
 
 @test "invalid IP in field 1 fails with field-specific error" {
     DHCP_RANGE="192.168.254.999,192.168.254.200,255.255.255.0,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"field 1 '192.168.254.999' is not a valid IPv4 address"* ]]
 }
 
 @test "invalid IP in field 2 fails with field-specific error" {
     DHCP_RANGE="192.168.254.100,192.168.254.999,255.255.255.0,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"field 2 '192.168.254.999' is not a valid IPv4 address"* ]]
 }
 
 @test "invalid netmask in field 3 fails with field-specific error" {
     DHCP_RANGE="192.168.254.100,192.168.254.200,255.0.0,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"field 3 '255.0.0' is not a valid IPv4 address"* ]]
 }
 
 @test "non-numeric netmask in field 3 fails" {
     DHCP_RANGE="192.168.254.100,192.168.254.200,not-a-mask,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"field 3 'not-a-mask' is not a valid IPv4 address"* ]]
 }
 
 @test "IP with leading-zero octet in field 1 fails" {
     DHCP_RANGE="192.168.254.010,192.168.254.200,255.255.255.0,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"field 1"* ]]
 }
 
 @test "empty IP field fails validation" {
     DHCP_RANGE="192.168.254.100,,255.255.255.0,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"field 2"* ]]
 }
 
 @test "lease time with invalid unit suffix fails" {
     DHCP_RANGE="192.168.254.100,192.168.254.200,255.255.255.0,12x"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"field 4 '12x' is not a valid lease time"* ]]
 }
 
 @test "non-numeric lease time fails" {
     DHCP_RANGE="192.168.254.100,192.168.254.200,255.255.255.0,infinite"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"field 4 'infinite' is not a valid lease time"* ]]
 }
 
 @test "negative lease time fails" {
     DHCP_RANGE="192.168.254.100,192.168.254.200,255.255.255.0,-12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
 }
 
 @test "plain integer lease time is accepted" {
     DHCP_RANGE="192.168.254.50,192.168.254.150,255.255.255.0,3600"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 0 ]
     [ "${lines[@]: -1}" = "192.168.254.50,192.168.254.150,255.255.255.0,3600" ]
 }
 
 @test "minutes and seconds lease suffixes are accepted" {
     DHCP_RANGE="192.168.254.50,192.168.254.150,255.255.255.0,30m"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 0 ]
     DHCP_RANGE="192.168.254.50,192.168.254.150,255.255.255.0,45s"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 0 ]
 }
 
 @test "default range rejected for SUBNET with wrong octet count" {
     SUBNET="192.168.254"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"Invalid SUBNET: '192.168.254' is not a valid IPv4 address"* ]]
 }
 
 @test "default range rejected for SUBNET with too many octets" {
     SUBNET="192.168.254.0.1"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"Invalid SUBNET"* ]]
 }
@@ -178,14 +178,14 @@ setup() {
 # contiguous mask is supported; SUBNET just has to match it.
 @test "default range rejected for non-/24 SUBNET" {
     SUBNET="192.168.254.7"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"'192.168.254.7' is not a network address for the default /24 mask"* ]]
 }
 
 @test "invalid DHCP_LEASE fails for default range" {
     DHCP_LEASE="forever"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"Invalid DHCP_LEASE: 'forever' is not a valid lease time"* ]]
 }
@@ -199,7 +199,7 @@ setup() {
         PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
         env_resolve_config_env
         DHCP_RANGE="192.168.254.20,192.168.254.30,255.255.255.240,12h"
-        compute_dhcp_range > /dev/null || exit 1
+        dhcp_compute_range > /dev/null || exit 1
         echo "${DHCP_PREFIX}"
     '
     [ "$status" -eq 0 ]
@@ -214,7 +214,7 @@ setup() {
         SUBNET="192.168.254.0" AP_ADDR="192.168.254.1" INTERFACE="wlan0"
         PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
         env_resolve_config_env
-        compute_dhcp_range > /dev/null 2>&1 || exit 1
+        dhcp_compute_range > /dev/null 2>&1 || exit 1
         echo "${DHCP_PREFIX}"
     '
     [ "$status" -eq 0 ]
@@ -230,7 +230,7 @@ setup() {
         PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
         env_resolve_config_env
         DHCP_RANGE="10.10.10.50,10.10.10.150,255.255.255.0,12h"
-        compute_dhcp_range > /dev/null || exit 1
+        dhcp_compute_range > /dev/null || exit 1
         echo "${DHCP_PREFIX}"
     '
     [ "$status" -eq 0 ]
@@ -246,7 +246,7 @@ setup() {
         PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
         env_resolve_config_env
         DHCP_RANGE="192.168.100.50,192.168.200.150,255.255.0.0,12h"
-        compute_dhcp_range > /dev/null || exit 1
+        dhcp_compute_range > /dev/null || exit 1
         echo "${DHCP_PREFIX}"
     '
     [ "$status" -eq 0 ]
@@ -255,7 +255,7 @@ setup() {
 
 @test "non-contiguous netmask in DHCP_RANGE fails" {
     DHCP_RANGE="192.168.254.100,192.168.254.200,255.0.255.0,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"field 3 '255.0.255.0' is not a usable netmask"* ]]
 }
@@ -263,7 +263,7 @@ setup() {
 @test "SUBNET with host bits set fails for /28 mask" {
     SUBNET="192.168.254.17"
     DHCP_RANGE="192.168.254.20,192.168.254.30,255.255.255.240,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"Invalid SUBNET: '192.168.254.17' is not a network address for mask 255.255.255.240"* ]]
 }
@@ -272,7 +272,7 @@ setup() {
     SUBNET="192.168.254.16"
     AP_ADDR="192.168.254.17"
     DHCP_RANGE="192.168.254.20,192.168.254.30,255.255.255.240,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 0 ]
     [ "${lines[@]: -1}" = "192.168.254.20,192.168.254.30,255.255.255.240,12h" ]
 }
@@ -280,21 +280,21 @@ setup() {
 # Semantic validation: order, subnet bounds, AP overlap.
 @test "inverted range (start > end) is rejected" {
     DHCP_RANGE="192.168.254.200,192.168.254.100,255.255.255.0,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"field 1 '192.168.254.200' is greater than field 2 '192.168.254.100'"* ]]
 }
 
 @test "start endpoint outside the subnet is rejected" {
     DHCP_RANGE="192.168.253.50,192.168.254.150,255.255.255.0,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"'192.168.253.50' is outside subnet 192.168.254.0/24"* ]]
 }
 
 @test "end endpoint outside the subnet is rejected" {
     DHCP_RANGE="192.168.254.50,192.168.255.150,255.255.255.0,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"'192.168.255.150' is outside subnet 192.168.254.0/24"* ]]
 }
@@ -303,26 +303,26 @@ setup() {
     SUBNET="192.168.0.0"
     AP_ADDR="192.168.0.1"
     DHCP_RANGE="192.168.100.50,192.168.200.150,255.255.0.0,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 0 ]
 }
 
 @test "range containing AP_ADDR is rejected" {
     DHCP_RANGE="192.168.254.1,192.168.254.100,255.255.255.0,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"contains AP_ADDR '192.168.254.1'"* ]]
 }
 
 @test "range ending exactly on AP_ADDR is rejected" {
     DHCP_RANGE="192.168.254.50,192.168.254.1,255.255.255.0,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
 }
 
 @test "range just below and above AP_ADDR is accepted" {
     DHCP_RANGE="192.168.254.2,192.168.254.100,255.255.255.0,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 0 ]
 }
 
@@ -330,7 +330,7 @@ setup() {
     SUBNET="192.168.254.16"
     AP_ADDR="192.168.254.17"
     DHCP_RANGE="192.168.254.17,192.168.254.30,255.255.255.240,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"contains AP_ADDR '192.168.254.17'"* ]]
 }
@@ -339,7 +339,7 @@ setup() {
 @test "AP_ADDR outside default subnet is rejected" {
     SUBNET="192.168.254.0"
     AP_ADDR="10.0.0.1"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"AP_ADDR '10.0.0.1' is not inside SUBNET 192.168.254.0/24"* ]]
 }
@@ -347,7 +347,7 @@ setup() {
 @test "AP_ADDR outside explicit DHCP_RANGE subnet is rejected" {
     AP_ADDR="10.0.0.1"
     DHCP_RANGE="192.168.254.100,192.168.254.200,255.255.255.0,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"AP_ADDR '10.0.0.1' is not inside SUBNET 192.168.254.0/24"* ]]
 }
@@ -356,7 +356,7 @@ setup() {
     SUBNET="192.168.254.16"
     AP_ADDR="192.168.254.17"
     DHCP_RANGE="192.168.254.20,192.168.254.30,255.255.255.240,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 0 ]
 }
 
@@ -364,7 +364,7 @@ setup() {
     SUBNET="192.168.254.16"
     AP_ADDR="10.0.0.1"
     DHCP_RANGE="192.168.254.20,192.168.254.30,255.255.255.240,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"AP_ADDR '10.0.0.1' is not inside SUBNET 192.168.254.16/28"* ]]
 }
@@ -373,7 +373,7 @@ setup() {
     SUBNET="192.168.0.0"
     AP_ADDR="10.0.0.1"
     DHCP_RANGE="192.168.100.50,192.168.200.150,255.255.0.0,12h"
-    run compute_dhcp_range
+    run dhcp_compute_range
     [ "$status" -eq 1 ]
     [[ "${lines[*]}" == *"AP_ADDR '10.0.0.1' is not inside SUBNET 192.168.0.0/16"* ]]
 }
@@ -388,7 +388,7 @@ setup() {
         SUBNET="192.168.254.0" AP_ADDR="192.168.254.1" INTERFACE="wlan0"
         PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
         env_resolve_config_env
-        DHCP_RANGE_COMPUTED=$(compute_dhcp_range) || exit 1
+        DHCP_RANGE_COMPUTED=$(dhcp_compute_range) || exit 1
         export DHCP_RANGE_COMPUTED
         emit_dnsmasq_conf
     '
@@ -411,7 +411,7 @@ setup() {
         PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
         env_resolve_config_env
         # Startup path: compute once, reuse in emit_dnsmasq_conf
-        DHCP_RANGE_COMPUTED=$(compute_dhcp_range 2> "'"${BATS_TEST_TMPDIR}"'/err1") || exit 1
+        DHCP_RANGE_COMPUTED=$(dhcp_compute_range 2> "'"${BATS_TEST_TMPDIR}"'/err1") || exit 1
         export DHCP_RANGE_COMPUTED
         emit_dnsmasq_conf > /dev/null 2> "'"${BATS_TEST_TMPDIR}"'/err2"
     '

--- a/tests/env.bats
+++ b/tests/env.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# Tests for resolve_config_env() in lib/env.sh - the single place where
+# Tests for env_resolve_config_env() in lib/env.sh - the single place where
 # environment defaults are applied (issue #237).
 
 setup() {
@@ -13,10 +13,10 @@ setup() {
     . "${BATS_TEST_DIRNAME}/../lib/env.sh"
 }
 
-@test "resolve_config_env applies all defaults when env is empty" {
+@test "env_resolve_config_env applies all defaults when env is empty" {
     run bash -c '
         . "'"${BATS_TEST_DIRNAME}"'/../lib/env.sh"
-        resolve_config_env 2>/dev/null
+        env_resolve_config_env 2>/dev/null
         printf "%s\n" "${HW_MODE}" "${CHANNEL}" "${COUNTRY_CODE}" \
             "${SUBNET}" "${AP_ADDR}" "${PRI_DNS}" "${SEC_DNS}" \
             "${DHCP_LEASE}" "${SSID}" "${WPA_PASSPHRASE}" \
@@ -37,13 +37,13 @@ setup() {
     [ "${lines[11]}" = "0" ]
 }
 
-@test "resolve_config_env never overrides explicitly set variables" {
+@test "env_resolve_config_env never overrides explicitly set variables" {
     run bash -c '
         . "'"${BATS_TEST_DIRNAME}"'/../lib/env.sh"
         export HW_MODE=a CHANNEL=36 COUNTRY_CODE=US SUBNET=10.0.0.0 AP_ADDR=10.0.0.1
         export PRI_DNS=1.1.1.1 SEC_DNS=1.0.0.1 DHCP_LEASE=24h SSID=myssid
         export WPA_PASSPHRASE=supersecret WPA_VERSION=3 MAX_STATIONS=16
-        resolve_config_env 2>/dev/null
+        env_resolve_config_env 2>/dev/null
         printf "%s\n" "${HW_MODE}" "${CHANNEL}" "${COUNTRY_CODE}" \
             "${SUBNET}" "${AP_ADDR}" "${PRI_DNS}" "${SEC_DNS}" \
             "${DHCP_LEASE}" "${SSID}" "${WPA_PASSPHRASE}" \
@@ -64,15 +64,15 @@ setup() {
     [ "${lines[11]}" = "16" ]
 }
 
-@test "resolve_config_env warns when COUNTRY_CODE is not set" {
-    run resolve_config_env
+@test "env_resolve_config_env warns when COUNTRY_CODE is not set" {
+    run env_resolve_config_env
     [ "$status" -eq 0 ]
     [[ "$output" == *"COUNTRY_CODE not set, defaulting to 'EU'"* ]]
 }
 
-@test "resolve_config_env stays silent when COUNTRY_CODE is set" {
+@test "env_resolve_config_env stays silent when COUNTRY_CODE is set" {
     COUNTRY_CODE=JP
-    run resolve_config_env
+    run env_resolve_config_env
     [ "$status" = 0 ]
     [ "$output" = "" ]
 }

--- a/tests/env.bats
+++ b/tests/env.bats
@@ -80,23 +80,23 @@ setup() {
 # Lib modules must not re-default their own vars (#237): sourcing only
 # the module and calling it with an empty environment must fail loudly
 # rather than silently resolving defaults.
-@test "compute_wpa_conf without resolved env does not apply defaults" {
+@test "wpa_compute_conf without resolved env does not apply defaults" {
     . "${BATS_TEST_DIRNAME}/../lib/wpa.sh"
     unset WPA_VERSION
-    run compute_wpa_conf
+    run wpa_compute_conf
     [ "$status" -ne 0 ]
 }
 
-@test "compute_max_sta_conf without MAX_STATIONS errors instead of defaulting" {
+@test "stations_compute_max_sta_conf without MAX_STATIONS errors instead of defaulting" {
     . "${BATS_TEST_DIRNAME}/../lib/stations.sh"
     unset MAX_STATIONS
-    run compute_max_sta_conf
+    run stations_compute_max_sta_conf
     [ "$status" -ne 0 ]
 }
 
-@test "validate_channel with unresolved empty env fails loudly" {
+@test "channel_validate with unresolved empty env fails loudly" {
     . "${BATS_TEST_DIRNAME}/../lib/channel.sh"
     unset HW_MODE CHANNEL COUNTRY_CODE
-    run validate_channel_strict
+    run channel_validate_strict
     [ "$status" -ne 0 ]
 }

--- a/tests/extra_opts.bats
+++ b/tests/extra_opts.bats
@@ -6,28 +6,28 @@ setup() {
 }
 
 @test "HOSTAPD_EXTRA_OPTS unset produces no output" {
-    run compute_extra_opts_lines
+    run extra_opts_compute_lines
     [ "$status" -eq 0 ]
     [ "$output" = "" ]
 }
 
 @test "HOSTAPD_EXTRA_OPTS empty string produces no output" {
     HOSTAPD_EXTRA_OPTS=""
-    run compute_extra_opts_lines
+    run extra_opts_compute_lines
     [ "$status" -eq 0 ]
     [ "$output" = "" ]
 }
 
 @test "HOSTAPD_EXTRA_OPTS single line is passed through verbatim" {
     HOSTAPD_EXTRA_OPTS="auth_algs=3"
-    run compute_extra_opts_lines
+    run extra_opts_compute_lines
     [ "$status" -eq 0 ]
     [ "$output" = "auth_algs=3" ]
 }
 
 @test "HOSTAPD_EXTRA_OPTS multiple lines are emitted in order" {
     HOSTAPD_EXTRA_OPTS=$'auth_algs=3\nignore_broadcast_ssid=1\nbeacon_int=100'
-    run compute_extra_opts_lines
+    run extra_opts_compute_lines
     [ "$status" -eq 0 ]
     [ "${lines[0]}" = "auth_algs=3" ]
     [ "${lines[1]}" = "ignore_broadcast_ssid=1" ]
@@ -36,7 +36,7 @@ setup() {
 
 @test "HOSTAPD_EXTRA_OPTS blank lines are skipped" {
     HOSTAPD_EXTRA_OPTS=$'auth_algs=3\n\n\nbeacon_int=100\n'
-    run compute_extra_opts_lines
+    run extra_opts_compute_lines
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -eq 2 ]
 }

--- a/tests/failure_report.bats
+++ b/tests/failure_report.bats
@@ -9,51 +9,51 @@ load_logging() {
     . "$(dirname "$BATS_TEST_FILENAME")/../lib/logging.sh"
 }
 
-@test "report_failure is defined after loading lib/logging.sh" {
+@test "logging_report_failure is defined after loading lib/logging.sh" {
     load_logging
-    [ "$(type -t report_failure)" = "function" ]
+    [ "$(type -t logging_report_failure)" = "function" ]
 }
 
-@test "report_failure points at last tagged daemon line" {
+@test "logging_report_failure points at last tagged daemon line" {
     load_logging
     local log
     log=$(mktemp)
     printf '[dnsmasq] started\n[hostapd] line 1\n[hostapd] IEEE 802.11 driver not found\n' > "${log}"
-    run report_failure 1 "${log}"
+    run logging_report_failure 1 "${log}"
     rm -f "${log}"
     [ "$status" -eq 0 ]
     [[ "$output" == *"[Error] Container exiting (status 1): check [hostapd] lines above for startup failure."* ]]
 }
 
-@test "report_failure falls back to generic tag when log empty" {
+@test "logging_report_failure falls back to generic tag when log empty" {
     load_logging
-    run report_failure 3 ""
+    run logging_report_failure 3 ""
     [[ "$output" == *"[daemon] lines above for startup failure."* ]]
 }
 
-@test "report_failure falls back to generic tag when no tags present" {
+@test "logging_report_failure falls back to generic tag when no tags present" {
     load_logging
     local log
     log=$(mktemp)
     printf 'some untagged output\n' > "${log}"
-    run report_failure 2 "${log}"
+    run logging_report_failure 2 "${log}"
     rm -f "${log}"
     [[ "$output" == *"check [daemon] lines"* ]]
 }
 
-@test "report_failure writes to stderr" {
+@test "logging_report_failure writes to stderr" {
     load_logging
-    run bash -c ". '${BATS_TEST_DIRNAME}/../lib/logging.sh'; report_failure 1"
+    run bash -c ". '${BATS_TEST_DIRNAME}/../lib/logging.sh'; logging_report_failure 1"
     [[ "$output" == *"[Error]"* ]]
 }
 
-@test "report_failure preserves full log at FAILURE_LOG_PATH and mentions it" {
+@test "logging_report_failure preserves full log at FAILURE_LOG_PATH and mentions it" {
     load_logging
     local log dest
     log=$(mktemp)
     dest=$(mktemp)
     printf '[dnsmasq] started\n[hostapd] IEEE 802.11 driver not found\n' > "${log}"
-    FAILURE_LOG_PATH="${dest}" run report_failure 1 "${log}"
+    FAILURE_LOG_PATH="${dest}" run logging_report_failure 1 "${log}"
     rm -f "${log}"
     [ "$status" -eq 0 ]
     [[ "$output" == *"Full daemon log saved to ${dest}."* ]]
@@ -61,18 +61,18 @@ load_logging() {
     rm -f "${dest}"
 }
 
-@test "report_failure does not mention saved log when none given" {
+@test "logging_report_failure does not mention saved log when none given" {
     load_logging
-    run report_failure 2 ""
+    run logging_report_failure 2 ""
     [[ "$output" != *"saved to"* ]]
 }
 
-@test "report_failure warns and continues when FAILURE_LOG_PATH is unwritable" {
+@test "logging_report_failure warns and continues when FAILURE_LOG_PATH is unwritable" {
     load_logging
     local log
     log=$(mktemp)
     printf '[hostapd] driver missing\n' > "${log}"
-    FAILURE_LOG_PATH="/nonexistent-dir-162/failure.log" run report_failure 1 "${log}"
+    FAILURE_LOG_PATH="/nonexistent-dir-162/failure.log" run logging_report_failure 1 "${log}"
     rm -f "${log}"
     [ "$status" -eq 0 ]
     [[ "$output" == *"Warning: could not save daemon log to /nonexistent-dir-162/failure.log."* ]]
@@ -85,10 +85,10 @@ load_logging() {
     dir=$(mktemp -d)
     log=$(mktemp)
     printf '[hostapd] driver missing\n' > "${log}"
-    FAILURE_LOG_PATH="" FAILURE_LOG_DIR="${dir}" run report_failure 1 "${log}"
+    FAILURE_LOG_PATH="" FAILURE_LOG_DIR="${dir}" run logging_report_failure 1 "${log}"
     [ "$status" -eq 0 ]
     sleep 1
-    FAILURE_LOG_PATH="" FAILURE_LOG_DIR="${dir}" run report_failure 2 "${log}"
+    FAILURE_LOG_PATH="" FAILURE_LOG_DIR="${dir}" run logging_report_failure 2 "${log}"
     rm -f "${log}"
     local count
     count=$(find "${dir}" -name 'hostap-failure-*.log' | wc -l | tr -d ' ')
@@ -109,7 +109,7 @@ load_logging() {
     log=$(mktemp)
     printf '[hostapd] fresh\n' > "${log}"
     FAILURE_LOG_PATH="" FAILURE_LOG_DIR="${dir}" FAILURE_LOG_KEEP=3 \
-        run report_failure 1 "${log}"
+        run logging_report_failure 1 "${log}"
     rm -f "${log}"
     [ "$status" -eq 0 ]
     local count
@@ -127,7 +127,7 @@ load_logging() {
     log=$(mktemp)
     dest="$(mktemp -d)/fixed-name.log"
     printf '[hostapd] driver missing\n' > "${log}"
-    FAILURE_LOG_PATH="${dest}" FAILURE_LOG_KEEP=5 run report_failure 1 "${log}"
+    FAILURE_LOG_PATH="${dest}" FAILURE_LOG_KEEP=5 run logging_report_failure 1 "${log}"
     rm -f "${log}"
     [ -f "${dest}" ]
     grep -q '\[hostapd\] driver missing' "${dest}"
@@ -135,12 +135,12 @@ load_logging() {
 }
 
 @test "wlanstart reports failing daemon on non-signal exit" {
-    grep -q 'report_failure "${STATUS}"' "${SCRIPT}"
+    grep -q 'logging_report_failure "${STATUS}"' "${SCRIPT}"
 }
 
 @test "wlanstart removes temp daemon log only on clean shutdown (#162)" {
     run grep -A4 'if \[ "\${STATUS}" -ne 0 \] ; then' "${SCRIPT}"
-    [[ "$output" == *"report_failure"* ]]
+    [[ "$output" == *"logging_report_failure"* ]]
     # failure branch must NOT delete the temp log; the rm lives in else/clean path
     run bash -c "grep -c 'rm -f \"\${_DAEMON_LOG}\"' '${SCRIPT}'"
     [ "$output" -ge 1 ]
@@ -163,7 +163,7 @@ _MULTIRUN_PID=\$!
 wait \"\${_MULTIRUN_PID}\"
 STATUS=\$?
 if [ \"\${STATUS}\" -ne 0 ] ; then
-    report_failure \"\${STATUS}\" \"\${_DAEMON_LOG}\"
+    logging_report_failure \"\${STATUS}\" \"\${_DAEMON_LOG}\"
 else
     rm -f \"\${_DAEMON_LOG}\"
 fi
@@ -188,7 +188,7 @@ exit \"\${STATUS}\"
     run bash -c "
 $(sed -n '/^_MULTIRUN_PID=\"\"$/p; /^_SIGNALED=0$/p' "${SCRIPT}")
 cleanup() { : ; }
-report_failure() { echo \"MOCK_REPORT \$@\"; }
+logging_report_failure() { echo \"MOCK_REPORT \$@\"; }
 _DAEMON_LOG=\$(mktemp)
 # stub multirun: emit tagged lines like real daemons, then die like hostapd
 multirun() {
@@ -204,7 +204,7 @@ _MULTIRUN_PID=\$!
 wait \"\${_MULTIRUN_PID}\"
 STATUS=\$?
 if [ \"\${STATUS}\" -ne 0 ] ; then
-    report_failure \"\${STATUS}\" \"\${_DAEMON_LOG}\"
+    logging_report_failure \"\${STATUS}\" \"\${_DAEMON_LOG}\"
 fi
 rm -f \"\${_DAEMON_LOG}\"
 exit \"\${STATUS}\"

--- a/tests/hide_ssid.bats
+++ b/tests/hide_ssid.bats
@@ -6,28 +6,28 @@ setup() {
 }
 
 @test "HIDE_SSID not set produces no config line" {
-    run compute_ssid_hidden_line
+    run ssid_hidden_compute_line
     [ "$status" -eq 0 ]
     [ "$output" = "" ]
 }
 
 @test "HIDE_SSID=1 produces ssid_hidden=1" {
     HIDE_SSID=1
-    run compute_ssid_hidden_line
+    run ssid_hidden_compute_line
     [ "$status" -eq 0 ]
     [ "$output" = "ssid_hidden=1" ]
 }
 
 @test "HIDE_SSID=0 produces ssid_hidden=0" {
     HIDE_SSID=0
-    run compute_ssid_hidden_line
+    run ssid_hidden_compute_line
     [ "$status" -eq 0 ]
     [ "$output" = "ssid_hidden=0" ]
 }
 
 @test "HIDE_SSID empty string produces ssid_hidden with empty value" {
     HIDE_SSID=""
-    run compute_ssid_hidden_line
+    run ssid_hidden_compute_line
     [ "$status" -eq 0 ]
     [ "$output" = "ssid_hidden=" ]
 }

--- a/tests/interface_prefix.bats
+++ b/tests/interface_prefix.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# Tests exercise setup_interface() from lib/interface.sh with a stubbed
+# Tests exercise interface_setup() from lib/interface.sh with a stubbed
 # ip command, verifying the netmask-derived prefix (DHCP_PREFIX).
 
 REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
@@ -17,21 +17,21 @@ setup() {
     ip() { echo "ip $*" >> "${LOG}"; }
 }
 
-@test "setup_interface defaults to /24 when DHCP_PREFIX is unset" {
-    run setup_interface
+@test "interface_setup defaults to /24 when DHCP_PREFIX is unset" {
+    run interface_setup
     [ "$status" -eq 0 ]
     grep -q -- "ip addr add 192.168.254.1/24 dev wlan0" "${LOG}"
 }
 
-@test "setup_interface uses DHCP_PREFIX for the interface address" {
+@test "interface_setup uses DHCP_PREFIX for the interface address" {
     DHCP_PREFIX=28
-    run setup_interface
+    run interface_setup
     [ "$status" -eq 0 ]
     grep -q -- "ip addr add 192.168.254.1/28 dev wlan0" "${LOG}"
 }
 
-@test "setup_interface flushes addresses before assigning" {
-    run setup_interface
+@test "interface_setup flushes addresses before assigning" {
+    run interface_setup
     [ "$status" -eq 0 ]
     [ "$(grep -n 'addr add' "${LOG}" | cut -d: -f1)" -gt "$(grep -n 'addr flush' "${LOG}" | cut -d: -f1)" ]
 }

--- a/tests/ipv6.bats
+++ b/tests/ipv6.bats
@@ -30,86 +30,86 @@ setup() {
     [ "${lines[@]: -1}" = "dhcp-range=::,constructor:wlan0,ra-names,stateless" ]
 }
 
-@test "apply_ipv6_rules with OUTGOINGS calls ip6tables per interface" {
+@test "ipv6_apply_rules with OUTGOINGS calls ip6tables per interface" {
     IPV6=1
     OUTGOINGS="eth0,eth1"
-    parse_outgoings() { ints=("eth0" "eth1"); }
-    interface_exists() { return 0; }
+    nat_parse_outgoings() { ints=("eth0" "eth1"); }
+    nat_interface_exists() { return 0; }
     ip6tables() { echo "ip6tables $*"; }
-    parse_outgoings
-    run apply_ipv6_rules
+    nat_parse_outgoings
+    run ipv6_apply_rules
     [ "$status" -eq 0 ]
     [[ "${output}" == *"ip6tables -A FORWARD -i eth0 -o wlan0"* ]]
     [[ "${output}" == *"ip6tables -A FORWARD -i wlan0 -o eth1"* ]]
 }
 
-@test "apply_ipv6_rules fails fast naming nonexistent OUTGOINGS interface" {
+@test "ipv6_apply_rules fails fast naming nonexistent OUTGOINGS interface" {
     IPV6=1
     OUTGOINGS="bogus9"
     ip6tables() { echo "ip6tables $*"; }
-    run apply_ipv6_rules
+    run ipv6_apply_rules
     [ "$status" -eq 1 ]
     [[ "${output}" == *"[Error] OUTGOINGS interface 'bogus9' does not exist"* ]]
 }
 
-@test "apply_ipv6_rules without OUTGOINGS uses generic rules" {
+@test "ipv6_apply_rules without OUTGOINGS uses generic rules" {
     IPV6=1
     ip6tables() { echo "ip6tables $*"; }
-    run apply_ipv6_rules
+    run ipv6_apply_rules
     [ "$status" -eq 0 ]
     [[ "${output}" == *"ip6tables -A FORWARD -i wlan0 -j ACCEPT"* ]]
     [[ "${output}" == *"-o wlan0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT"* ]]
 }
 
-@test "remove_ipv6_rules deletes generic rules" {
+@test "ipv6_remove_rules deletes generic rules" {
     local log="${BATS_TEST_TMPDIR}/ip6tables.log"
     ip6tables() {
         if [ "$1" = "-D" ] ; then echo "delete $*" >> "${log}"; fi
         return 0
     }
-    remove_ipv6_rules
+    ipv6_remove_rules
     [ "$(grep -c delete "${log}")" -eq 2 ]
     [[ "$(cat "${log}")" == *"-i wlan0 -j ACCEPT"* ]]
 }
 
-@test "remove_ipv6_rules works standalone with OUTGOINGS (no nat.sh loaded)" {
+@test "ipv6_remove_rules works standalone with OUTGOINGS (no nat.sh loaded)" {
     local log="${BATS_TEST_TMPDIR}/ip6tables-standalone.log"
     rm -f "${log}"
     REPO_ROOT="$REPO_ROOT" LOG="${log}" \
     run bash -c '
         ip6tables() { case "$*" in *"-D "*) echo "$*" >> "${LOG}" ;; esac ; }
         . "'"${REPO_ROOT}"'/lib/ipv6.sh"
-        INTERFACE="wlan0" OUTGOINGS="eth0,eth1" remove_ipv6_rules
+        INTERFACE="wlan0" OUTGOINGS="eth0,eth1" ipv6_remove_rules
     '
     [ "$status" -eq 0 ]
     grep -q -- "-D FORWARD -i wlan0 -o eth0 -j ACCEPT" "${log}"
     grep -q -- "-D FORWARD -i eth1 -o wlan0 -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT" "${log}"
 }
 
-@test "apply_ipv6_rules works standalone with OUTGOINGS (no nat.sh loaded)" {
+@test "ipv6_apply_rules works standalone with OUTGOINGS (no nat.sh loaded)" {
     run bash -c '
         ip6tables() { echo "ip6tables $*" >&2; }
         ip() { return 0; }
         . "'"${REPO_ROOT}"'/lib/ipv6.sh"
-        INTERFACE="wlan0" OUTGOINGS="eth0,eth1" apply_ipv6_rules
+        INTERFACE="wlan0" OUTGOINGS="eth0,eth1" ipv6_apply_rules
     '
     [ "$status" -eq 0 ]
     [[ "${output}" == *"ip6tables -A FORWARD -i eth0 -o wlan0"* ]]
     [[ "${output}" == *"ip6tables -A FORWARD -i wlan0 -o eth1 -j ACCEPT"* ]]
 }
 
-@test "enable_ipv6_forwarding writes 1 to forwarding sysctl" {
+@test "ipv6_enable_forwarding writes 1 to forwarding sysctl" {
     local base="${BATS_TEST_TMPDIR}/sysctl-ok/net/ipv6"
     mkdir -p "${base}/conf/all"
     IPV6_SYSCTL_BASE="${base}"
-    run enable_ipv6_forwarding
+    run ipv6_enable_forwarding
     [ "$status" -eq 0 ]
     [ "$(cat "${base}/conf/all/forwarding")" = "1" ]
 }
 
-@test "enable_ipv6_forwarding warns on missing sysctl without aborting" {
+@test "ipv6_enable_forwarding warns on missing sysctl without aborting" {
     IPV6_SYSCTL_BASE="${BATS_TEST_TMPDIR}/nonexistent-ipv6-sysctl"
-    run enable_ipv6_forwarding
+    run ipv6_enable_forwarding
     [ "$status" -eq 0 ]
     [[ "${output}" == *"[Warning] Cannot set net.ipv6.conf.all.forwarding"* ]]
 }

--- a/tests/ipv6.bats
+++ b/tests/ipv6.bats
@@ -13,19 +13,19 @@ setup() {
 
 @test "IPv6 disabled by default: no dnsmasq conf" {
     unset IPV6
-    run compute_dnsmasq_ipv6_conf
+    run ipv6_compute_dnsmasq_conf
     [ "$status" -eq 1 ]
 }
 
 @test "IPv6 disabled explicitly (IPV6=0): no dnsmasq conf" {
     IPV6=0
-    run compute_dnsmasq_ipv6_conf
+    run ipv6_compute_dnsmasq_conf
     [ "$status" -eq 1 ]
 }
 
 @test "IPV6=1 emits RA/stateless DHCPv6 range for AP interface" {
     IPV6=1
-    run compute_dnsmasq_ipv6_conf
+    run ipv6_compute_dnsmasq_conf
     [ "$status" -eq 0 ]
     [ "${lines[@]: -1}" = "dhcp-range=::,constructor:wlan0,ra-names,stateless" ]
 }

--- a/tests/mac_filter.bats
+++ b/tests/mac_filter.bats
@@ -10,14 +10,14 @@ setup() {
 }
 
 @test "MAC filter disabled by default: silent no-op success" {
-    run compute_mac_filter_conf
+    run mac_filter_compute_conf
     [ "$status" -eq 0 ]
     [ "$output" = "" ]
 }
 
 @test "MAC_FILTER=0 explicitly: silent no-op success" {
     MAC_FILTER=0
-    run compute_mac_filter_conf
+    run mac_filter_compute_conf
     [ "$status" -eq 0 ]
     [ "$output" = "" ]
 }
@@ -25,7 +25,7 @@ setup() {
 @test "MAC_FILTER=1 emits macaddr_acl=1 and accept_mac_file" {
     MAC_FILTER=1
     MAC_ACL_FILE="/etc/hostapd.accept"
-    run compute_mac_filter_conf
+    run mac_filter_compute_conf
     [ "$status" -eq 0 ]
     [ "${lines[0]}" = "macaddr_acl=1" ]
     [ "${lines[1]}" = "accept_mac_file=/etc/hostapd.accept" ]
@@ -34,21 +34,21 @@ setup() {
 @test "MAC_FILTER=2 emits macaddr_acl=1 and deny_mac_file" {
     MAC_FILTER=2
     MAC_ACL_FILE="/etc/hostapd.deny"
-    run compute_mac_filter_conf
+    run mac_filter_compute_conf
     [ "$status" -eq 0 ]
     [ "${lines[0]}" = "macaddr_acl=1" ]
     [ "${lines[1]}" = "deny_mac_file=/etc/hostapd.deny" ]
 }
 
 @test "validation passes when filter disabled without file" {
-    run validate_mac_filter
+    run mac_filter_validate
     [ "$status" -eq 0 ]
 }
 
 @test "validation errors if allowlist enabled without file" {
     MAC_FILTER=1
     unset MAC_ACL_FILE
-    run validate_mac_filter
+    run mac_filter_validate
     [ "$status" -eq 1 ]
     [[ "${output}" == *"[Error]"*"MAC_ACL_FILE"* ]]
 }
@@ -56,14 +56,14 @@ setup() {
 @test "validation errors if denylist enabled without file" {
     MAC_FILTER=2
     unset MAC_ACL_FILE
-    run validate_mac_filter
+    run mac_filter_validate
     [ "$status" -eq 1 ]
 }
 
 @test "validation warns if ACL file missing" {
     MAC_FILTER=1
     MAC_ACL_FILE="${BATS_TEST_TMPDIR}/does-not-exist"
-    run validate_mac_filter
+    run mac_filter_validate
     [ "$status" -eq 0 ]
     [[ "${output}" == *"[Warning]"* ]]
 }
@@ -73,7 +73,7 @@ setup() {
     echo "aa:bb:cc:dd:ee:ff" > "${f}"
     MAC_FILTER=2
     MAC_ACL_FILE="${f}"
-    run validate_mac_filter
+    run mac_filter_validate
     [ "$status" -eq 0 ]
     [ "$output" = "" ]
 }
@@ -81,7 +81,7 @@ setup() {
 @test "validation rejects invalid MAC_FILTER value" {
     MAC_FILTER=3
     MAC_ACL_FILE="/etc/hostapd.accept"
-    run validate_mac_filter
+    run mac_filter_validate
     [ "$status" -eq 1 ]
     [[ "${output}" == *"[Error]"*"Invalid MAC_FILTER"* ]]
 }

--- a/tests/max_stations.bats
+++ b/tests/max_stations.bats
@@ -14,35 +14,35 @@ setup() {
 }
 
 @test "default MAX_STATIONS=0 produces no config line" {
-    run compute_max_sta_conf
+    run stations_compute_max_sta_conf
     [ "$status" -eq 0 ]
     [ "$output" = "" ]
 }
 
 @test "MAX_STATIONS=1 produces max_num_sta=1" {
     MAX_STATIONS=1
-    run compute_max_sta_conf
+    run stations_compute_max_sta_conf
     [ "$status" -eq 0 ]
     [ "$output" = "max_num_sta=1" ]
 }
 
 @test "MAX_STATIONS=10 produces max_num_sta=10" {
     MAX_STATIONS=10
-    run compute_max_sta_conf
+    run stations_compute_max_sta_conf
     [ "$status" -eq 0 ]
     [ "$output" = "max_num_sta=10" ]
 }
 
 @test "MAX_STATIONS=0 produces no config line" {
     MAX_STATIONS=0
-    run compute_max_sta_conf
+    run stations_compute_max_sta_conf
     [ "$status" -eq 0 ]
     [ "$output" = "" ]
 }
 
 @test "negative MAX_STATIONS fails with error and no config line" {
     MAX_STATIONS=-5
-    run compute_max_sta_conf
+    run stations_compute_max_sta_conf
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid MAX_STATIONS"* ]]
     [[ "$output" != *"max_num_sta"* ]]
@@ -50,7 +50,7 @@ setup() {
 
 @test "non-numeric MAX_STATIONS fails with error and no config line" {
     MAX_STATIONS="abc"
-    run compute_max_sta_conf
+    run stations_compute_max_sta_conf
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid MAX_STATIONS"* ]]
     [[ "$output" != *"max_num_sta"* ]]
@@ -58,14 +58,14 @@ setup() {
 
 @test "MAX_STATIONS=0 does not produce warning" {
     MAX_STATIONS=0
-    run compute_max_sta_conf
+    run stations_compute_max_sta_conf
     [ "$status" -eq 0 ]
     [[ "$output" != *"Invalid"* ]]
 }
 
 @test "MAX_STATIONS=10 does not produce warning" {
     MAX_STATIONS=10
-    run compute_max_sta_conf
+    run stations_compute_max_sta_conf
     [ "$status" -eq 0 ]
     [[ "$output" != *"Invalid"* ]]
 }

--- a/tests/max_stations.bats
+++ b/tests/max_stations.bats
@@ -8,7 +8,7 @@ setup() {
     # shellcheck source=../lib/env.sh
     . "$(dirname "$BATS_TEST_FILENAME")/../lib/env.sh"
     # Default MAX_STATIONS now applied centrally in lib/env.sh (issue #237)
-    resolve_config_env
+    env_resolve_config_env
     # shellcheck source=../lib/stations.sh
     . "$(dirname "$BATS_TEST_FILENAME")/../lib/stations.sh"
 }

--- a/tests/nat.bats
+++ b/tests/nat.bats
@@ -11,29 +11,29 @@ setup() {
     export OUTGOINGS=""
 }
 
-@test "parse_outgoings parses comma-separated interfaces" {
-    OUTGOINGS="eth0,wlan0" parse_outgoings
+@test "nat_parse_outgoings parses comma-separated interfaces" {
+    OUTGOINGS="eth0,wlan0" nat_parse_outgoings
     [ "${#ints[@]}" -eq 2 ]
     [ "${ints[0]}" = "eth0" ]
     [ "${ints[1]}" = "wlan0" ]
 }
 
-@test "parse_outgoings collapses repeated commas" {
-    OUTGOINGS="eth0,,wlan0," parse_outgoings
+@test "nat_parse_outgoings collapses repeated commas" {
+    OUTGOINGS="eth0,,wlan0," nat_parse_outgoings
     [ "${#ints[@]}" -eq 2 ]
 }
 
-@test "parse_outgoings yields empty array when OUTGOINGS unset" {
-    OUTGOINGS="" parse_outgoings
+@test "nat_parse_outgoings yields empty array when OUTGOINGS unset" {
+    OUTGOINGS="" nat_parse_outgoings
     [ "${#ints[@]}" -eq 0 ]
 }
 
-@test "apply_nat_rules adds rules per interface with OUTGOINGS" {
+@test "nat_apply_rules adds rules per interface with OUTGOINGS" {
     export OUTGOINGS="eth0,eth1"
     ip() { return 0; }
-    parse_outgoings
+    nat_parse_outgoings
     iptables() { echo "iptables $*"; }
-    run apply_nat_rules
+    run nat_apply_rules
     [ "$status" -eq 0 ]
     [[ "${output}" == *"Setting iptables for outgoing traffics on eth0..."* ]]
     [[ "${output}" == *"iptables -t nat -A POSTROUTING -s 192.168.254.0/24 -o eth0 -j MASQUERADE"* ]]
@@ -42,9 +42,9 @@ setup() {
     [[ "${output}" == *"iptables -A FORWARD -i wlan0 -o eth1 -j ACCEPT"* ]]
 }
 
-@test "apply_nat_rules adds generic rules without OUTGOINGS" {
+@test "nat_apply_rules adds generic rules without OUTGOINGS" {
     iptables() { echo "iptables $*"; }
-    run apply_nat_rules
+    run nat_apply_rules
     [ "$status" -eq 0 ]
     [[ "${output}" == *"Setting iptables for outgoing traffics on all interfaces..."* ]]
     [[ "${output}" == *"iptables -t nat -A POSTROUTING -s 192.168.254.0/24 -j MASQUERADE"* ]]
@@ -52,40 +52,40 @@ setup() {
     [[ "${output}" == *"iptables -A FORWARD -i wlan0 -j ACCEPT"* ]]
 }
 
-@test "apply_nat_rules fails fast naming nonexistent OUTGOINGS interface" {
+@test "nat_apply_rules fails fast naming nonexistent OUTGOINGS interface" {
     export OUTGOINGS="eth0,doesnotexist0"
     iptables() { echo "iptables $*"; }
-    run apply_nat_rules
+    run nat_apply_rules
     [ "$status" -eq 1 ]
     [[ "${output}" == *"[Error] OUTGOINGS interface 'doesnotexist0' does not exist"* ]]
     [[ "${output}" != *"Setting iptables"* ]]
 }
 
-@test "apply_nat_rules proceeds when all OUTGOINGS interfaces exist (stubbed ip)" {
+@test "nat_apply_rules proceeds when all OUTGOINGS interfaces exist (stubbed ip)" {
     export OUTGOINGS="eth0"
     ip() { return 0; }
     iptables() { echo "iptables $*"; }
-    run apply_nat_rules
+    run nat_apply_rules
     [ "$status" -eq 0 ]
     [[ "${output}" == *"Setting iptables for outgoing traffics on eth0..."* ]]
 }
 
-@test "validate_outgoings fails for missing interface without real network tools" {
+@test "nat_validate_outgoings fails for missing interface without real network tools" {
     export OUTGOINGS="bogus9"
     export IP_BASE="${BATS_TEST_TMPDIR}/no-ip"
-    run validate_outgoings
+    run nat_validate_outgoings
     [ "$status" -eq 1 ]
     [[ "${output}" == *"[Error] OUTGOINGS interface 'bogus9' does not exist"* ]]
 }
 
-@test "apply_nat_rules removes stale rule before adding (delete precedes append)" {
+@test "nat_apply_rules removes stale rule before adding (delete precedes append)" {
     local log="${BATS_TEST_TMPDIR}/iptables-order.log"
     iptables() { echo "$1" >> "${log}"; }
-    apply_nat_rules
+    nat_apply_rules
     [ "$(grep -n '^-D' "${log}" | head -1 | cut -d: -f1)" -lt "$(grep -n '^-A' "${log}" | head -1 | cut -d: -f1)" ]
 }
 
-@test "remove_nat_rules deletes generic rules without OUTGOINGS" {
+@test "nat_remove_rules deletes generic rules without OUTGOINGS" {
     local log
     log=$(mktemp)
     OUTGOINGS="" INTERFACE="wlan0" SUBNET="192.168.254.0" \
@@ -93,7 +93,7 @@ setup() {
     run bash -c '
         iptables() { case "$*" in *"-D "*) echo "$*" >> "${LOG}" ;; esac ; }
         . "${REPO_ROOT}/lib/nat.sh"
-        remove_nat_rules
+        nat_remove_rules
     '
     [ "$status" -eq 0 ]
     grep -q -- "-t nat -D POSTROUTING -s 192.168.254.0/24 -j MASQUERADE" "${log}"
@@ -101,15 +101,15 @@ setup() {
     rm -f "${log}"
 }
 
-@test "apply_nat_rules uses DHCP_PREFIX when set" {
+@test "nat_apply_rules uses DHCP_PREFIX when set" {
     DHCP_PREFIX=28
     iptables() { echo "iptables $*"; }
-    run apply_nat_rules
+    run nat_apply_rules
     [ "$status" -eq 0 ]
     [[ "${output}" == *"iptables -t nat -A POSTROUTING -s 192.168.254.0/28 -j MASQUERADE"* ]]
 }
 
-@test "remove_nat_rules deletes rules per interface with OUTGOINGS" {
+@test "nat_remove_rules deletes rules per interface with OUTGOINGS" {
     local log
     log=$(mktemp)
     OUTGOINGS="eth0,eth1" INTERFACE="wlan0" SUBNET="192.168.254.0" \
@@ -117,7 +117,7 @@ setup() {
     run bash -c '
         iptables() { case "$*" in *"-D "*) echo "$*" >> "${LOG}" ;; esac ; }
         . "${REPO_ROOT}/lib/nat.sh"
-        remove_nat_rules
+        nat_remove_rules
     '
     [ "$status" -eq 0 ]
     grep -q -- "-t nat -D POSTROUTING -s 192.168.254.0/24 -o eth0 -j MASQUERADE" "${log}"
@@ -126,26 +126,26 @@ setup() {
     rm -f "${log}"
 }
 
-@test "set_sysctls skips sysctls already set to 1" {
+@test "nat_set_sysctls skips sysctls already set to 1" {
     local dir="${BATS_TEST_TMPDIR}/proc"
     mkdir -p "${dir}"
     echo 1 > "${dir}/ip_dynaddr"
-    SYSCTL_BASE="${dir}" run set_sysctls ip_dynaddr
+    SYSCTL_BASE="${dir}" run nat_set_sysctls ip_dynaddr
     [ "$status" -eq 0 ]
     [[ "${output}" == *"ip_dynaddr already 1"* ]]
     [ "$(cat "${dir}/ip_dynaddr")" = "1" ]
 }
 
-@test "set_sysctls sets sysctl when value is not 1" {
+@test "nat_set_sysctls sets sysctl when value is not 1" {
     local dir="${BATS_TEST_TMPDIR}/proc"
     mkdir -p "${dir}"
     echo 0 > "${dir}/ip_forward"
-    SYSCTL_BASE="${dir}" run set_sysctls ip_forward
+    SYSCTL_BASE="${dir}" run nat_set_sysctls ip_forward
     [ "$status" -eq 0 ]
     [ "$(cat "${dir}/ip_forward")" = "1" ]
 }
 
-@test "set_sysctls warns and continues for missing sysctl" {
+@test "nat_set_sysctls warns and continues for missing sysctl" {
     local dir="${BATS_TEST_TMPDIR}/proc"
     mkdir -p "${dir}"
     echo 0 > "${dir}/ip_forward"
@@ -153,37 +153,37 @@ setup() {
     # fail regardless of privileges (CI may run as root).
     local missing="${BATS_TEST_TMPDIR}/no-such-proc"
     # shellcheck disable=SC2016
-    run bash -c ". '${REPO_ROOT}/lib/nat.sh'; SYSCTL_BASE='${missing}' set_sysctls ip_dynaddr && SYSCTL_BASE='${dir}' set_sysctls ip_forward 2>&1"
+    run bash -c ". '${REPO_ROOT}/lib/nat.sh'; SYSCTL_BASE='${missing}' nat_set_sysctls ip_dynaddr && SYSCTL_BASE='${dir}' nat_set_sysctls ip_forward 2>&1"
     [ "$status" -eq 0 ]
     [[ "${output}" == *"[Warning] Cannot set ip_dynaddr"* ]]
     [ "$(cat "${dir}/ip_forward")" = "1" ]
 }
 
-@test "show_sysctls prints labeled values" {
+@test "nat_show_sysctls prints labeled values" {
     local dir="${BATS_TEST_TMPDIR}/proc"
     mkdir -p "${dir}"
     echo 1 > "${dir}/ip_dynaddr"
     echo 0 > "${dir}/ip_forward"
-    SYSCTL_BASE="${dir}" run show_sysctls ip_dynaddr ip_forward
+    SYSCTL_BASE="${dir}" run nat_show_sysctls ip_dynaddr ip_forward
     [ "$status" -eq 0 ]
     [[ "${output}" == *"ip_dynaddr=1"* ]]
     [[ "${output}" == *"ip_forward=0"* ]]
 }
 
-@test "show_sysctls prints ? for missing sysctl" {
+@test "nat_show_sysctls prints ? for missing sysctl" {
     local dir="${BATS_TEST_TMPDIR}/no-such-proc"
-    SYSCTL_BASE="${dir}" run show_sysctls ip_dynaddr
+    SYSCTL_BASE="${dir}" run nat_show_sysctls ip_dynaddr
     [ "$status" -eq 0 ]
     [[ "${output}" == *"ip_dynaddr=?"* ]]
 }
 
-@test "set_sysctls warns when write fails on non-numeric value" {
+@test "nat_set_sysctls warns when write fails on non-numeric value" {
     local dir="${BATS_TEST_TMPDIR}/proc"
     mkdir -p "${dir}"
     echo "garbage" > "${dir}/ip_dynaddr"
     chmod 444 "${dir}/ip_dynaddr"
     # shellcheck disable=SC2016
-    run bash -c ". '${REPO_ROOT}/lib/nat.sh'; SYSCTL_BASE='${dir}' set_sysctls ip_dynaddr 2>&1"
+    run bash -c ". '${REPO_ROOT}/lib/nat.sh'; SYSCTL_BASE='${dir}' nat_set_sysctls ip_dynaddr 2>&1"
     [ "$status" -eq 0 ]
     [[ "${output}" == *"[Warning] Cannot set ip_dynaddr"* ]]
 }

--- a/tests/passphrase_validation.bats
+++ b/tests/passphrase_validation.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# Tests exercise validate_passphrase() from lib/passphrase.sh — the exact
+# Tests exercise passphrase_validate() from lib/passphrase.sh — the exact
 # code used by wlanstart.sh (no duplicated logic).
 
 setup() {
@@ -14,21 +14,21 @@ load_lib() {
 @test "8-character passphrase is accepted" {
     load_lib
     WPA_PASSPHRASE=12345678
-    run validate_passphrase
+    run passphrase_validate
     [ "$status" -eq 0 ]
 }
 
 @test "63-character passphrase is accepted" {
     load_lib
     WPA_PASSPHRASE=$(printf 'a%.0s' {1..63})
-    run validate_passphrase
+    run passphrase_validate
     [ "$status" -eq 0 ]
 }
 
 @test "7-character passphrase is rejected with error message" {
     load_lib
     WPA_PASSPHRASE=1234567
-    run validate_passphrase
+    run passphrase_validate
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid WPA_PASSPHRASE"* ]]
     [[ "$output" == *"8-63"* ]]
@@ -37,7 +37,7 @@ load_lib() {
 @test "64-character passphrase is rejected with error message" {
     load_lib
     WPA_PASSPHRASE=$(printf 'a%.0s' {1..64})
-    run validate_passphrase
+    run passphrase_validate
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid WPA_PASSPHRASE"* ]]
     [[ "$output" == *"8-63"* ]]
@@ -46,7 +46,7 @@ load_lib() {
 @test "empty passphrase is rejected" {
     load_lib
     WPA_PASSPHRASE=""
-    run validate_passphrase
+    run passphrase_validate
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid WPA_PASSPHRASE"* ]]
 }

--- a/tests/secret_file.bats
+++ b/tests/secret_file.bats
@@ -85,6 +85,6 @@ load_lib() {
     WPA_PASSPHRASE_FILE="${SECRET_FILE}"
     secret_file_load WPA_PASSPHRASE WPA_PASSPHRASE_FILE
     [ "${WPA_PASSPHRASE}" = "passw0rd-from-file" ]
-    run validate_passphrase
+    run passphrase_validate
     [ "$status" -eq 0 ]
 }

--- a/tests/secret_file.bats
+++ b/tests/secret_file.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# Tests exercise load_from_file() from lib/secret_file.sh - the exact
+# Tests exercise secret_file_load() from lib/secret_file.sh - the exact
 # code used by wlanstart.sh (no duplicated logic).
 
 setup() {
@@ -16,7 +16,7 @@ load_lib() {
     load_lib
     printf 'myssid\notherline\n' > "${SECRET_FILE}"
     SSID_FILE="${SECRET_FILE}"
-    load_from_file SSID SSID_FILE
+    secret_file_load SSID SSID_FILE
     [ "${SSID}" = "myssid" ]
 }
 
@@ -24,7 +24,7 @@ load_lib() {
     load_lib
     printf 'sup3rs3cret\n' > "${SECRET_FILE}"
     WPA_PASSPHRASE_FILE="${SECRET_FILE}"
-    load_from_file WPA_PASSPHRASE WPA_PASSPHRASE_FILE
+    secret_file_load WPA_PASSPHRASE WPA_PASSPHRASE_FILE
     [ "${WPA_PASSPHRASE}" = "sup3rs3cret" ]
 }
 
@@ -33,7 +33,7 @@ load_lib() {
     printf 'fromfile\n' > "${SECRET_FILE}"
     SSID=direct
     SSID_FILE="${SECRET_FILE}"
-    load_from_file SSID SSID_FILE 2> "${BATS_TEST_TMPDIR}/stderr"
+    secret_file_load SSID SSID_FILE 2> "${BATS_TEST_TMPDIR}/stderr"
     [ "${SSID}" = "fromfile" ]
     grep -q "using value from SSID_FILE" "${BATS_TEST_TMPDIR}/stderr"
 }
@@ -43,7 +43,7 @@ load_lib() {
     printf 'fromfile\n' > "${SECRET_FILE}"
     WPA_PASSPHRASE=direct
     WPA_PASSPHRASE_FILE="${SECRET_FILE}"
-    run load_from_file WPA_PASSPHRASE WPA_PASSPHRASE_FILE
+    run secret_file_load WPA_PASSPHRASE WPA_PASSPHRASE_FILE
     [ "$status" -eq 0 ]
     [[ "$output" == *"[Warning] Both WPA_PASSPHRASE and WPA_PASSPHRASE_FILE are set"* ]]
 }
@@ -52,7 +52,7 @@ load_lib() {
     load_lib
     SSID=direct
     unset SSID_FILE
-    run load_from_file SSID SSID_FILE
+    run secret_file_load SSID SSID_FILE
     [ "$status" -eq 0 ]
     [ "${SSID}" = "direct" ]
 }
@@ -60,7 +60,7 @@ load_lib() {
 @test "missing file fails with clear error" {
     load_lib
     SSID_FILE="${BATS_TEST_TMPDIR}/does-not-exist"
-    run load_from_file SSID SSID_FILE
+    run secret_file_load SSID SSID_FILE
     [ "$status" -ne 0 ]
     [[ "$output" == *"[Error] SSID_FILE '${BATS_TEST_TMPDIR}/does-not-exist' is not readable"* ]]
 }
@@ -73,7 +73,7 @@ load_lib() {
         skip "cannot make file unreadable (running as root)"
     fi
     WPA_PASSPHRASE_FILE="${SECRET_FILE}"
-    run load_from_file WPA_PASSPHRASE WPA_PASSPHRASE_FILE
+    run secret_file_load WPA_PASSPHRASE WPA_PASSPHRASE_FILE
     [ "$status" -ne 0 ]
     [[ "$output" == *"is not readable"* ]]
 }
@@ -83,7 +83,7 @@ load_lib() {
     . "${BATS_TEST_DIRNAME}/../lib/passphrase.sh"
     printf 'passw0rd-from-file\n' > "${SECRET_FILE}"
     WPA_PASSPHRASE_FILE="${SECRET_FILE}"
-    load_from_file WPA_PASSPHRASE WPA_PASSPHRASE_FILE
+    secret_file_load WPA_PASSPHRASE WPA_PASSPHRASE_FILE
     [ "${WPA_PASSPHRASE}" = "passw0rd-from-file" ]
     run validate_passphrase
     [ "$status" -eq 0 ]

--- a/tests/security_warnings.bats
+++ b/tests/security_warnings.bats
@@ -10,7 +10,7 @@ setup() {
 check_warnings() {
     : "${SSID:=raspberry}"
     : "${WPA_PASSPHRASE:=passw0rd}"
-    emit_credential_warnings
+    warnings_emit_credential_warnings
 }
 
 @test "default WPA passphrase triggers warning" {

--- a/tests/ssid_validation.bats
+++ b/tests/ssid_validation.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# Tests exercise validate_ssid() from lib/validation.sh - the exact
+# Tests exercise validation_check_ssid() from lib/validation.sh - the exact
 # code used by wlanstart.sh (no duplicated logic).
 
 load_lib() {
@@ -9,26 +9,26 @@ load_lib() {
 
 @test "default SSID 'raspberry' is accepted" {
     load_lib
-    run validate_ssid "raspberry"
+    run validation_check_ssid "raspberry"
     [ "$status" -eq 0 ]
 }
 
 @test "32-character SSID is accepted" {
     load_lib
-    run validate_ssid "$(printf 'a%.0s' {1..32})"
+    run validation_check_ssid "$(printf 'a%.0s' {1..32})"
     [ "$status" -eq 0 ]
 }
 
 @test "empty SSID is rejected" {
     load_lib
-    run validate_ssid ""
+    run validation_check_ssid ""
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid SSID"* ]]
 }
 
 @test "33-character SSID is rejected with error message" {
     load_lib
-    run validate_ssid "$(printf 'a%.0s' {1..33})"
+    run validation_check_ssid "$(printf 'a%.0s' {1..33})"
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid SSID"* ]]
     [[ "$output" == *"32"* ]]
@@ -36,48 +36,48 @@ load_lib() {
 
 @test "SSID containing newline (config key injection) is rejected" {
     load_lib
-    run validate_ssid $'legit\nauth_algs=1'
+    run validation_check_ssid $'legit\nauth_algs=1'
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid SSID"* ]]
 }
 
 @test "SSID containing '=' (config key injection) is rejected" {
     load_lib
-    run validate_ssid "ssid=evil"
+    run validation_check_ssid "ssid=evil"
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid SSID"* ]]
 }
 
 @test "SSID containing '#' (comment injection) is rejected" {
     load_lib
-    run validate_ssid "my#ssid"
+    run validation_check_ssid "my#ssid"
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid SSID"* ]]
 }
 
 @test "SSID with leading whitespace is rejected" {
     load_lib
-    run validate_ssid " ssid"
+    run validation_check_ssid " ssid"
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid SSID"* ]]
 }
 
 @test "SSID with trailing whitespace is rejected" {
     load_lib
-    run validate_ssid "ssid "
+    run validation_check_ssid "ssid "
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid SSID"* ]]
 }
 
 @test "SSID of 32 multibyte characters (over 32 bytes) is rejected" {
     load_lib
-    run validate_ssid "$(printf 'é%.0s' {1..32})"
+    run validation_check_ssid "$(printf 'é%.0s' {1..32})"
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid SSID"* ]]
 }
 
 @test "SSID within 32 bytes containing multibyte characters is accepted" {
     load_lib
-    run validate_ssid "ááááááááááááááá"  # 15 chars = 30 bytes in UTF-8
+    run validation_check_ssid "ááááááááááááááá"  # 15 chars = 30 bytes in UTF-8
     [ "$status" -eq 0 ]
 }

--- a/tests/tx_power.bats
+++ b/tests/tx_power.bats
@@ -14,83 +14,83 @@ setup() {
 }
 
 @test "unset TX_POWER validates OK" {
-    run validate_tx_power
+    run radio_validate_tx_power
     [ "$status" -eq 0 ]
 }
 
 @test "TX_POWER=auto validates OK" {
     TX_POWER=auto
-    run validate_tx_power
+    run radio_validate_tx_power
     [ "$status" -eq 0 ]
 }
 
 @test "TX_POWER=20 (dBm) validates OK" {
     TX_POWER=20
-    run validate_tx_power
+    run radio_validate_tx_power
     [ "$status" -eq 0 ]
 }
 
 @test "TX_POWER=0 validates OK" {
     TX_POWER=0
-    run validate_tx_power
+    run radio_validate_tx_power
     [ "$status" -eq 0 ]
 }
 
 @test "invalid TX_POWER 'high' fails with error" {
     TX_POWER=high
-    run validate_tx_power
+    run radio_validate_tx_power
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid TX_POWER"* ]]
 }
 
 @test "negative TX_POWER fails with error" {
     TX_POWER=-5
-    run validate_tx_power
+    run radio_validate_tx_power
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid TX_POWER"* ]]
 }
 
 @test "non-numeric TX_POWER with digits mixed in fails" {
     TX_POWER=10dbm
-    run validate_tx_power
+    run radio_validate_tx_power
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid TX_POWER"* ]]
 }
 
-@test "apply_tx_power is a no-op when unset" {
-    run apply_tx_power
+@test "radio_apply_tx_power is a no-op when unset" {
+    run radio_apply_tx_power
     [ "$status" -eq 0 ]
 }
 
-@test "apply_tx_power runs iw set txpower fixed for dBm values" {
+@test "radio_apply_tx_power runs iw set txpower fixed for dBm values" {
     TX_POWER=15
     PATH="/usr/bin:/bin"
     mkdir -p "$BATS_TMPDIR/fakebin"
     printf '#!/bin/sh\necho "iw $@"\n' > "$BATS_TMPDIR/fakebin/iw"
     chmod +x "$BATS_TMPDIR/fakebin/iw"
-    PATH="$BATS_TMPDIR/fakebin:$PATH" run apply_tx_power
+    PATH="$BATS_TMPDIR/fakebin:$PATH" run radio_apply_tx_power
     rm -rf "$BATS_TMPDIR/fakebin"
     [ "$status" -eq 0 ]
     [[ "$output" == *"iw dev wlan0 set txpower fixed 15"* ]]
 }
 
-@test "apply_tx_power runs iw set txpower auto for auto" {
+@test "radio_apply_tx_power runs iw set txpower auto for auto" {
     TX_POWER=auto
     mkdir -p "$BATS_TMPDIR/fakebin"
     printf '#!/bin/sh\necho "iw $@"\n' > "$BATS_TMPDIR/fakebin/iw"
     chmod +x "$BATS_TMPDIR/fakebin/iw"
-    PATH="$BATS_TMPDIR/fakebin:$PATH" run apply_tx_power
+    PATH="$BATS_TMPDIR/fakebin:$PATH" run radio_apply_tx_power
     rm -rf "$BATS_TMPDIR/fakebin"
     [ "$status" -eq 0 ]
     [[ "$output" == *"iw dev wlan0 set txpower auto"* ]]
 }
 
-@test "iw failure makes apply_tx_power fatal" {
+@test "iw failure makes radio_apply_tx_power fatal" {
     TX_POWER=15
     mkdir -p "$BATS_TMPDIR/fakebin"
     printf '#!/bin/sh\nexit 1\n' > "$BATS_TMPDIR/fakebin/iw"
     chmod +x "$BATS_TMPDIR/fakebin/iw"
-    PATH="$BATS_TMPDIR/fakebin:$PATH" run apply_tx_power
+    PATH="$BATS_TMPDIR/fakebin:$PATH" run radio_apply_tx_power
     rm -rf "$BATS_TMPDIR/fakebin"
     [ "$status" -ne 0 ]
     [[ "$output" == *"Failed to set txpower"* ]]

--- a/tests/tx_power.bats
+++ b/tests/tx_power.bats
@@ -8,7 +8,7 @@ setup() {
     COUNTRY_CODE=EU
     # shellcheck source=../lib/env.sh
     . "$(dirname "$BATS_TEST_FILENAME")/../lib/env.sh"
-    resolve_config_env
+    env_resolve_config_env
     # shellcheck source=../lib/radio.sh
     . "$(dirname "$BATS_TEST_FILENAME")/../lib/radio.sh"
 }

--- a/tests/validation.bats
+++ b/tests/validation.bats
@@ -1,69 +1,69 @@
 #!/usr/bin/env bats
 
-# Tests exercise validate_ipv4() from lib/validation.sh — the exact
+# Tests exercise validation_check_ipv4() from lib/validation.sh — the exact
 # code used by wlanstart.sh (no duplicated logic).
 
 load_lib() {
     . "${BATS_TEST_DIRNAME}/../lib/validation.sh"
 }
 
-# wlanstart-level check: exercise validate_ipv4_param, the exact helper
+# wlanstart-level check: exercise validation_check_ipv4_param, the exact helper
 # used by wlanstart.sh for SUBNET/AP_ADDR.
 run_wlanstart_validation() {
     bash -c "
 . '${BATS_TEST_DIRNAME}/../lib/validation.sh'
-validate_ipv4_param SUBNET \"\${SUBNET}\" || exit 1
-validate_ipv4_param AP_ADDR \"\${AP_ADDR}\" || exit 1
+validation_check_ipv4_param SUBNET \"\${SUBNET}\" || exit 1
+validation_check_ipv4_param AP_ADDR \"\${AP_ADDR}\" || exit 1
 " 2>&1
 }
 
 @test "valid IPv4 addresses are accepted" {
     load_lib
     for addr in 192.168.254.0 192.168.254.1 8.8.8.8 0.0.0.0 255.255.255.255 10.0.0.1 ; do
-        run validate_ipv4 "${addr}"
+        run validation_check_ipv4 "${addr}"
         [ "$status" -eq 0 ]
     done
 }
 
 @test "letters are rejected" {
     load_lib
-    run validate_ipv4 "192.168.abc.1"
+    run validation_check_ipv4 "192.168.abc.1"
     [ "$status" -ne 0 ]
 }
 
 @test "octets above 255 are rejected" {
     load_lib
-    run validate_ipv4 "192.168.256.1"
+    run validation_check_ipv4 "192.168.256.1"
     [ "$status" -ne 0 ]
-    run validate_ipv4 "300.168.0.1"
+    run validation_check_ipv4 "300.168.0.1"
     [ "$status" -ne 0 ]
 }
 
 @test "wrong octet count is rejected" {
     load_lib
-    run validate_ipv4 "192.168.0"
+    run validation_check_ipv4 "192.168.0"
     [ "$status" -ne 0 ]
-    run validate_ipv4 "192.168.0.1.5"
+    run validation_check_ipv4 "192.168.0.1.5"
     [ "$status" -ne 0 ]
 }
 
 @test "empty value is rejected" {
     load_lib
-    run validate_ipv4 ""
+    run validation_check_ipv4 ""
     [ "$status" -ne 0 ]
-    run validate_ipv4
+    run validation_check_ipv4
     [ "$status" -ne 0 ]
 }
 
 @test "leading-zero octets are rejected" {
     load_lib
-    run validate_ipv4 "192.168.01.1"
+    run validation_check_ipv4 "192.168.01.1"
     [ "$status" -ne 0 ]
 }
 
 @test "missing octets between dots is rejected" {
     load_lib
-    run validate_ipv4 "192..0.1"
+    run validation_check_ipv4 "192..0.1"
     [ "$status" -ne 0 ]
 }
 

--- a/tests/validation.bats
+++ b/tests/validation.bats
@@ -84,41 +84,41 @@ validate_ipv4_param AP_ADDR \"\${AP_ADDR}\" || exit 1
     [ "$status" -eq 0 ]
 }
 
-@test "netmask_to_prefix converts common masks" {
+@test "validation_netmask_to_prefix converts common masks" {
     load_lib
     for pair in "255.255.255.0:24" "255.255.0.0:16" "255.0.0.0:8" "0.0.0.0:0" "255.255.255.255:32" "255.255.255.240:28" "255.255.255.128:25" "255.255.240.0:20" ; do
         mask="${pair%:*}"
         want="${pair#*:}"
-        run netmask_to_prefix "${mask}"
+        run validation_netmask_to_prefix "${mask}"
         [ "$status" -eq 0 ]
         [ "${output}" = "${want}" ]
     done
 }
 
-@test "netmask_to_prefix rejects invalid masks" {
+@test "validation_netmask_to_prefix rejects invalid masks" {
     load_lib
     for mask in 255.0.255.0 255.255.0.255 255.255.255.1 255.255.255.3 not-a-mask 255.0.0 "192.168.256.0" ; do
-        run netmask_to_prefix "${mask}"
+        run validation_netmask_to_prefix "${mask}"
         [ "$status" -ne 0 ]
     done
 }
 
-@test "is_network_address accepts network addresses matching the mask" {
+@test "validation_is_network_address accepts network addresses matching the mask" {
     load_lib
     for pair in "192.168.254.0:255.255.255.0" "192.168.254.16:255.255.255.240" "10.0.0.0:255.0.0.0" ; do
         addr="${pair%%:*}"
         mask="${pair#*:}"
-        run is_network_address "${addr}" "${mask}"
+        run validation_is_network_address "${addr}" "${mask}"
         [ "$status" -eq 0 ]
     done
 }
 
-@test "is_network_address rejects host bits set" {
+@test "validation_is_network_address rejects host bits set" {
     load_lib
     for pair in "192.168.254.7:255.255.255.0" "192.168.254.17:255.255.255.240" "10.1.0.0:255.0.0.0" ; do
         addr="${pair%%:*}"
         mask="${pair#*:}"
-        run is_network_address "${addr}" "${mask}"
+        run validation_is_network_address "${addr}" "${mask}"
         [ "$status" -ne 0 ]
     done
 }

--- a/tests/wpa_version.bats
+++ b/tests/wpa_version.bats
@@ -13,7 +13,7 @@ setup() {
     # shellcheck source=../lib/env.sh
     . "${BATS_TEST_DIRNAME}/../lib/env.sh"
     # Defaults now live centrally in lib/env.sh (issue #237)
-    resolve_config_env
+    env_resolve_config_env
 }
 
 load_lib() {

--- a/tests/wpa_version.bats
+++ b/tests/wpa_version.bats
@@ -1,6 +1,6 @@
 #!/usr/bin/env bats
 
-# Tests exercise compute_wpa_conf() from lib/wpa.sh — the exact code
+# Tests exercise wpa_compute_conf() from lib/wpa.sh — the exact code
 # used by wlanstart.sh (no duplicated logic).
 
 setup() {
@@ -22,7 +22,7 @@ load_lib() {
 
 @test "default WPA_VERSION produces wpa=2 with WPA-PSK" {
     load_lib
-    run compute_wpa_conf
+    run wpa_compute_conf
     [ "$status" -eq 0 ]
     [[ "$output" == *"wpa=2"* ]]
     [[ "$output" == *"wpa_key_mgmt=WPA-PSK"* ]]
@@ -32,7 +32,7 @@ load_lib() {
 @test "WPA_VERSION=3 produces wpa=3 with SAE" {
     load_lib
     WPA_VERSION=3
-    run compute_wpa_conf
+    run wpa_compute_conf
     [ "$status" -eq 0 ]
     [[ "$output" == *"wpa=3"* ]]
     [[ "$output" == *"wpa_key_mgmt=SAE"* ]]
@@ -43,7 +43,7 @@ load_lib() {
 @test "WPA_VERSION=3 does not include WPA-PSK" {
     load_lib
     WPA_VERSION=3
-    run compute_wpa_conf
+    run wpa_compute_conf
     [ "$status" -eq 0 ]
     [[ "$output" != *"WPA-PSK"* ]]
 }
@@ -51,7 +51,7 @@ load_lib() {
 @test "WPA_VERSION=mixed produces wpa=3 with WPA-PSK SAE" {
     load_lib
     WPA_VERSION=mixed
-    run compute_wpa_conf
+    run wpa_compute_conf
     [ "$status" -eq 0 ]
     [[ "$output" == *"wpa=3"* ]]
     [[ "$output" == *"wpa_key_mgmt=WPA-PSK SAE"* ]]
@@ -64,7 +64,7 @@ load_lib() {
     load_lib
     WPA_VERSION=3
     HW_MODE=b
-    run compute_wpa_conf
+    run wpa_compute_conf
     [ "$status" -eq 0 ]
     [[ "$output" == *"hw_mode=b"* ]]
 }
@@ -73,7 +73,7 @@ load_lib() {
     load_lib
     WPA_VERSION=mixed
     HW_MODE=g
-    run compute_wpa_conf
+    run wpa_compute_conf
     [ "$status" -eq 0 ]
     [[ "$output" != *"hw_mode=b"* ]]
 }
@@ -81,7 +81,7 @@ load_lib() {
 @test "WPA_VERSION=2 does not include ieee80211w" {
     load_lib
     WPA_VERSION=2
-    run compute_wpa_conf
+    run wpa_compute_conf
     [ "$status" -eq 0 ]
     [[ "$output" != *"ieee80211w"* ]]
 }
@@ -89,7 +89,7 @@ load_lib() {
 @test "invalid WPA_VERSION fails with error" {
     load_lib
     WPA_VERSION=1
-    run compute_wpa_conf
+    run wpa_compute_conf
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid WPA_VERSION"* ]]
 }

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -112,7 +112,7 @@ secret_file_load WPA_PASSPHRASE WPA_PASSPHRASE_FILE || exit 1
 # shellcheck source=lib/channel.sh
 . "$(dirname "$0")/lib/channel.sh"
 
-# IPv4 address validation (validate_ipv4)
+# IPv4 address validation (validation_check_ipv4)
 # Logic lives in lib/validation.sh, shared with tests
 # shellcheck source=lib/validation.sh
 . "$(dirname "$0")/lib/validation.sh"
@@ -172,12 +172,12 @@ secret_file_load WPA_PASSPHRASE WPA_PASSPHRASE_FILE || exit 1
 # Emit hostapd.conf to stdout from the current environment.
 emit_hostapd_conf() {
     local wpa_conf ap_isolation_conf ssid_hidden_conf mac_filter_conf max_sta_conf ctrl_conf
-    wpa_conf=$(compute_wpa_conf) || return 1
-    ap_isolation_conf=$(compute_ap_isolation_line)
-    ssid_hidden_conf=$(compute_ssid_hidden_line)
-    mac_filter_conf=$(compute_mac_filter_conf)
-    max_sta_conf=$(compute_max_sta_conf) || return 1
-    ctrl_conf=$(compute_ctrl_interface_conf)
+    wpa_conf=$(wpa_compute_conf) || return 1
+    ap_isolation_conf=$(ap_isolation_compute_line)
+    ssid_hidden_conf=$(ssid_hidden_compute_line)
+    mac_filter_conf=$(mac_filter_compute_conf)
+    max_sta_conf=$(stations_compute_max_sta_conf) || return 1
+    ctrl_conf=$(ctrl_interface_compute_conf)
 
     cat <<EOF
 interface=${INTERFACE}
@@ -206,22 +206,22 @@ ${VHT_ENABLED+"ieee80211ac=1"}
 ${VHT_CAPAB+"vht_capab=${VHT_CAPAB}"}
 EOF
 
-    compute_extra_opts_lines
+    extra_opts_compute_lines
 }
 
 # Emit dnsmasq.conf to stdout from the current environment.
 emit_dnsmasq_conf() {
     local dhcp_range ipv6_conf=""
     # Reuse the range computed at startup (DHCP_RANGE_COMPUTED) when
-    # available so compute_dhcp_range (and its warnings) runs only once;
+    # available so dhcp_compute_range (and its warnings) runs only once;
     # validation mode and tests without it still compute on demand.
     if [ -n "${DHCP_RANGE_COMPUTED:-}" ] ; then
         dhcp_range=${DHCP_RANGE_COMPUTED}
     else
-        dhcp_range=$(compute_dhcp_range) || return 1
+        dhcp_range=$(dhcp_compute_range) || return 1
     fi
     if [ "${IPV6:-0}" = "1" ] ; then
-        ipv6_conf=$(compute_dnsmasq_ipv6_conf)
+        ipv6_conf=$(ipv6_compute_dnsmasq_conf)
     fi
 
     cat <<EOF
@@ -247,19 +247,19 @@ run_validation_mode() {
         errors=$((errors + 1))
     fi
 
-    validate_channel_strict || errors=$((errors + 1))
-    validate_vht || errors=$((errors + 1))
+    channel_validate_strict || errors=$((errors + 1))
+    channel_validate_vht || errors=$((errors + 1))
 
-    validate_ipv4_param SUBNET "${SUBNET}" || errors=$((errors + 1))
-    validate_ipv4_param AP_ADDR "${AP_ADDR}" || errors=$((errors + 1))
-    validate_ipv4_param PRI_DNS "${PRI_DNS}" || errors=$((errors + 1))
-    validate_ipv4_param SEC_DNS "${SEC_DNS}" || errors=$((errors + 1))
+    validation_check_ipv4_param SUBNET "${SUBNET}" || errors=$((errors + 1))
+    validation_check_ipv4_param AP_ADDR "${AP_ADDR}" || errors=$((errors + 1))
+    validation_check_ipv4_param PRI_DNS "${PRI_DNS}" || errors=$((errors + 1))
+    validation_check_ipv4_param SEC_DNS "${SEC_DNS}" || errors=$((errors + 1))
 
     warnings_emit_credential_warnings >&2 || true
-    validate_passphrase || errors=$((errors + 1))
-    validate_ssid "${SSID}" || errors=$((errors + 1))
-    validate_mac_filter || errors=$((errors + 1))
-    validate_tx_power || errors=$((errors + 1))
+    passphrase_validate || errors=$((errors + 1))
+    validation_check_ssid "${SSID}" || errors=$((errors + 1))
+    mac_filter_validate || errors=$((errors + 1))
+    radio_validate_tx_power || errors=$((errors + 1))
 
     if [ "${errors}" -ne 0 ] ; then
         echo "[Error] Validation failed with ${errors} error(s)." >&2
@@ -291,46 +291,46 @@ fi
 # Startup warnings for default credentials (normal mode only; validation
 # mode emits them above so they are not interleaved with stdout configs).
 warnings_emit_credential_warnings
-if ! validate_passphrase ; then
+if ! passphrase_validate ; then
     exit 1
 fi
-if ! validate_ssid "${SSID}" ; then
-    exit 1
-fi
-check_interrupted
-
-if ! validate_mac_filter ; then
+if ! validation_check_ssid "${SSID}" ; then
     exit 1
 fi
 check_interrupted
 
-if ! validate_channel ; then
+if ! mac_filter_validate ; then
     exit 1
 fi
 check_interrupted
 
-if ! validate_vht ; then
+if ! channel_validate ; then
     exit 1
 fi
-if ! validate_tx_power ; then
+check_interrupted
+
+if ! channel_validate_vht ; then
+    exit 1
+fi
+if ! radio_validate_tx_power ; then
     exit 1
 fi
 
-validate_ipv4_param SUBNET "${SUBNET}" || exit 1
-validate_ipv4_param AP_ADDR "${AP_ADDR}" || exit 1
-validate_ipv4_param PRI_DNS "${PRI_DNS}" || exit 1
-validate_ipv4_param SEC_DNS "${SEC_DNS}" || exit 1
+validation_check_ipv4_param SUBNET "${SUBNET}" || exit 1
+validation_check_ipv4_param AP_ADDR "${AP_ADDR}" || exit 1
+validation_check_ipv4_param PRI_DNS "${PRI_DNS}" || exit 1
+validation_check_ipv4_param SEC_DNS "${SEC_DNS}" || exit 1
 
 # Compute DHCP range early so the netmask-derived prefix (DHCP_PREFIX)
 # is available for interface_setup and nat_apply_rules, and so the
 # computed range (and its warnings) is produced exactly once per startup;
 # emit_dnsmasq_conf reuses it below (#224).
-DHCP_RANGE_COMPUTED=$(compute_dhcp_range) || exit 1
+DHCP_RANGE_COMPUTED=$(dhcp_compute_range) || exit 1
 export DHCP_RANGE_COMPUTED
 
 # Always regenerate hostapd.conf so env var changes apply between runs.
 # Generated atomically so a failure leaves the old config intact (#157).
-write_atomic_config emit_hostapd_conf "/etc/hostapd.conf" || exit 1
+atomic_write_config emit_hostapd_conf "/etc/hostapd.conf" || exit 1
 check_interrupted
 
 # Setup interface and restart DHCP service
@@ -340,7 +340,7 @@ fi
 check_interrupted
 
 # Optional transmit power cap (TX_POWER); fatal on failure (#236)
-apply_tx_power || exit 1
+radio_apply_tx_power || exit 1
 check_interrupted
 
 # NAT settings
@@ -361,7 +361,7 @@ echo "Configuring DHCP server .."
 
 # Always regenerate dnsmasq.conf so env var changes apply between runs.
 # Generated atomically so a failure leaves the old config intact (#157).
-write_atomic_config emit_dnsmasq_conf "/etc/dnsmasq.conf" || exit 1
+atomic_write_config emit_dnsmasq_conf "/etc/dnsmasq.conf" || exit 1
 
 echo "Starting dnsmasq and hostapd via multirun ..."
 check_interrupted

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -10,14 +10,14 @@
 cleanup() {
     echo "Shutting down..."
 
-    remove_nat_rules
+    nat_remove_rules
 
     if [ "${IPV6:-0}" = "1" ] ; then
         echo "Removing ip6tables rules..."
-        remove_ipv6_rules
+        ipv6_remove_rules
     fi
 
-    teardown_interface
+    interface_teardown
 }
 
 # multirun manages hostapd/dnsmasq and exits when any child dies.
@@ -98,14 +98,14 @@ fi
 # Logic lives in lib/env.sh, shared with tests
 # shellcheck source=lib/env.sh
 . "$(dirname "$0")/lib/env.sh"
-resolve_config_env
+env_resolve_config_env
 
 # Secret-file inputs for SSID/WPA_PASSPHRASE (_FILE convention, issue #232)
 # Logic lives in lib/secret_file.sh, shared with tests
 # shellcheck source=lib/secret_file.sh
 . "$(dirname "$0")/lib/secret_file.sh"
-load_from_file SSID SSID_FILE || exit 1
-load_from_file WPA_PASSPHRASE WPA_PASSPHRASE_FILE || exit 1
+secret_file_load SSID SSID_FILE || exit 1
+secret_file_load WPA_PASSPHRASE WPA_PASSPHRASE_FILE || exit 1
 
 # Validate channel against regulatory domain and hardware mode
 # Logic lives in lib/channel.sh, shared with tests
@@ -255,7 +255,7 @@ run_validation_mode() {
     validate_ipv4_param PRI_DNS "${PRI_DNS}" || errors=$((errors + 1))
     validate_ipv4_param SEC_DNS "${SEC_DNS}" || errors=$((errors + 1))
 
-    emit_credential_warnings >&2 || true
+    warnings_emit_credential_warnings >&2 || true
     validate_passphrase || errors=$((errors + 1))
     validate_ssid "${SSID}" || errors=$((errors + 1))
     validate_mac_filter || errors=$((errors + 1))
@@ -290,7 +290,7 @@ fi
 
 # Startup warnings for default credentials (normal mode only; validation
 # mode emits them above so they are not interleaved with stdout configs).
-emit_credential_warnings
+warnings_emit_credential_warnings
 if ! validate_passphrase ; then
     exit 1
 fi
@@ -322,7 +322,7 @@ validate_ipv4_param PRI_DNS "${PRI_DNS}" || exit 1
 validate_ipv4_param SEC_DNS "${SEC_DNS}" || exit 1
 
 # Compute DHCP range early so the netmask-derived prefix (DHCP_PREFIX)
-# is available for setup_interface and apply_nat_rules, and so the
+# is available for interface_setup and nat_apply_rules, and so the
 # computed range (and its warnings) is produced exactly once per startup;
 # emit_dnsmasq_conf reuses it below (#224).
 DHCP_RANGE_COMPUTED=$(compute_dhcp_range) || exit 1
@@ -334,7 +334,7 @@ write_atomic_config emit_hostapd_conf "/etc/hostapd.conf" || exit 1
 check_interrupted
 
 # Setup interface and restart DHCP service
-if ! setup_interface ; then
+if ! interface_setup ; then
     exit 1
 fi
 check_interrupted
@@ -344,17 +344,17 @@ apply_tx_power || exit 1
 check_interrupted
 
 # NAT settings
-set_sysctls ip_dynaddr ip_forward
-show_sysctls ip_dynaddr ip_forward
+nat_set_sysctls ip_dynaddr ip_forward
+nat_show_sysctls ip_dynaddr ip_forward
 
-apply_nat_rules
+nat_apply_rules
 
 # Optional IPv6 support (off by default, enable with IPV6=1)
 if [ "${IPV6:-0}" = "1" ] ; then
     echo "Enabling IPv6 forwarding..."
-    enable_ipv6_forwarding
+    ipv6_enable_forwarding
     echo "Setting ip6tables rules for outgoing traffics..."
-    apply_ipv6_rules
+    ipv6_apply_rules
 fi
 
 echo "Configuring DHCP server .."
@@ -399,9 +399,9 @@ if [ "${_SIGNALED}" = "1" ] ; then
 fi
 if [ "${STATUS}" -ne 0 ] ; then
     # Preserve the full tagged daemon log for post-mortem (issue #162);
-    # report_failure preserves a timestamped copy and mentions the path.
+    # logging_report_failure preserves a timestamped copy and mentions the path.
     # The temp log is only removed on clean shutdown / signal exit.
-    report_failure "${STATUS}" "${_DAEMON_LOG}"
+    logging_report_failure "${STATUS}" "${_DAEMON_LOG}"
 else
     rm -f "${_DAEMON_LOG}"
 fi


### PR DESCRIPTION
# refactor: enforce <module>_<verb> naming convention across lib/

Closes #242

## Summary

Adopts the strict `<module>_<verb>` naming convention for every public function in `lib/`, per the design in #242. No back-compat wrappers; all call sites (root scripts, tests, docs) updated in one pass.

## Renames

### lib/nat.sh
- `parse_outgoings` -> `nat_parse_outgoings`
- `interface_exists` -> `nat_interface_exists`
- `validate_outgoings` -> `nat_validate_outgoings`
- `apply_nat_rules` -> `nat_apply_rules`
- `set_sysctls` -> `nat_set_sysctls`
- `show_sysctls` -> `nat_show_sysctls`
- `remove_nat_rules` -> `nat_remove_rules`

### lib/ipv6.sh
- `enable_ipv6_forwarding` -> `ipv6_enable_forwarding`
- `apply_ipv6_rules` -> `ipv6_apply_rules`
- `remove_ipv6_rules` -> `ipv6_remove_rules`

### lib/dhcp.sh
- `ip_to_int` -> `dhcp_ip_to_int`
- `check_ap_addr_in_subnet` -> `dhcp_check_ap_addr_in_subnet`
- `validate_lease_time` -> `dhcp_validate_lease_time`

### lib/validation.sh
- `netmask_to_prefix` -> `validation_netmask_to_prefix`
- `is_network_address` -> `validation_is_network_address`

### lib/interface.sh
- `setup_interface` -> `interface_setup`
- `teardown_interface` -> `interface_teardown`

### lib/client_env.sh
- `require_interface` -> `client_env_require_interface`
- `resolve_ctrl_iface_dir` -> `client_env_resolve_ctrl_iface_dir`
- `require_ctrl_interface` -> `client_env_require_ctrl_interface`

### lib/env.sh
- `resolve_config_env` -> `env_resolve_config_env`

### lib/logging.sh
- `report_failure` -> `logging_report_failure`

### lib/warnings.sh
- `emit_credential_warnings` -> `warnings_emit_credential_warnings`

### lib/secret_file.sh
- `load_from_file` -> `secret_file_load`

### clients.sh (root entry point)
- `usage` -> `clients_show_usage`
- `json_escape` -> `clients_json_escape`
- `emit_json` -> `clients_emit_json`
- `station_count` -> `clients_count_stations`

## Renames (round 2 - verb-first helpers)

- lib/ap_isolation.sh: `compute_ap_isolation_line` -> `ap_isolation_compute_line`
- lib/atomic.sh: `write_atomic_config` -> `atomic_write_config`
- lib/channel.sh: `validate_channel` -> `channel_validate`, `validate_vht` -> `channel_validate_vht`, `validate_channel_strict` -> `channel_validate_strict`
- lib/ctrl_interface.sh: `compute_ctrl_interface_conf` -> `ctrl_interface_compute_conf`
- lib/dhcp.sh: `compute_dhcp_range` -> `dhcp_compute_range`
- lib/extra_opts.sh: `compute_extra_opts_lines` -> `extra_opts_compute_lines`
- lib/ipv6.sh: `compute_dnsmasq_ipv6_conf` -> `ipv6_compute_dnsmasq_conf`
- lib/mac_filter.sh: `validate_mac_filter` -> `mac_filter_validate`, `compute_mac_filter_conf` -> `mac_filter_compute_conf`
- lib/passphrase.sh: `validate_passphrase` -> `passphrase_validate`
- lib/radio.sh: `validate_tx_power` -> `radio_validate_tx_power`, `apply_tx_power` -> `radio_apply_tx_power`
- lib/ssid_hidden.sh: `compute_ssid_hidden_line` -> `ssid_hidden_compute_line`
- lib/stations.sh: `compute_max_sta_conf` -> `stations_compute_max_sta_conf`
- lib/validation.sh: `validate_ipv4` -> `validation_check_ipv4`, `validate_ssid` -> `validation_check_ssid`, `validate_ipv4_param` -> `validation_check_ipv4_param`
- lib/wpa.sh: `compute_wpa_conf` -> `wpa_compute_conf`

### Private helpers (lib/logging.sh)
- `_failure_log_target` -> `_logging_failure_log_target`
- `_failure_log_prune` -> `_logging_failure_prune`

## Kept as-is

- `_`-prefixed private helpers (`_log_emit`, `_logging_failure_prune`, ...) - already module-scoped.
- The `log()` / `log_debug()` / ... family in `lib/log.sh`: the module namespace itself is "log", so these already conform; bare `log()` is documented as an exception.
- Small script-local handlers in root scripts (`cleanup`, `handle_signal`, `check_interrupted`) - documented as exempt.

## Docs

Convention documented in AGENTS.md ("Bash Function Naming Convention").

## Verification

- shellcheck clean on all `lib/*.sh`, `clients.sh`, `healthcheck.sh`, `wlanstart.sh`.
- Full bats suite: 415/415 passing.
- No name collisions between modules (all prefixes are unique module names).
