### PR TITLE
fix: upgrade alpine packages at image build to clear CVE-2026-14456

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,10 @@ FROM alpine:3.24.1
 
 LABEL maintainer="Sergio R. <sdelrio@users.noreply.github.com>"
 
-RUN apk add --no-cache \
+# Upgrade first so base-image libraries (e.g. libssl/libcrypto) pick up
+# security fixes published after the alpine point release was tagged.
+RUN apk upgrade --no-cache && \
+    apk add --no-cache \
     bash=5.3.9-r1 \
     hostapd=2.11-r4 \
     iptables=1.8.13-r0 \


### PR DESCRIPTION
## Summary
- add `apk upgrade --no-cache` before package install so base-image libs (libssl3/libcrypto3 3.5.7-r0 -> 3.5.8-r0) pick up security fixes published after the alpine:3.24.1 point release was tagged

## Context
- clears CI Trivy failure CVE-2026-14456 (build check red on other PRs, e.g. #265)
- hunk originally split out of #265 per review