### PR TITLE
refactor: extract config emission into lib/hostapd_conf.sh and lib/dnsmasq_conf.sh

### DIFF
--- a/lib/bootstrap.sh
+++ b/lib/bootstrap.sh
@@ -24,6 +24,11 @@ if ! declare -F require_module > /dev/null 2>&1 ; then
     # shellcheck disable=SC2034  # read dynamically via ${!deps_var}
     MODULE_DEPENDENCIES_ipv6="nat"
 
+    # Config emission modules (issue #238) pull their compute helpers
+    # transitively via the loader.
+    MODULE_DEPENDENCIES_hostapd_conf="wpa ap_isolation ssid_hidden mac_filter stations ctrl_interface extra_opts"
+    MODULE_DEPENDENCIES_dnsmasq_conf="dhcp ipv6"
+
     # require_module loads lib/{core,sys}/<module>.sh once, recursively
     # satisfying declared dependencies first. Accepts one or more module
     # names: require_module lifecycle nat interface

--- a/lib/core/dnsmasq_conf.sh
+++ b/lib/core/dnsmasq_conf.sh
@@ -1,0 +1,29 @@
+# shellcheck shell=bash
+# DHCP server config emission (issue #238): pure module, prints the
+# generated config to stdout from the current environment. No external tools.
+
+# Emit the DHCP server config to stdout from the current environment.
+dnsmasq_conf_emit() {
+    local dhcp_range ipv6_conf=""
+    # Reuse the range computed at startup (DHCP_RANGE_COMPUTED) when
+    # available so dhcp_compute_range (and its warnings) runs only once;
+    # validation mode and tests without it still compute on demand.
+    if [ -n "${DHCP_RANGE_COMPUTED:-}" ] ; then
+        dhcp_range=${DHCP_RANGE_COMPUTED}
+    else
+        dhcp_range=$(dhcp_compute_range) || return 1
+    fi
+    if [ "${IPV6:-0}" = "1" ] ; then
+        ipv6_conf=$(ipv6_compute_dnsmasq_conf)
+    fi
+
+    cat <<EOF
+interface=${INTERFACE}
+bind-dynamic
+dhcp-authoritative
+dhcp-range=${dhcp_range}
+dhcp-option=option:router,${AP_ADDR}
+dhcp-option=option:dns-server,${PRI_DNS},${SEC_DNS}
+${ipv6_conf}
+EOF
+}

--- a/lib/core/hostapd_conf.sh
+++ b/lib/core/hostapd_conf.sh
@@ -1,0 +1,44 @@
+# shellcheck shell=bash
+# hostapd.conf emission (issue #238): pure module, prints the generated
+# hostapd.conf to stdout from the current environment. All computation is
+# delegated to core compute helpers; no system commands are invoked.
+
+# Emit hostapd.conf to stdout from the current environment.
+hostapd_conf_emit() {
+    local wpa_conf ap_isolation_conf ssid_hidden_conf mac_filter_conf max_sta_conf ctrl_conf
+    wpa_conf=$(wpa_compute_conf) || return 1
+    ap_isolation_conf=$(ap_isolation_compute_line)
+    ssid_hidden_conf=$(ssid_hidden_compute_line)
+    mac_filter_conf=$(mac_filter_compute_conf)
+    max_sta_conf=$(stations_compute_max_sta_conf) || return 1
+    ctrl_conf=$(ctrl_interface_compute_conf)
+
+    cat <<EOF
+interface=${INTERFACE}
+${DRIVER+"driver=${DRIVER}"}
+ssid=${SSID}
+${ssid_hidden_conf}
+hw_mode=${HW_MODE}
+channel=${CHANNEL}
+${COUNTRY_CODE+"country_code=${COUNTRY_CODE}"}
+${wpa_conf}
+wpa_ptk_rekey=600
+wmm_enabled=1
+${max_sta_conf}
+${ap_isolation_conf}
+${mac_filter_conf}
+${ctrl_conf}
+
+# Activate channel selection for HT High Throughput (802.11an)
+
+${HT_ENABLED+"ieee80211n=1"}
+${HT_CAPAB+"ht_capab=${HT_CAPAB}"}
+
+# Activate channel selection for VHT Very High Throughput (802.11ac)
+
+${VHT_ENABLED+"ieee80211ac=1"}
+${VHT_CAPAB+"vht_capab=${VHT_CAPAB}"}
+EOF
+
+    extra_opts_compute_lines
+}

