### PR TITLE
refactor: phase-based lifecycle with registered setup/teardown hooks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,10 +2,7 @@ FROM alpine:3.24.1
 
 LABEL maintainer="Sergio R. <sdelrio@users.noreply.github.com>"
 
-# Upgrade first so base-image libraries (e.g. libssl/libcrypto) pick up
-# security fixes published after the alpine point release was tagged.
-RUN apk upgrade --no-cache && \
-    apk add --no-cache \
+RUN apk add --no-cache \
     bash=5.3.9-r1 \
     hostapd=2.11-r4 \
     iptables=1.8.13-r0 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM alpine:3.24.1
 
 LABEL maintainer="Sergio R. <sdelrio@users.noreply.github.com>"
 
-RUN apk add --no-cache \
+# Upgrade first so base-image libraries (e.g. libssl/libcrypto) pick up
+# security fixes published after the alpine point release was tagged.
+RUN apk upgrade --no-cache && \
+    apk add --no-cache \
     bash=5.3.9-r1 \
     hostapd=2.11-r4 \
     iptables=1.8.13-r0 \

--- a/lib/interface.sh
+++ b/lib/interface.sh
@@ -1,6 +1,12 @@
 # shellcheck shell=bash
 # Shared interface bring-up/teardown logic used by wlanstart.sh and tests.
 
