### PR TITLE
chore(docker): pin libssl3/libcrypto3 explicitly in apk install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,15 @@ FROM alpine:3.24.1
 
 LABEL maintainer="Sergio R. <sdelrio@users.noreply.github.com>"
 
-# Upgrade first so base-image libraries (e.g. libssl/libcrypto) pick up
-# security fixes published after the alpine point release was tagged.
+# Upgrade first so base-image libraries pick up security fixes published
+# after the alpine point release was tagged. libssl3/libcrypto3 are pinned
+# explicitly because hostapd links them at runtime; without pins apk would
+# upgrade them as unversioned deps, making builds non-reproducible.
 RUN apk upgrade --no-cache && \
     apk add --no-cache \
     bash=5.3.9-r1 \
+    libssl3=3.5.8-r0 \
+    libcrypto3=3.5.8-r0 \
     hostapd=2.11-r4 \
     iptables=1.8.13-r0 \
     dnsmasq=2.92_p2-r0 \


### PR DESCRIPTION
## chore(docker): pin libssl3/libcrypto3 explicitly in apk install

Closes #271

### Problem

The Dockerfile's `apk upgrade --no-cache` upgrades `libcrypto3`/`libssl3`
implicitly as unversioned dependencies, so image builds are not
reproducible: whatever OpenSSL point release is current in the v3.24 repo
at build time gets installed.

### Dependency-chain findings

Docker was not available locally (daemon not running), so the chain was
determined from the Alpine package metadata
(pkgs.alpinelinux.org, branch v3.24):

- `hostapd` depends directly on `libssl3` and `libcrypto3` (it links
  OpenSSL for EAP-TLS/802.11w PMF support). It is a hard runtime
  dependency of our AP.
- `dnsmasq`, `iptables`, `multirun`, and `bash` do NOT depend on
  libssl3/libcrypto3.

Conclusion: both libraries ARE needed at runtime (via hostapd), so they
must be pinned rather than removed. Narrowing to drop them is not
possible while hostapd is in the image.

### Chosen pins

Alpine v3.24 repo currently ships:

- `libssl3=3.5.8-r0`
- `libcrypto3=3.5.8-r0`

Both added to the `apk add --no-cache` list with explicit pins, matching
the version the implicit upgrade would have pulled in - so behavior is
unchanged but builds are now reproducible until we bump the pins.

### Verification

- CI docker build + Trivy scan must stay green (watching checks).
- Healthcheck unchanged; no runtime behavior change expected since the
  pinned versions match what the implicit upgrade installed.