--- a/tests/atomic_config.bats
+++ b/tests/atomic_config.bats
@@ -2,7 +2,7 @@
 
 # Tests exercise atomic_write_config() from lib/sys/atomic.sh - the exact code
 # used by wlanstart.sh (no duplicated logic) - together with the real
-# emit_hostapd_conf/emit_dnsmasq_conf validators, covering the failure
+# hostapd_conf_emit/dnsmasq_conf_emit emitters, covering the failure
 # paths from issue #157: failed config generation must leave any
 # pre-existing config untouched.
 
@@ -19,16 +19,14 @@ teardown() {
 
 load_emit_fns() {
     export INTERFACE=wlan0
-    . "${LIB_DIR}/core/validation.sh"
-    . "${LIB_DIR}/core/wpa.sh"
-    . "${LIB_DIR}/core/dhcp.sh"
-    . "${LIB_DIR}/sys/atomic.sh"
+    . "${LIB_DIR}/bootstrap.sh"
+    require_module hostapd_conf dnsmasq_conf atomic
 }
 
 @test "invalid WPA_VERSION leaves pre-existing hostapd.conf untouched" {
     load_emit_fns
     WPA_VERSION=1   # rejected by wpa_compute_conf
-    run atomic_write_config emit_hostapd_conf "${target}"
+    run atomic_write_config hostapd_conf_emit "${target}"
     [ "$status" -ne 0 ]
     [ "$(cat "${target}")" = "OLD-CONFIG" ]
 }
@@ -36,14 +34,13 @@ load_emit_fns() {
 @test "invalid DHCP_RANGE leaves pre-existing dnsmasq.conf untouched" {
     load_emit_fns
     DHCP_RANGE=not-an-ip,192.168.254.200,255.255.255.0,12h
-    run atomic_write_config emit_dnsmasq_conf "${target}"
+    run atomic_write_config dnsmasq_conf_emit "${target}"
     [ "$status" -ne 0 ]
     [ "$(cat "${target}")" = "OLD-CONFIG" ]
 }
 
 @test "successful generation replaces the target content atomically" {
     . "$LIB_DIR/sys/atomic.sh"
-    # emit_hostapd_conf/emit_dnsmasq_conf live in wlanstart.sh itself;
     # use a representative emitter to verify the atomic replace path.
     good_emit() { printf 'interface=wlan0\n'; }
     run atomic_write_config good_emit "${target}"

--- a/tests/channel_validation.bats
+++ b/tests/channel_validation.bats
@@ -258,15 +258,9 @@ setup() {
     export INTERFACE=wlan0 SSID=test WPA_PASSPHRASE=passw0rd
     export HW_MODE=g CHANNEL=acs COUNTRY_CODE=EU WPA_VERSION=2
     export MAX_STATIONS=0
-    eval "$(sed -n '/^emit_hostapd_conf()/,/^}/p' "${BATS_TEST_DIRNAME}/../wlanstart.sh")"
-    . "${BATS_TEST_DIRNAME}/../lib/core/stations.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/ctrl_interface.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/wpa.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/ssid_hidden.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/mac_filter.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/ap_isolation.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/extra_opts.sh"
-    run emit_hostapd_conf
+    . "${BATS_TEST_DIRNAME}/../lib/bootstrap.sh"
+    require_module hostapd_conf
+    run hostapd_conf_emit
     [ "$status" -eq 0 ]
     grep -qx 'channel=acs' <<< "$output"
 }

--- a/tests/config_emission.bats
+++ b/tests/config_emission.bats
@@ -1,0 +1,107 @@
+#!/usr/bin/env bats
+
+# Direct tests for the extracted config emission modules (issue #238):
+# lib/core/hostapd_conf.sh and lib/core/dnsmasq_conf.sh.
+
+REPO="${BATS_TEST_DIRNAME}/.."
+
+# Load modules with a fixed environment so env_resolve_config_env sees
+# the same inputs the assertions below expect.
+load_modules() {
+    . "${REPO}/lib/bootstrap.sh"
+    require_module env hostapd_conf dnsmasq_conf
+    export INTERFACE=wlan0 SSID=testnet WPA_PASSPHRASE=supersecret COUNTRY_CODE=US
+    env_resolve_config_env >/dev/null 2>&1
+}
+
+@test "hostapd_conf_emit generates expected hostapd.conf" {
+    load_modules
+    hostapd_conf_emit > "${BATS_TMPDIR}/hostapd_actual.conf"
+    diff -u /dev/stdin "${BATS_TMPDIR}/hostapd_actual.conf" <<'CONF'
+interface=wlan0
+
+ssid=testnet
+
+hw_mode=g
+channel=11
+country_code=US
+wpa=2
+wpa_passphrase=supersecret
+wpa_key_mgmt=WPA-PSK
+# TKIP is no secure anymore
+#wpa_pairwise=TKIP CCMP
+wpa_pairwise=CCMP
+rsn_pairwise=CCMP
+wpa_ptk_rekey=600
+wmm_enabled=1
+
+
+
+
+
+# Activate channel selection for HT High Throughput (802.11an)
+
+
+
+
+# Activate channel selection for VHT Very High Throughput (802.11ac)
+
+
+
+CONF
+}
+
+@test "hostapd_conf_emit includes optional lines only when enabled" {
+    load_modules
+    export DRIVER=nl80211 HT_ENABLED=1 HT_CAPAB="[SHORT-GI-20]" \
+        MAX_STATIONS=10 AP_ISOLATION=1
+    run hostapd_conf_emit
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"driver=nl80211"* ]]
+    [[ "$output" == *"ieee80211n=1"* ]]
+    [[ "$output" == *"ht_capab=[SHORT-GI-20]"* ]]
+    [[ "$output" == *"max_num_sta=10"* ]]
+    [[ "$output" == *"ap_isolate=1"* ]]
+}
+
+@test "hostapd_conf_emit fails on invalid WPA_VERSION" {
+    load_modules
+    export WPA_VERSION=bogus
+    run hostapd_conf_emit
+    [ "$status" -ne 0 ]
+}
+
+@test "dnsmasq_conf_emit generates expected dnsmasq.conf from SUBNET defaults" {
+    load_modules
+    run dnsmasq_conf_emit
+    [ "$status" -eq 0 ]
+    diff -u /dev/stdin <(dnsmasq_conf_emit) <<'CONF' 2>/dev/null
+interface=wlan0
+bind-dynamic
+dhcp-authoritative
+dhcp-range=192.168.254.100,192.168.254.200,255.255.255.0,12h
+dhcp-option=option:router,192.168.254.1
+dhcp-option=option:dns-server,8.8.8.8,8.8.4.4
+
+CONF
+}
+
+@test "dnsmasq_conf_emit reuses DHCP_RANGE_COMPUTED when set" {
+    load_modules
+    export DHCP_RANGE_COMPUTED="10.0.0.10,10.0.0.20,255.255.255.0,24h"
+    run dnsmasq_conf_emit
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"dhcp-range=10.0.0.10,10.0.0.20,255.255.255.0,24h"* ]]
+}
+
+@test "dnsmasq_conf_emit adds IPv6 options with IPV6=1" {
+    load_modules
+    export IPV6=1
+    run dnsmasq_conf_emit
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"dhcp-range=::,constructor:wlan0,ra-names,stateless"* ]]
+}
+
+@test "emit functions are not defined by wlanstart.sh itself" {
+    ! grep -E '(hostapd|dnsmasq)_conf[a-z_]*\(\)' "${REPO}/wlanstart.sh"
+}

