### PR TITLE
feat(wpa): PMF (802.11w) toggle env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ docker run -d \
 | `AP_ISOLATION` | No | Isolate clients from each other (`1` = enabled) | `0` |
 | `COUNTRY_CODE` | No | Regulatory domain (`US`/`CA`/`MX`: ch 1-11, `JP`: ch 1-14, others: ch 1-13). Sets `country_code` in hostapd.conf | `EU` |
 | `WPA_VERSION` | No | WPA version: `2` = WPA2-PSK, `3` = WPA3-SAE (requires client support), `mixed` = WPA2/WPA3 transition (legacy clients allowed) | `2` |
+| `PMF` | No | Protected Management Frames / 802.11w (`ieee80211w=`): `0` = disabled, `1` = optional, `2` = required. Overrides the WPA-derived default (`2` for `WPA_VERSION=3`, `1` for `mixed`, none for `2`); `0` is rejected with `WPA_VERSION=3`. See [PMF](docs/configuration.md#pmf-80211w) | unset |
 | `IPV6` | No | Enable IPv6 RA/DHCPv6 for clients (`1` = enabled) | `0` |
 | `MAC_FILTER` | No | MAC address filtering: `0` = off, `1` = allowlist (only listed MACs), `2` = denylist (listed MACs rejected). Requires `MAC_ACL_FILE` | `0` |
 | `MAC_ACL_FILE` | No | Path to MAC list file (one MAC per line, mounted volume); required when `MAC_FILTER` is `1` or `2` | unset |

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -158,6 +158,40 @@ If any required client lacks SAE support, use `WPA_VERSION=mixed` instead.
 
 Setting `WPA_VERSION=mixed` enables WPA2/WPA3 transition mode: WPA3-SAE capable devices use SAE, while legacy WPA2 clients can still connect with WPA2-PSK. Note that transition mode is considered less secure than WPA3-only.
 
+## PMF (802.11w)
+
+Protected Management Frames (PMF, IEEE 802.11w) encrypt deauthentication and other management frames, protecting clients from spoofed deauth attacks. It is configured in hostapd.conf via `ieee80211w`.
+
+By default PMF is derived from `WPA_VERSION`:
+
+| WPA_VERSION | Emitted | Why |
+|-------------|-----------------|-----|
+| `2` | nothing | WPA2-only keeps maximum legacy compatibility |
+| `3` | `ieee80211w=2` | WPA3-SAE mandates PMF |
+| `mixed` | `ieee80211w=1` | transition mode makes PMF optional so legacy clients can join |
+
+Set `PMF` explicitly to override the derived default:
+
+| Value | Emitted | Meaning |
+|-------|---------|---------|
+| `0` | `ieee80211w=0` | disabled |
+| `1` | `ieee80211w=1` | optional |
+| `2` | `ieee80211w=2` | required |
+
+Notes:
+
+- Any other value fails startup with `[Error] Invalid PMF '...'. Must be 0 (disabled), 1 (optional) or 2 (required).`
+- `PMF=0` combined with `WPA_VERSION=3` is rejected: WPA3-SAE requires Protected Management Frames.
+- Enabling `PMF=2` on a WPA2-only network requires client support for 802.11w; older devices will fail to associate.
+
+```bash
+docker run -d --name hostap \
+  --privileged --net host \
+  -e INTERFACE=wlan0 -e SSID=myap -e WPA_PASSPHRASE=changeme \
+  -e WPA_VERSION=mixed -e PMF=2 \
+  sdelrio/rpi-hostap
+```
+
 ## Regional Channel Validation
 
 When `COUNTRY_CODE` is set, channels are validated against regional limits.

--- a/lib/core/wpa.sh
+++ b/lib/core/wpa.sh
@@ -1,9 +1,15 @@
 # shellcheck shell=bash
 # Shared WPA configuration logic used by wlanstart.sh and tests.
 #
-# wpa_compute_conf reads WPA_VERSION (2 | 3 | mixed) and HW_MODE from the
-# environment and writes the hostapd wpa_* block to stdout. Messages go to
-# stderr. Returns non-zero for invalid WPA_VERSION values.
+# wpa_compute_conf reads WPA_VERSION (2 | 3 | mixed), HW_MODE and the
+# optional PMF variable (0 | 1 | 2) from the environment and writes the
+# hostapd wpa_* block to stdout. Messages go to stderr. Returns non-zero
+# for invalid values.
+#
+# PMF (802.11w, ieee80211w): when unset, it is derived from WPA_VERSION
+# (2 for WPA3-only, 1 for transition mode, nothing for WPA2). An explicit
+# PMF value overrides the derived default, except that PMF=0 is rejected
+# as incompatible with WPA_VERSION=3 (WPA3-SAE mandates PMF).
 wpa_compute_conf() {
     # Defaults (WPA_VERSION, HW_MODE, WPA_PASSPHRASE) are applied
     # centrally by lib/core/env.sh (issue #237).
@@ -40,6 +46,23 @@ ${_WPA_PAIRWISE}"
             return 1
             ;;
     esac
+    if [ -n "${PMF+x}" ] ; then
+        case "${PMF}" in
+            0)
+                if [ "${WPA_VERSION}" = "3" ] ; then
+                    echo "[Error] PMF=0 (disabled) is incompatible with WPA_VERSION=3: WPA3-SAE requires Protected Management Frames." >&2
+                    return 1
+                fi
+                _PMF="ieee80211w=0"
+                ;;
+            1) _PMF="ieee80211w=1" ;;
+            2) _PMF="ieee80211w=2" ;;
+            *)
+                echo "[Error] Invalid PMF '${PMF}'. Must be 0 (disabled), 1 (optional) or 2 (required)." >&2
+                return 1
+                ;;
+        esac
+    fi
     _PMF_LINE=""
     [ -n "${_PMF}" ] && _PMF_LINE="
 ${_PMF}"