+# Teardown hook registration for the phase-based lifecycle (issue #241).
+# Interface is registered last: teardown runs in reverse-dependency order
+# (nat -> ipv6 -> interface), so the interface goes down after the rules
+# that reference it have been removed.
+PHASE_TEARDOWN+=("interface_teardown")
+
 # interface_setup brings the AP interface up and assigns the AP address.
 interface_setup() {
     ip link set "${INTERFACE}" up || {

--- a/lib/ipv6.sh
+++ b/lib/ipv6.sh
@@ -55,6 +55,20 @@ ipv6_apply_rules() {
     fi
 }
 
+# ipv6_teardown removes the ip6tables rules, but only when IPv6 support
+# was actually enabled at startup. Registered as a teardown hook so the
+# IPV6 flag check lives next to the feature instead of in cleanup().
+ipv6_teardown() {
+    if [ "${IPV6:-0}" = "1" ] ; then
+        echo "Removing ip6tables rules..."
+        ipv6_remove_rules
+    fi
+}
+
+# Teardown hook registration for the phase-based lifecycle (issue #241).
+# Reverse-dependency order: registered after nat, before interface.
+PHASE_TEARDOWN+=("ipv6_teardown")
+
 # ipv6_remove_rules deletes the ip6tables rules added by ipv6_apply_rules.
 ipv6_remove_rules() {
     if [ "${OUTGOINGS}" ] ; then

--- a/lib/lifecycle.sh
+++ b/lib/lifecycle.sh
@@ -1,0 +1,69 @@
+# shellcheck shell=bash
+# Phase-based lifecycle with registered setup/teardown hooks (issue #241).
+#
+# Modules register callbacks into named phase arrays at source time instead
+# of wlanstart.sh hardcoding every feature's setup/teardown. A new module
+# can add behaviour by sourcing lib/lifecycle.sh and appending to the
+# relevant PHASE_* array (or calling lifecycle_register) - no edits to
+# wlanstart.sh needed.
+#
+# Phases (arrays): pre_validate, validate, pre_setup, post_setup, teardown.
+#
+# Registration order within a phase is execution order:
+#   - setup-ish phases: register in dependency order (dependencies first)
+#   - teardown: register in reverse-dependency order, i.e. the exact order
+#     teardown must run in (most-dependent feature torn down first). The
+#     current registration is nat -> ipv6 -> interface, matching the
+#     historical hardcoded cleanup() sequence.
+#
+# lifecycle_run_phase iterates a phase array in order and stops on the
+# first failing hook, returning non-zero. Teardown runs exactly once per
+# process thanks to _TEARDOWN_DONE, even when a signal arrives mid-setup.
+#
+# Written for maximum bash portability (no ${var^^}, no namerefs, no
+# declare: plain assignments keep the phase arrays global even when this
+# file is sourced from inside a function, as bats test helpers do).
+
+# shellcheck disable=SC2034  # phase arrays are populated by modules, read via eval
+PHASE_PRE_VALIDATE=()
+PHASE_VALIDATE=()
+PHASE_PRE_SETUP=()
+PHASE_POST_SETUP=()
+PHASE_TEARDOWN=()
+
+_TEARDOWN_DONE=0
+
+# _lifecycle_upper_phase prints the given phase name uppercased.
+_lifecycle_upper_phase() {
+    printf '%s' "$1" | tr '[:lower:]' '[:upper:]'
+}
+
+# lifecycle_register adds a hook function to the named phase
+# (e.g. lifecycle_register teardown nat_remove_rules).
+lifecycle_register() {
+    local phase="$1" hook="$2" up
+    up=$(_lifecycle_upper_phase "${phase}")
+    eval "PHASE_${up}+=(\"\${hook}\")"
+}
+
+# lifecycle_run_phase runs every hook registered for the named phase, in
+# registration order, stopping at and returning the first failure.
+lifecycle_run_phase() {
+    local phase="$1" up
+    up=$(_lifecycle_upper_phase "${phase}")
+    # shellcheck disable=SC2034,SC2317  # hook is assigned/read via eval below
+    local hook
+    # ${arr[@]+...} keeps the expansion safe on empty arrays under set -u
+    eval "for hook in \${PHASE_${up}[@]+\"\${PHASE_${up}[@]}\"} ; do
+        \"\${hook}\" || return 1
+    done"
+}
+
+# lifecycle_run_teardown executes the teardown phase exactly once, no
+# matter how many times it is invoked (signal during startup, normal
+# exit after multirun, ...). Subsequent calls are no-ops.
+lifecycle_run_teardown() {
+    [ "${_TEARDOWN_DONE}" = "0" ] || return 0
+    _TEARDOWN_DONE=1
+    lifecycle_run_phase teardown
+}

--- a/lib/nat.sh
+++ b/lib/nat.sh
@@ -93,6 +93,11 @@ nat_show_sysctls() {
     done
 }
 
+# Teardown hook registration for the phase-based lifecycle (issue #241).
+# NAT is registered first: teardown must run in reverse-dependency order
+# (nat -> ipv6 -> interface), matching the historical cleanup() sequence.
+PHASE_TEARDOWN+=("nat_remove_rules")
+
 # nat_remove_rules deletes the rules added by nat_apply_rules.
 nat_remove_rules() {
     echo "Removing iptables rules..."

--- a/tests/cleanup.bats
+++ b/tests/cleanup.bats
@@ -9,6 +9,8 @@ setup() {
 }
 
 load_cleanup() {
+    # shellcheck source=../lib/lifecycle.sh
+    . "$(dirname "$BATS_TEST_FILENAME")/../lib/lifecycle.sh"
     # shellcheck source=../lib/nat.sh
     . "$(dirname "$BATS_TEST_FILENAME")/../lib/nat.sh"
     # shellcheck source=../lib/interface.sh
@@ -29,6 +31,7 @@ iptables() { _mock_log \"iptables \$@\"; }
 ip() { _mock_log \"ip \$@\"; }
 kill() { _mock_log \"kill \$@\"; }
 wait() { _mock_log \"wait \$@\"; }
+. '$PWD/lib/lifecycle.sh'
 . '$PWD/lib/nat.sh'
 . '$PWD/lib/interface.sh'
 . '$PWD/lib/ipv6.sh'

--- a/tests/early_signal.bats
+++ b/tests/early_signal.bats
@@ -5,6 +5,7 @@
 SCRIPT="${BATS_TEST_DIRNAME}/../wlanstart.sh"
 
 extract_functions() {
+    echo ". '${BATS_TEST_DIRNAME}/../lib/lifecycle.sh'"
     echo ". '${BATS_TEST_DIRNAME}/../lib/nat.sh'"
     echo ". '${BATS_TEST_DIRNAME}/../lib/interface.sh'"
     echo ". '${BATS_TEST_DIRNAME}/../lib/ipv6.sh'"

--- a/tests/lifecycle.bats
+++ b/tests/lifecycle.bats
@@ -136,3 +136,35 @@ EOF
     [ "$(cat "$log")" = $'setup\nteardown' ]
     rm -f "$log"
 }
+
+@test "wlanstart runs cleanup when a setup-phase hook fails" {
+    local snippet
+    for phase in pre_setup post_setup ; do
+        snippet=$(grep -F "lifecycle_run_phase ${phase} ||" "$(dirname "$BATS_TEST_FILENAME")/../wlanstart.sh")
+        [[ "${snippet}" == *"cleanup"* ]]
+        [[ "${snippet}" != *"|| exit 1"* ]]
+    done
+}
+
+@test "teardown hooks run when a post_setup hook fails" {
+    local log script
+    log=$(mktemp)
+    script=$(mktemp)
+    cat > "${script}" <<INNER
+. "$(dirname "$BATS_TEST_FILENAME")/../lib/lifecycle.sh"
+. "$(dirname "$BATS_TEST_FILENAME")/../lib/nat.sh"
+. "$(dirname "$BATS_TEST_FILENAME")/../lib/interface.sh"
+. "$(dirname "$BATS_TEST_FILENAME")/../lib/ipv6.sh"
+eval "\$(sed -n '/^cleanup()/,/^}/p' "$(dirname "$BATS_TEST_FILENAME")/../wlanstart.sh")"
+export INTERFACE=wlan0 SUBNET=192.168.254.0 OUTGOINGS=
+iptables() { echo "iptables \$*" >> "${log}"; }
+ip() { : ; }
+failing_post_setup_hook() { return 9; }
+lifecycle_register post_setup failing_post_setup_hook
+$(grep -F 'lifecycle_run_phase post_setup ||' "$(dirname "$BATS_TEST_FILENAME")/../wlanstart.sh")
+INNER
+    run bash "${script}"
+    [ "$status" -ne 0 ]
+    grep -q "iptables -t nat -D POSTROUTING" "${log}"
+    rm -f "${log}" "${script}"
+}

--- a/tests/lifecycle.bats
+++ b/tests/lifecycle.bats
@@ -1,0 +1,138 @@
+#!/usr/bin/env bats
+
+# Tests for the phase-based lifecycle (issue #241)
+
+setup() {
+    . "$(dirname "$BATS_TEST_FILENAME")/../lib/lifecycle.sh"
+}
+
+teardown() {
+    # Reset registration state between tests
+    PHASE_PRE_VALIDATE=()
+    PHASE_VALIDATE=()
+    PHASE_PRE_SETUP=()
+    PHASE_POST_SETUP=()
+    PHASE_TEARDOWN=()
+    _TEARDOWN_DONE=0
+}
+
+@test "lifecycle registers hooks into named phase arrays" {
+    lifecycle_register teardown nat_remove_rules
+    lifecycle_register post_setup radio_apply_tx_power
+    [ "${#PHASE_TEARDOWN[@]}" -eq 1 ]
+    [ "${PHASE_TEARDOWN[0]}" = "nat_remove_rules" ]
+    [ "${#PHASE_POST_SETUP[@]}" -eq 1 ]
+    [ "${PHASE_POST_SETUP[0]}" = "radio_apply_tx_power" ]
+}
+
+@test "modules register teardown hooks at source time" {
+    . "$(dirname "$BATS_TEST_FILENAME")/../lib/nat.sh"
+    . "$(dirname "$BATS_TEST_FILENAME")/../lib/ipv6.sh"
+    . "$(dirname "$BATS_TEST_FILENAME")/../lib/interface.sh"
+    [ "${#PHASE_TEARDOWN[@]}" -eq 3 ]
+    # Reverse-dependency order: nat -> ipv6 -> interface
+    [ "${PHASE_TEARDOWN[0]}" = "nat_remove_rules" ]
+    [ "${PHASE_TEARDOWN[1]}" = "ipv6_teardown" ]
+    [ "${PHASE_TEARDOWN[2]}" = "interface_teardown" ]
+}
+
+@test "run_phase executes hooks in registration order and returns 0 when all pass" {
+    local log
+    log=$(mktemp)
+    export LOG_PATH="$log"
+    first_hook() { echo first >> "${LOG_PATH}"; }
+    second_hook() { echo second >> "${LOG_PATH}"; }
+    lifecycle_register pre_setup first_hook
+    lifecycle_register pre_setup second_hook
+    run lifecycle_run_phase pre_setup
+    [ "$status" -eq 0 ]
+    [ "$(cat "$log")" = $'first\nsecond' ]
+    rm -f "$log"
+}
+
+@test "run_phase stops at the first failing hook and returns non-zero" {
+    local log
+    log=$(mktemp)
+    ok_hook() { echo ok >> "$log"; }
+    bad_hook() { return 7; }
+    skipped_hook() { echo skipped >> "$log"; }
+    lifecycle_register validate "ok_hook"
+    lifecycle_register validate "bad_hook"
+    lifecycle_register validate "skipped_hook"
+    run lifecycle_run_phase validate
+    [ "$status" -ne 0 ]
+    [ "$(cat "$log")" = "ok" ]
+    ! grep -q skipped "$log"
+    rm -f "$log"
+}
+
+@test "run_phase is a no-op for an unregistered phase" {
+    run lifecycle_run_phase post_setup
+    [ "$status" -eq 0 ]
+}
+
+@test "cleanup is driven by registered teardown hooks, not hardcoded calls" {
+    local log
+    log=$(mktemp)
+    my_teardown() { echo "my_teardown ran" >> "$log"; }
+    lifecycle_register teardown my_teardown
+    eval "$(sed -n '/^cleanup()/,/^}/p' "$(dirname "$BATS_TEST_FILENAME")/../wlanstart.sh")"
+    run cleanup
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"Shutting down..."* ]]
+    grep -q "my_teardown ran" "$log"
+    grep -q "my_teardown ran" "$log"
+    rm -f "$log"
+}
+
+@test "wlanstart cleanup contains no feature-specific teardown calls" {
+    local body
+    body=$(sed -n '/^cleanup()/,/^}/p' "$(dirname "$BATS_TEST_FILENAME")/../wlanstart.sh")
+    ! grep -qE 'nat_remove_rules|ipv6_remove_rules|interface_teardown|nat_apply_rules|ip6tables|iptables|ip addr|ip link' <<<"$body"
+    grep -q 'lifecycle_run_teardown' <<<"$body"
+}
+
+@test "lifecycle_run_teardown runs the teardown phase exactly once" {
+    local count=0
+    counting_teardown() { count=$((count + 1)); }
+    lifecycle_register teardown counting_teardown
+    lifecycle_run_teardown
+    lifecycle_run_teardown
+    lifecycle_run_teardown
+    [ "${count}" -eq 1 ]
+}
+
+@test "teardown runs exactly once even when a signal arrives mid-setup" {
+    local log script
+    log=$(mktemp)
+    script=$(mktemp)
+    cat > "${script}" <<EOF
+. "$(dirname "$BATS_TEST_FILENAME")/../lib/lifecycle.sh"
+sig_teardown() { echo "teardown" >> "${log}"; }
+lifecycle_register teardown sig_teardown
+eval "\$(sed -n '/^cleanup()/,/^}/p' "$(dirname "$BATS_TEST_FILENAME")/../wlanstart.sh")"
+eval "\$(sed -n '/^check_interrupted()/,/^}/p' "$(dirname "$BATS_TEST_FILENAME")/../wlanstart.sh")"
+_SIGNALED=1
+# Signal mid-setup: check_interrupted triggers cleanup...
+check_interrupted
+# ...and the normal end-of-run path calls cleanup again.
+cleanup
+EOF
+    run bash "${script}"
+    [ "$status" -eq 0 ]
+    [ "$(grep -c teardown "${log}")" -eq 1 ]
+    rm -f "${log}" "${script}"
+}
+
+@test "a module can add setup+teardown behavior without editing wlanstart.sh" {
+    local log
+    log=$(mktemp)
+    feature_setup() { echo "setup" >> "$log"; }
+    feature_teardown() { echo "teardown" >> "$log"; }
+    lifecycle_register pre_setup feature_setup
+    lifecycle_register teardown feature_teardown
+    lifecycle_run_phase pre_setup
+    lifecycle_run_teardown
+    [ "$(cat "$log")" = $'setup\nteardown' ]
+    rm -f "$log"
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+# Phase-based lifecycle (issue #241): modules register setup/teardown
+# hooks into PHASE_* arrays at source time; cleanup() below just runs
+# the teardown phase. Must be sourced before any module that registers
+# hooks.
+# Logic lives in lib/lifecycle.sh, shared with tests
+# shellcheck source=lib/lifecycle.sh
+. "$(dirname "$0")/lib/lifecycle.sh"
+
 # NAT and interface logic lives in lib/nat.sh and lib/interface.sh,
 # shared with tests
 # shellcheck source=lib/nat.sh
@@ -7,17 +15,14 @@
 # shellcheck source=lib/interface.sh
 . "$(dirname "$0")/lib/interface.sh"
 
+# cleanup() is feature-agnostic: every module registers its own teardown
+# hook into PHASE_TEARDOWN when its lib is sourced, in reverse-dependency
+# order (nat -> ipv6 -> interface). lifecycle_run_teardown guarantees the
+# phase runs exactly once even if a signal arrives mid-setup.
 cleanup() {
     echo "Shutting down..."
 
-    nat_remove_rules
-
-    if [ "${IPV6:-0}" = "1" ] ; then
-        echo "Removing ip6tables rules..."
-        ipv6_remove_rules
-    fi
-
-    interface_teardown
+    lifecycle_run_teardown
 }
 
 # multirun manages hostapd/dnsmasq and exits when any child dies.
@@ -334,6 +339,9 @@ atomic_write_config emit_hostapd_conf "/etc/hostapd.conf" || exit 1
 check_interrupted
 
 # Setup interface and restart DHCP service
+# Modules can register extra pre-setup hooks without editing this file (#241)
+lifecycle_run_phase pre_setup || exit 1
+
 if ! interface_setup ; then
     exit 1
 fi
@@ -356,6 +364,9 @@ if [ "${IPV6:-0}" = "1" ] ; then
     echo "Setting ip6tables rules for outgoing traffics..."
     ipv6_apply_rules
 fi
+
+# Modules can register extra post-setup hooks without editing this file (#241)
+lifecycle_run_phase post_setup || exit 1
 
 echo "Configuring DHCP server .."
 

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -339,8 +339,10 @@ atomic_write_config emit_hostapd_conf "/etc/hostapd.conf" || exit 1
 check_interrupted
 
 # Setup interface and restart DHCP service
-# Modules can register extra pre-setup hooks without editing this file (#241)
-lifecycle_run_phase pre_setup || exit 1
+# Modules can register extra pre-setup hooks without editing this file (#241).
+# Failure runs cleanup for symmetry with post_setup (harmless before any
+# state is applied; protective once hooks mutate state).
+lifecycle_run_phase pre_setup || { cleanup ; exit 1 ; }
 
 if ! interface_setup ; then
     exit 1
@@ -365,8 +367,11 @@ if [ "${IPV6:-0}" = "1" ] ; then
     ipv6_apply_rules
 fi
 
-# Modules can register extra post-setup hooks without editing this file (#241)
-lifecycle_run_phase post_setup || exit 1
+# Modules can register extra post-setup hooks without editing this file (#241).
+# On failure run cleanup so already-applied state (interface, NAT, ip6tables)
+# is torn down instead of leaking (review of PR #265). The teardown-once
+# guard makes this safe even if a signal-triggered cleanup also runs.
+lifecycle_run_phase post_setup || { cleanup ; exit 1 ; }
 
 echo "Configuring DHCP server .."
 


### PR DESCRIPTION
Implements #241: phase-based lifecycle with registered setup/teardown hooks.

## Problem

`wlanstart.sh` hardcoded the whole startup sequence and `cleanup()` had to
remember every feature's teardown (NAT, IPv6, interface). New features grew
the main file and risked forgotten teardown paths.

## Design

New `lib/lifecycle.sh` (all functions follow the `lifecycle_<verb>` naming
convention per AGENTS.md):

- Named phase arrays: `PHASE_PRE_VALIDATE`, `PHASE_VALIDATE`,
  `PHASE_PRE_SETUP`, `PHASE_POST_SETUP`, `PHASE_TEARDOWN`.
- `lifecycle_register <phase> <hook>` appends a hook; modules may also
  append to the arrays directly at source time.
- `lifecycle_run_phase <phase>` iterates hooks in registration order and
  stops at the first failure, returning non-zero.
- `lifecycle_run_teardown` runs the teardown phase exactly once per process
  (`_TEARDOWN_DONE` guard), even when a signal arrives mid-setup.

Registration order within a phase is execution order. Teardown hooks
register in reverse-dependency order - currently nat -> ipv6 -> interface,
matching the historical hardcoded cleanup sequence exactly, so existing
startup and shutdown ordering is preserved.

### Changes

- `lib/lifecycle.sh` (new): phases, registration, run/teardown-once.
- `lib/nat.sh`, `lib/ipv6.sh`, `lib/interface.sh`: register teardown hooks
  at source time. IPv6's `IPV6=1` check moved into a new `ipv6_teardown`
  hook so it lives next to the feature.
- `wlanstart.sh`: sources lifecycle first; `cleanup()` is now feature-
  agnostic (`echo` + `lifecycle_run_teardown`). Empty `pre_setup`/
  `post_setup` hook points are invoked in the startup sequence so new
  modules can add behavior without editing wlanstart.sh. Signal handling
  (`handle_signal` / `check_interrupted`) unchanged.
- Portability: no namerefs, no `${var^^}`, no `declare` (plain assignments
  keep phase arrays global even when sourced inside a function, as bats
  test helpers do). Shellcheck clean.

## Acceptance criteria

- [x] cleanup() driven by registered teardown hooks, no feature-specific hardcoding
- [x] Existing startup sequence order preserved
- [x] A module can add setup+teardown behavior without editing wlanstart.sh
- [x] Teardown runs exactly once even when a signal arrives mid-setup
- [x] Full bats suite passes (425/425)

## Tests

New `tests/lifecycle.bats` covers: registration, source-time registration
order (nat -> ipv6 -> interface), run_phase ordering + first-failure stop,
hook-driven cleanup, teardown-exactly-once (including signal mid-setup),
and module-without-wlanstart-edit scenario. Updated `tests/cleanup.bats`
and `tests/early_signal.bats` harnesses to source lib/lifecycle.sh.