--- a/tests/dhcp_range.bats
+++ b/tests/dhcp_range.bats
@@ -383,14 +383,14 @@ setup() {
     run bash -c '
         . "'"${REPO_ROOT}"'/lib/core/env.sh"
         . "'"${REPO_ROOT}"'/lib/core/dhcp.sh"
-        wlanstart="'"${REPO_ROOT}"'/wlanstart.sh"
-        eval "$(sed -n "/^emit_dnsmasq_conf()/,/^}/p" "${wlanstart}")"
+        . "'"${REPO_ROOT}"'/lib/bootstrap.sh"
+        require_module dnsmasq_conf
         SUBNET="192.168.254.0" AP_ADDR="192.168.254.1" INTERFACE="wlan0"
         PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
         env_resolve_config_env
         DHCP_RANGE_COMPUTED=$(dhcp_compute_range) || exit 1
         export DHCP_RANGE_COMPUTED
-        emit_dnsmasq_conf
+        dnsmasq_conf_emit
     '
     [ "$status" -eq 0 ]
     [[ "${output}" == *'interface=wlan0'* ]]
@@ -398,26 +398,24 @@ setup() {
     [[ "${output}" == *'dhcp-authoritative'* ]]
 }
 
-@test "default-range warning appears once when emit_dnsmasq_conf reuses computed range (#224)" {
+@test "default-range warning appears once when dnsmasq_conf_emit reuses computed range (#224)" {
     # shellcheck disable=SC2016
     run bash -c '
         . "'"${REPO_ROOT}"'/lib/core/env.sh"
         . "'"${REPO_ROOT}"'/lib/core/dhcp.sh"
-        wlanstart="'"${REPO_ROOT}"'/wlanstart.sh"
-        # Extract emit_dnsmasq_conf from wlanstart.sh (same pattern as
-        # tests/atomic_config.bats)
-        eval "$(sed -n "/^emit_dnsmasq_conf()/,/^}/p" "${wlanstart}")"
+        . "'"${REPO_ROOT}"'/lib/bootstrap.sh"
+        require_module dnsmasq_conf
         SUBNET="192.168.254.0" AP_ADDR="192.168.254.1" INTERFACE="wlan0"
         PRI_DNS="8.8.8.8" SEC_DNS="8.8.4.4" COUNTRY_CODE=EU
         env_resolve_config_env
-        # Startup path: compute once, reuse in emit_dnsmasq_conf
+        # Startup path: compute once, reuse in dnsmasq_conf_emit
         DHCP_RANGE_COMPUTED=$(dhcp_compute_range 2> "'"${BATS_TEST_TMPDIR}"'/err1") || exit 1
         export DHCP_RANGE_COMPUTED
-        emit_dnsmasq_conf > /dev/null 2> "'"${BATS_TEST_TMPDIR}"'/err2"
+        dnsmasq_conf_emit > /dev/null 2> "'"${BATS_TEST_TMPDIR}"'/err2"
     '
     [ "$status" -eq 0 ]
     local err1="${BATS_TEST_TMPDIR}/err1" err2="${BATS_TEST_TMPDIR}/err2"
     grep -q "using default" "${err1}"
-    # emit_dnsmasq_conf must not warn again when the range is reused
+    # dnsmasq_conf_emit must not warn again when the range is reused
     [ "$(grep -c "using default" "${err2}")" = "0" ]
 }