--- a/tests/wpa_version.bats
+++ b/tests/wpa_version.bats
@@ -5,6 +5,7 @@
 
 setup() {
     unset WPA_VERSION
+    unset PMF
     unset HW_MODE
     unset _WPA_CONF
     unset _WPA_LEVEL
@@ -92,4 +93,77 @@ load_lib() {
     run wpa_compute_conf
     [ "$status" -ne 0 ]
     [[ "$output" == *"Invalid WPA_VERSION"* ]]
+}
+
+@test "unset PMF with WPA_VERSION=2 emits no ieee80211w" {
+    load_lib
+    WPA_VERSION=2
+    unset PMF
+    run wpa_compute_conf
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"ieee80211w"* ]]
+}
+
+@test "unset PMF with WPA_VERSION=3 derives ieee80211w=2" {
+    load_lib
+    WPA_VERSION=3
+    unset PMF
+    run wpa_compute_conf
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ieee80211w=2"* ]]
+}
+
+@test "unset PMF with WPA_VERSION=mixed derives ieee80211w=1" {
+    load_lib
+    WPA_VERSION=mixed
+    unset PMF
+    run wpa_compute_conf
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ieee80211w=1"* ]]
+}
+
+@test "PMF=0 emits ieee80211w=0 for WPA2-only" {
+    load_lib
+    WPA_VERSION=2
+    PMF=0
+    run wpa_compute_conf
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ieee80211w=0"* ]]
+}
+
+@test "explicit PMF=2 overrides mixed-mode derived default" {
+    load_lib
+    WPA_VERSION=mixed
+    PMF=2
+    run wpa_compute_conf
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ieee80211w=2"* ]]
+    [[ "$output" != *"ieee80211w=1"* ]]
+}
+
+@test "explicit PMF=1 overrides WPA3-derived default" {
+    load_lib
+    WPA_VERSION=3
+    PMF=1
+    run wpa_compute_conf
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ieee80211w=1"* ]]
+}
+
+@test "PMF=0 combined with WPA_VERSION=3 is rejected" {
+    load_lib
+    WPA_VERSION=3
+    PMF=0
+    run wpa_compute_conf
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"incompatible with WPA_VERSION=3"* ]]
+}
+
+@test "invalid PMF value fails with clear error" {
+    load_lib
+    WPA_VERSION=2
+    PMF=3
+    run wpa_compute_conf
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Invalid PMF '3'"* ]]
 }


### PR DESCRIPTION
## Summary

Adds a `PMF` env var to control Protected Management Frames (IEEE 802.11w, `ieee80211w=` in hostapd.conf), building on the existing WPA3/transition derivation added in #220.

### Behavior

| PMF | Emitted | Notes |
|-----|---------|-------|
| unset | derived from `WPA_VERSION` | `ieee80211w=2` for `3`, `=1` for `mixed`, nothing for `2` (unchanged) |
| `0` | `ieee80211w=0` | rejected when `WPA_VERSION=3` (WPA3-SAE mandates PMF) |
| `1` | `ieee80211w=1` | optional |
| `2` | `ieee80211w=2` | required |

- Explicit values override the WPA-derived default.
- Invalid values fail with `[Error] Invalid PMF '...'. Must be 0 (disabled), 1 (optional) or 2 (required).`
- Implementation in `lib/core/wpa.sh::wpa_compute_conf` (pure core module, layer-check clean); no hostapd_conf.sh changes needed since the line already flows through `_PMF`.

### Docs

- README.md: new `PMF` row in the env var table.
- docs/configuration.md: new "PMF (802.11w)" section with derivation matrix, override table and example.

### Tests

9 new bats tests in `tests/wpa_version.bats` covering the derivation matrix (unset x WPA_VERSION 2/3/mixed), explicit overrides, `PMF=0` + `WPA_VERSION=3` rejection and invalid-value error.

Full suite: 451 tests passing locally; shellcheck clean; `make layer-check` clean.

Closes #235
