### PR TITLE
refactor: declarative module loading via lib/bootstrap.sh

### DIFF
--- a/clients.sh
+++ b/clients.sh
@@ -9,8 +9,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/core/client_env.sh
-source "${SCRIPT_DIR}/lib/core/client_env.sh"
+# Declarative module loading (issue #239)
+# shellcheck source=lib/bootstrap.sh
+source "${SCRIPT_DIR}/lib/bootstrap.sh"
+require_module client_env
 
 clients_show_usage() {
     echo "Usage: clients.sh [--json] [count] [deauth <mac>]" >&2

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -2,8 +2,10 @@
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=lib/core/client_env.sh
-source "${SCRIPT_DIR}/lib/core/client_env.sh"
+# Declarative module loading (issue #239)
+# shellcheck source=lib/bootstrap.sh
+source "${SCRIPT_DIR}/lib/bootstrap.sh"
+require_module client_env
 
 # Health check script for rpi-hostap container
 # Checks if hostapd, dnsmasq are running and the interface is up

--- a/lib/bootstrap.sh
+++ b/lib/bootstrap.sh
@@ -1,0 +1,53 @@
+# shellcheck shell=bash
+# Declarative module loading for lib/ (issue #239).
+#
+# Usage:
+#   . "$(dirname "$0")/lib/bootstrap.sh"
+#   require_module lifecycle nat interface ...
+#
+# require_module() sources a module exactly once per process (_LOADED_*
+# tracking), resolving core/ vs sys/ automatically, and pulls declared
+# dependencies first.
+#
+# Loaded state and dependencies are tracked in dynamic variables
+# (_LOADED_<module>, MODULE_DEPENDENCIES_<module>) rather than
+# associative arrays so the loader also works on bash 3.2 (macOS).
+#
+# Sourcing this file twice is safe and cheap.
+
+if ! declare -F require_module > /dev/null 2>&1 ; then
+
+    LIB_BOOTSTRAP_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+    # Cross-module dependencies: MODULE_DEPENDENCIES_<module> holds a
+    # space-separated list of modules that must be loaded first.
+    # shellcheck disable=SC2034  # read dynamically via ${!deps_var}
+    MODULE_DEPENDENCIES_ipv6="nat"
+
+    # require_module loads lib/{core,sys}/<module>.sh once, recursively
+    # satisfying declared dependencies first. Accepts one or more module
+    # names: require_module lifecycle nat interface
+    require_module() {
+        local m
+        for m in "$@" ; do
+            _require_one_module "$m"
+        done
+    }
+
+    _require_one_module() {
+        local m=$1
+        local loaded_var="_LOADED_${m}"
+        [ -n "${!loaded_var:-}" ] && return 0
+        local deps_var="MODULE_DEPENDENCIES_${m}"
+        local dep
+        for dep in ${!deps_var:-} ; do
+            require_module "$dep"
+        done
+        local layer=core
+        [ -f "${LIB_BOOTSTRAP_DIR}/sys/${m}.sh" ] && layer=sys
+        # shellcheck disable=SC1090
+        . "${LIB_BOOTSTRAP_DIR}/${layer}/${m}.sh"
+        eval "${loaded_var}=1"
+    }
+
+fi

--- a/lib/sys/ipv6.sh
+++ b/lib/sys/ipv6.sh
@@ -11,7 +11,11 @@
 
 # Ensure nat_parse_outgoings (lib/sys/nat.sh) is available so the rule functions
 # below are self-contained and can be called without nat_apply_rules first.
-if ! declare -F nat_parse_outgoings > /dev/null 2>&1 ; then
+# Prefer the declarative loader when present; fall back to a direct source
+# for consumers that source this module without lib/bootstrap.sh.
+if declare -F require_module > /dev/null 2>&1 ; then
+    require_module nat
+elif ! declare -F nat_parse_outgoings > /dev/null 2>&1 ; then
     # shellcheck source=lib/sys/nat.sh
     . "$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/nat.sh"
 fi

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -1,0 +1,68 @@
+#!/usr/bin/env bats
+# Declarative module loading via lib/bootstrap.sh (issue #239).
+
+setup() {
+    ROOT="${BATS_TEST_DIRNAME}/.."
+    LIB="${ROOT}/lib"
+}
+
+@test "bootstrap defines require_module exactly once after double source" {
+    run bash -c '
+        set -euo pipefail
+        . "'"${LIB}"'/bootstrap.sh"
+        . "'"${LIB}"'/bootstrap.sh"
+        declare -F require_module > /dev/null
+    '
+    [ "$status" -eq 0 ]
+}
+
+@test "require_module resolves core and sys modules" {
+    run bash -c '
+        set -euo pipefail
+        . "'"${LIB}"'/bootstrap.sh"
+        require_module validation
+        declare -F validation_check_ipv4_param > /dev/null
+        require_module nat
+        declare -F nat_apply_rules > /dev/null
+        [ -n "${_LOADED_validation:-}" ] && [ -n "${_LOADED_nat:-}" ]
+    '
+    [ "$status" -eq 0 ]
+}
+
+@test "require_module is idempotent: double load is a no-op" {
+    run bash -c '
+        set -euo pipefail
+        . "'"${LIB}"'/bootstrap.sh"
+        require_module lifecycle
+        PHASE_TEARDOWN=()
+        # Second call must not re-execute the module body (which would
+        # re-append teardown hooks).
+        require_module lifecycle
+        [ "${#PHASE_TEARDOWN[@]}" -eq 0 ]
+    '
+    [ "$status" -eq 0 ]
+}
+
+@test "require_module accepts multiple modules in one call" {
+    run bash -c '
+        set -euo pipefail
+        . "'"${LIB}"'/bootstrap.sh"
+        require_module channel validation nat
+        declare -F channel_validate_strict > /dev/null
+        declare -F validation_check_ipv4_param > /dev/null
+        declare -F nat_apply_rules > /dev/null
+    '
+    [ "$status" -eq 0 ]
+}
+
+@test "dependency resolution: requiring ipv6 loads nat first" {
+    run bash -c '
+        set -euo pipefail
+        . "'"${LIB}"'/bootstrap.sh"
+        require_module ipv6
+        declare -F nat_parse_outgoings > /dev/null
+        declare -F ipv6_compute_dnsmasq_conf > /dev/null
+        [ -n "${_LOADED_nat:-}" ]
+    '
+    [ "$status" -eq 0 ]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -4,16 +4,13 @@
 # hooks into PHASE_* arrays at source time; cleanup() below just runs
 # the teardown phase. Must be sourced before any module that registers
 # hooks.
-# Logic lives in lib/core/lifecycle.sh, shared with tests
-# shellcheck source=lib/core/lifecycle.sh
-. "$(dirname "$0")/lib/core/lifecycle.sh"
+# Declarative module loading (issue #239): bootstrap resolves core/ vs sys/
+# paths, tracks what is already loaded (_LOADED) so double-sourcing is a
+# no-op, and pulls declared dependencies via require_module.
+# shellcheck source=lib/bootstrap.sh
+. "$(dirname "$0")/lib/bootstrap.sh"
 
-# NAT and interface logic lives in lib/sys/nat.sh and lib/sys/interface.sh,
-# shared with tests
-# shellcheck source=lib/sys/nat.sh
-. "$(dirname "$0")/lib/sys/nat.sh"
-# shellcheck source=lib/sys/interface.sh
-. "$(dirname "$0")/lib/sys/interface.sh"
+require_module lifecycle nat interface
 
 # cleanup() is feature-agnostic: every module registers its own teardown
 # hook into PHASE_TEARDOWN when its lib is sourced, in reverse-dependency
@@ -101,78 +98,18 @@ fi
 
 # Apply all environment defaults in one place (issue #237).
 # Logic lives in lib/core/env.sh, shared with tests
-# shellcheck source=lib/core/env.sh
-. "$(dirname "$0")/lib/core/env.sh"
+require_module env
 env_resolve_config_env
 
 # Secret-file inputs for SSID/WPA_PASSPHRASE (_FILE convention, issue #232)
-# Logic lives in lib/core/secret_file.sh, shared with tests
-# shellcheck source=lib/core/secret_file.sh
-. "$(dirname "$0")/lib/core/secret_file.sh"
+require_module secret_file
 secret_file_load SSID SSID_FILE || exit 1
 secret_file_load WPA_PASSPHRASE WPA_PASSPHRASE_FILE || exit 1
 
-# Validate channel against regulatory domain and hardware mode
-# Logic lives in lib/core/channel.sh, shared with tests
-# shellcheck source=lib/core/channel.sh
-. "$(dirname "$0")/lib/core/channel.sh"
-
-# IPv4 address validation (validation_check_ipv4)
-# Logic lives in lib/core/validation.sh, shared with tests
-# shellcheck source=lib/core/validation.sh
-. "$(dirname "$0")/lib/core/validation.sh"
-# Startup warnings for default credentials
-# Logic lives in lib/core/warnings.sh, shared with tests
-# shellcheck source=lib/core/warnings.sh
-. "$(dirname "$0")/lib/core/warnings.sh"
-# WPA_PASSPHRASE length validation
-# Logic lives in lib/core/passphrase.sh, shared with tests
-# shellcheck source=lib/core/passphrase.sh
-. "$(dirname "$0")/lib/core/passphrase.sh"
-# MAX_STATIONS
-# Logic lives in lib/core/stations.sh, shared with tests
-# shellcheck source=lib/core/stations.sh
-. "$(dirname "$0")/lib/core/stations.sh"
-# WPA version
-# Logic lives in lib/core/wpa.sh, shared with tests
-# shellcheck source=lib/core/wpa.sh
-. "$(dirname "$0")/lib/core/wpa.sh"
-# AP isolation
-# Logic lives in lib/core/ap_isolation.sh, shared with tests
-# shellcheck source=lib/core/ap_isolation.sh
-. "$(dirname "$0")/lib/core/ap_isolation.sh"
-# Hidden SSID
-# Logic lives in lib/core/ssid_hidden.sh, shared with tests
-# shellcheck source=lib/core/ssid_hidden.sh
-. "$(dirname "$0")/lib/core/ssid_hidden.sh"
-# MAC address filtering
-# Logic lives in lib/core/mac_filter.sh, shared with tests
-# shellcheck source=lib/core/mac_filter.sh
-. "$(dirname "$0")/lib/core/mac_filter.sh"
-# Control interface
-# Logic lives in lib/core/ctrl_interface.sh, shared with tests
-# shellcheck source=lib/core/ctrl_interface.sh
-. "$(dirname "$0")/lib/core/ctrl_interface.sh"
-# Optional IPv6 support
-# Logic lives in lib/sys/ipv6.sh, shared with tests
-# shellcheck source=lib/sys/ipv6.sh
-. "$(dirname "$0")/lib/sys/ipv6.sh"
-# DHCP_RANGE computation
-# Logic lives in lib/core/dhcp.sh, shared with tests
-# shellcheck source=lib/core/dhcp.sh
-. "$(dirname "$0")/lib/core/dhcp.sh"
-# Extra hostapd.conf options (HOSTAPD_EXTRA_OPTS)
-# Logic lives in lib/core/extra_opts.sh, shared with tests
-# shellcheck source=lib/core/extra_opts.sh
-. "$(dirname "$0")/lib/core/extra_opts.sh"
-# TX_POWER transmit power control
-# Logic lives in lib/sys/radio.sh, shared with tests
-# shellcheck source=lib/sys/radio.sh
-. "$(dirname "$0")/lib/sys/radio.sh"
-# Atomic config file writing (temp file + mv)
-# Logic lives in lib/sys/atomic.sh, shared with tests
-# shellcheck source=lib/sys/atomic.sh
-. "$(dirname "$0")/lib/sys/atomic.sh"
+# Remaining validation/config modules (each loaded once, idempotently)
+require_module channel validation warnings passphrase stations \
+    wpa ap_isolation ssid_hidden mac_filter ctrl_interface ipv6 \
+    dhcp extra_opts radio atomic
 
 # Emit hostapd.conf to stdout from the current environment.
 emit_hostapd_conf() {
@@ -386,8 +323,7 @@ check_interrupted
 # Output is teed to a temp log via process substitution so that the PID we
 # signal (_MULTIRUN_PID) remains multirun itself, keeping forwarding intact.
 # Failure reporting logic lives in lib/sys/logging.sh, shared with tests
-# shellcheck source=lib/sys/logging.sh
-. "$(dirname "$0")/lib/sys/logging.sh"
+require_module logging
 _DAEMON_LOG=$(mktemp)
 multirun \
     "sh -c 'exec dnsmasq --no-daemon 2>&1 | sed \"s/^/[dnsmasq] /\"'" \


### PR DESCRIPTION
Implements #239.

## Chosen approach

Approach A: a single `lib/bootstrap.sh` loader with `require_module()`.
The loader:

- Resolves module -> `lib/core/` or `lib/sys/` automatically (checks for
  a sys variant first, falls back to core).
- Tracks loaded modules in `_LOADED_<name>` so sourcing any module is
  idempotent and cheap (double-source safe).
- Pulls declared cross-module dependencies first via
  `MODULE_DEPENDENCIES_<name>` variables (currently only
  `MODULE_DEPENDENCIES_ipv6="nat"`).
- Uses dynamic variables (`${!var}`) instead of `declare -A` so it also
  works on bash 3.2 (macOS default), while remaining fully compatible
  with bash 4.x on the Pi.
- Sourcing bootstrap.sh itself twice is a no-op (guarded by a
  `declare -F require_module` check).

## Changes

- New `lib/bootstrap.sh` with `require_module()` / `_require_one_module()`.
- `wlanstart.sh`: ~17 copy-pasted source blocks reduced to one bootstrap
  source plus `require_module` calls (top-level entries only).
- `clients.sh`, `healthcheck.sh`: load `client_env` via `require_module`.
- `lib/sys/ipv6.sh`: ad-hoc `declare -F nat_parse_outgoings` guard now
  prefers `require_module nat` when the loader is present; keeps a direct
  source fallback for consumers that source modules without bootstrap.
- New `tests/bootstrap.bats`: double-source safety, core/sys resolution,
  idempotency (no duplicate teardown-hook registration), multi-module
  calls, and dependency resolution (ipv6 pulls nat).

## Acceptance criteria

- [x] Single consistent mechanism for module loading across lib/
- [x] No duplicated source blocks in wlanstart.sh (reduced to top-level entries)
- [x] Sourcing is idempotent (double-source safe)
- [x] Full bats suite passes: 435/435 locally; shellcheck clean; `make layer-check` OK