--- a/tests/extra_opts.bats
+++ b/tests/extra_opts.bats
@@ -46,15 +46,9 @@ setup() {
     export HW_MODE=g CHANNEL=6 WPA_VERSION=2
     export MAX_STATIONS=0
     export HOSTAPD_EXTRA_OPTS=$'auth_algs=3\nbeacon_int=100'
-    eval "$(sed -n '/^emit_hostapd_conf()/,/^}/p' "${BATS_TEST_DIRNAME}/../wlanstart.sh")"
-    . "${BATS_TEST_DIRNAME}/../lib/core/stations.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/ctrl_interface.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/wpa.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/ssid_hidden.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/mac_filter.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/ap_isolation.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/extra_opts.sh"
-    run emit_hostapd_conf
+    . "${BATS_TEST_DIRNAME}/../lib/bootstrap.sh"
+    require_module hostapd_conf
+    run hostapd_conf_emit
     [ "$status" -eq 0 ]
     [ "${#lines[@]}" -ge 2 ]
     [ "${lines[${#lines[@]} - 1]}" = "beacon_int=100" ]
@@ -65,15 +59,9 @@ setup() {
     export INTERFACE=wlan0 SSID=test WPA_PASSPHRASE=passw0rd
     export HW_MODE=g CHANNEL=6 WPA_VERSION=2
     export MAX_STATIONS=0
-    eval "$(sed -n '/^emit_hostapd_conf()/,/^}/p' "${BATS_TEST_DIRNAME}/../wlanstart.sh")"
-    . "${BATS_TEST_DIRNAME}/../lib/core/stations.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/ctrl_interface.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/wpa.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/ssid_hidden.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/mac_filter.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/ap_isolation.sh"
-    . "${BATS_TEST_DIRNAME}/../lib/core/extra_opts.sh"
-    run emit_hostapd_conf
+    . "${BATS_TEST_DIRNAME}/../lib/bootstrap.sh"
+    require_module hostapd_conf
+    run hostapd_conf_emit
     [ "$status" -eq 0 ]
     ! grep -q 'auth_algs=' <<< "$output"
 }

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -111,71 +111,9 @@ require_module channel validation warnings passphrase stations \
     wpa ap_isolation ssid_hidden mac_filter ctrl_interface ipv6 \
     dhcp extra_opts radio atomic
 
-# Emit hostapd.conf to stdout from the current environment.
-emit_hostapd_conf() {
-    local wpa_conf ap_isolation_conf ssid_hidden_conf mac_filter_conf max_sta_conf ctrl_conf
-    wpa_conf=$(wpa_compute_conf) || return 1
-    ap_isolation_conf=$(ap_isolation_compute_line)
-    ssid_hidden_conf=$(ssid_hidden_compute_line)
-    mac_filter_conf=$(mac_filter_compute_conf)
-    max_sta_conf=$(stations_compute_max_sta_conf) || return 1
-    ctrl_conf=$(ctrl_interface_compute_conf)
-
-    cat <<EOF
-interface=${INTERFACE}
-${DRIVER+"driver=${DRIVER}"}
-ssid=${SSID}
-${ssid_hidden_conf}
-hw_mode=${HW_MODE}
-channel=${CHANNEL}
-${COUNTRY_CODE+"country_code=${COUNTRY_CODE}"}
-${wpa_conf}
-wpa_ptk_rekey=600
-wmm_enabled=1
-${max_sta_conf}
-${ap_isolation_conf}
-${mac_filter_conf}
-${ctrl_conf}
-
-# Activate channel selection for HT High Throughput (802.11an)
-
-${HT_ENABLED+"ieee80211n=1"}
-${HT_CAPAB+"ht_capab=${HT_CAPAB}"}
-
-# Activate channel selection for VHT Very High Throughput (802.11ac)
-
-${VHT_ENABLED+"ieee80211ac=1"}
-${VHT_CAPAB+"vht_capab=${VHT_CAPAB}"}
-EOF
-
-    extra_opts_compute_lines
-}
-
-# Emit dnsmasq.conf to stdout from the current environment.
-emit_dnsmasq_conf() {
-    local dhcp_range ipv6_conf=""
-    # Reuse the range computed at startup (DHCP_RANGE_COMPUTED) when
-    # available so dhcp_compute_range (and its warnings) runs only once;
-    # validation mode and tests without it still compute on demand.
-    if [ -n "${DHCP_RANGE_COMPUTED:-}" ] ; then
-        dhcp_range=${DHCP_RANGE_COMPUTED}
-    else
-        dhcp_range=$(dhcp_compute_range) || return 1
-    fi
-    if [ "${IPV6:-0}" = "1" ] ; then
-        ipv6_conf=$(ipv6_compute_dnsmasq_conf)
-    fi
-
-    cat <<EOF
-interface=${INTERFACE}
-bind-dynamic
-dhcp-authoritative
-dhcp-range=${dhcp_range}
-dhcp-option=option:router,${AP_ADDR}
-dhcp-option=option:dns-server,${PRI_DNS},${SEC_DNS}
-${ipv6_conf}
-EOF
-}
+# Config emission lives in lib/core (issue #238); this file only wires the
+# generated configs into validation mode and atomic writes below.
+require_module hostapd_conf dnsmasq_conf
 
 # Dry-run validation mode: run every validator, collecting all failures
 # instead of stopping at the first one. On success print the generated
@@ -210,11 +148,11 @@ run_validation_mode() {
 
     # Config generation doubles as DHCP range / WPA config validation.
     local hostapd dnsmasq
-    hostapd=$(emit_hostapd_conf) || {
+    hostapd=$(hostapd_conf_emit) || {
         echo "[Error] Invalid WPA configuration." >&2
         return 1
     }
-    dnsmasq=$(emit_dnsmasq_conf) || {
+    dnsmasq=$(dnsmasq_conf_emit) || {
         echo "[Error] Invalid DHCP_RANGE." >&2
         return 1
     }
@@ -266,13 +204,13 @@ validation_check_ipv4_param SEC_DNS "${SEC_DNS}" || exit 1
 # Compute DHCP range early so the netmask-derived prefix (DHCP_PREFIX)
 # is available for interface_setup and nat_apply_rules, and so the
 # computed range (and its warnings) is produced exactly once per startup;
-# emit_dnsmasq_conf reuses it below (#224).
+# dnsmasq_conf_emit reuses it below (#224).
 DHCP_RANGE_COMPUTED=$(dhcp_compute_range) || exit 1
 export DHCP_RANGE_COMPUTED
 
 # Always regenerate hostapd.conf so env var changes apply between runs.
 # Generated atomically so a failure leaves the old config intact (#157).
-atomic_write_config emit_hostapd_conf "/etc/hostapd.conf" || exit 1
+atomic_write_config hostapd_conf_emit "/etc/hostapd.conf" || exit 1
 check_interrupted
 
 # Setup interface and restart DHCP service
@@ -314,7 +252,7 @@ echo "Configuring DHCP server .."
 
 # Always regenerate dnsmasq.conf so env var changes apply between runs.
 # Generated atomically so a failure leaves the old config intact (#157).
-atomic_write_config emit_dnsmasq_conf "/etc/dnsmasq.conf" || exit 1
+atomic_write_config dnsmasq_conf_emit "/etc/dnsmasq.conf" || exit 1
 
 echo "Starting dnsmasq and hostapd via multirun ..."
 check_interrupted


### PR DESCRIPTION
## Summary

Implements #238: extracts the config emission functions out of the `wlanstart.sh` entrypoint into dedicated pure modules in `lib/core/`.

- New `lib/core/hostapd_conf.sh` with `hostapd_conf_emit` (formerly `emit_hostapd_conf`)
- New `lib/core/dnsmasq_conf.sh` with `dnsmasq_conf_emit` (formerly `emit_dnsmasq_conf`)
- Both are pure (no system commands, pass `tests/layering.bats` / `make layer-check`) and pull their compute helpers transitively via `MODULE_DEPENDENCIES_<module>` declared in `lib/bootstrap.sh` per the loader convention (#239)
- `wlanstart.sh` now only does `require_module hostapd_conf dnsmasq_conf` and passes the emitters to `atomic_write_config`; it is orchestration-only
- Validation mode (`--validate`) output verified byte-for-byte identical to pre-refactor output

## Test changes

- New `tests/config_emission.bats`: calls `hostapd_conf_emit` / `dnsmasq_conf_emit` directly and asserts on full generated content (golden heredoc diffs), optional-line inclusion, failure paths, DHCP_RANGE_COMPUTED reuse, and IPv6 lines
- Migrated existing tests that extracted the functions from `wlanstart.sh` via `sed | eval` (`extra_opts.bats`, `channel_validation.bats`, `dhcp_range.bats`, `atomic_config.bats`) to use `require_module` instead

## Checklist

- [x] emit functions live in lib/, sourced not defined by wlanstart.sh
- [x] Generated hostapd.conf / dnsmasq.conf identical to current output (byte-identical diff captured before/after)
- [x] bats tests call emit functions directly
- [x] Full bats suite passes locally (443/443), shellcheck clean, layer-check green

Closes #238
