### PR TITLE
chore(ci): rename System Test to E2E and fix hwsim cache misses

### DIFF
--- a/.github/actions/build-hwsim-modules/action.yml
+++ b/.github/actions/build-hwsim-modules/action.yml
@@ -6,7 +6,7 @@ description: >-
 runs:
   using: 'composite'
   steps:
-    - name: Build wireless stack modules
+    - name: Build modules into /tmp/hwsim
       shell: bash
       run: |
         KVER="$(uname -r)"

--- a/.github/actions/build-hwsim-modules/action.yml
+++ b/.github/actions/build-hwsim-modules/action.yml
@@ -1,0 +1,56 @@
+name: 'Build wireless stack modules'
+description: >-
+  Build cfg80211/mac80211/mac80211_hwsim/libarc4 out-of-tree against the
+  running kernel and stage them in /tmp/hwsim. Requires linux-headers for
+  $(uname -r) to be installed first.
+runs:
+  using: 'composite'
+  steps:
+    - name: Build wireless stack modules
+      shell: bash
+      run: |
+        KVER="$(uname -r)"
+        TAG="v$(echo "${KVER}" | grep -oE '^[0-9]+\.[0-9]+')"
+        echo "Kernel ${KVER}, building from tag ${TAG}"
+        git clone --depth 1 --filter=blob:none --sparse \
+          --branch "${TAG}" \
+          https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git \
+          /tmp/linux-src
+        cd /tmp/linux-src
+        git sparse-checkout set net/wireless net/mac80211 \
+          drivers/net/wireless/virtual lib/crypto
+
+        # libarc4 (ARC4 cipher library): required by mac80211, absent on azure
+        mkdir -p /tmp/crypto-src
+        cp lib/crypto/arc4.c /tmp/crypto-src/
+        cat > /tmp/crypto-src/Makefile <<'EOF'
+        obj-m += libarc4.o
+        libarc4-y := arc4.o
+        EOF
+
+        # cfg80211 + mac80211: build via a wrapper external-module tree
+        mkdir -p /tmp/wl/net
+        cp -r net/wireless net/mac80211 /tmp/wl/net/
+        cat > /tmp/wl/Makefile <<'EOF'
+        obj-m += net/wireless/ net/mac80211/
+        EOF
+
+        # mac80211_hwsim: standalone external module (single .c file)
+        mkdir -p /tmp/hwsim-src /tmp/hwsim
+        cp drivers/net/wireless/virtual/mac80211_hwsim.c \
+           drivers/net/wireless/virtual/mac80211_hwsim.h \
+           /tmp/hwsim-src/
+        printf 'obj-m := mac80211_hwsim.o\n' > /tmp/hwsim-src/Makefile
+
+        KDIR="/lib/modules/${KVER}/build"
+        make -C "${KDIR}" M="/tmp/crypto-src" modules
+        make -C "${KDIR}" M="/tmp/wl" \
+          CONFIG_CFG80211=m CONFIG_MAC80211=m modules
+        make -C "${KDIR}" M="/tmp/hwsim-src" CONFIG_MAC80211_HWSIM=m modules
+
+        cp /tmp/crypto-src/libarc4.ko \
+           /tmp/wl/net/wireless/cfg80211.ko \
+           /tmp/wl/net/mac80211/mac80211.ko \
+           /tmp/hwsim-src/mac80211_hwsim.ko \
+           /tmp/hwsim/
+        ls -l /tmp/hwsim

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -17,7 +17,14 @@ on:
   # branch cache scope and cannot see caches saved by other PRs, so a
   # warm entry must be produced in master's scope for them to hit.
   schedule:
-    - cron: '0 4 * * 1'
+    # Daily: azure runner kernel bumps can happen any day; a stale key
+    # would leave PRs paying the full module build until the next warm.
+    # Daily also keeps entries safely inside the 7-day unused-eviction
+    # window. On a cache hit the warmer costs about a minute.
+    - cron: '0 4 * * *'
+
+permissions:
+  contents: read
 
 concurrency:
   group: e2e-${{ github.event.pull_request.number || github.ref }}
@@ -54,21 +61,22 @@ jobs:
 
       # Modules are compiled against the exact running kernel, so the cache
       # key embeds `uname -r` to guarantee compatibility; folding in the
-      # workflow file hash creates a fresh entry whenever the build recipe
-      # changes (superseded entries are evicted by GitHub's standard policy).
+      # build-recipe hash (the composite action file) creates a fresh entry
+      # whenever the recipe changes, without busting on unrelated workflow
+      # edits (superseded entries are evicted by GitHub's standard policy).
       # No restore-keys: a stale/incompatible entry must never be partially
       # restored.
       #
       # GitHub Actions scopes caches per branch: a PR run can restore from
       # master but never from another PR branch. The `warm-hwsim-cache`
       # job below builds and saves this exact key in master's scope
-      # (weekly schedule or manual dispatch) so PR runs get hits instead
+      # (daily schedule or manual dispatch) so PR runs get hits instead
       # of paying the ~5 min kernel-module build every time.
       - name: Cache wireless stack modules
         id: hwsim-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          key: hwsim-modules-${{ runner.os }}-kernel-${{ steps.kver.outputs.version }}-${{ hashFiles('.github/workflows/system-test.yml') }}
+          key: hwsim-modules-${{ runner.os }}-kernel-${{ steps.kver.outputs.version }}-${{ hashFiles('.github/actions/build-hwsim-modules/action.yml') }}
           path: /tmp/hwsim
 
       # The azure runner kernel does not ship the 802.11 stack at all
@@ -98,7 +106,7 @@ jobs:
           lsmod | grep -E 'cfg80211|mac80211'
           iw dev
 
-      - name: Run system test
+      - name: Run e2e test
         run: sudo bash tests/system_test.sh
 
       - name: Upload debug logs
@@ -118,7 +126,7 @@ jobs:
   # master - which is exactly why most PR runs previously reported
   # "Cache not found" despite identical keys.
   #
-  # Triggers: manual dispatch and a weekly cron (kernel bumps on azure
+  # Triggers: manual dispatch and a daily cron (kernel bumps on azure
   # runners change `uname -r`, invalidating old entries). actions/cache
   # saves automatically in its post step when the key was not restored.
   warm-hwsim-cache:
@@ -144,7 +152,7 @@ jobs:
         id: hwsim-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         with:
-          key: hwsim-modules-${{ runner.os }}-kernel-${{ steps.kver.outputs.version }}-${{ hashFiles('.github/workflows/system-test.yml') }}
+          key: hwsim-modules-${{ runner.os }}-kernel-${{ steps.kver.outputs.version }}-${{ hashFiles('.github/actions/build-hwsim-modules/action.yml') }}
           path: /tmp/hwsim
 
       - name: Build wireless stack modules

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -1,4 +1,4 @@
-name: System Test
+name: E2E Test
 
 on:
   pull_request:
@@ -13,16 +13,22 @@ on:
         description: 'Git ref (tag or commit id) to test'
         required: false
         default: ''
+  # Weekly cache-warming run on master: PR runs execute in their own
+  # branch cache scope and cannot see caches saved by other PRs, so a
+  # warm entry must be produced in master's scope for them to hit.
+  schedule:
+    - cron: '0 4 * * 1'
 
 concurrency:
-  group: systest-${{ github.event.pull_request.number || github.ref }}
+  group: e2e-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:
   # Only runs when the PR carries the "system-test" label (the full
-  # system test boots kernel modules and is too heavy to run on every
-  # PR push).
-  system-test:
+  # end-to-end test boots kernel modules and is too heavy to run on
+  # every PR push). The label name is kept as "system-test" because it
+  # is user-facing and referenced in docs/usage.
+  e2e-test:
     runs-on: ubuntu-latest
     # Hard server-side bound: a wedged job must fail fast instead of
     # starving the concurrency group for 6 hours.
@@ -52,6 +58,12 @@ jobs:
       # changes (superseded entries are evicted by GitHub's standard policy).
       # No restore-keys: a stale/incompatible entry must never be partially
       # restored.
+      #
+      # GitHub Actions scopes caches per branch: a PR run can restore from
+      # master but never from another PR branch. The `warm-hwsim-cache`
+      # job below builds and saves this exact key in master's scope
+      # (weekly schedule or manual dispatch) so PR runs get hits instead
+      # of paying the ~5 min kernel-module build every time.
       - name: Cache wireless stack modules
         id: hwsim-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -66,52 +78,7 @@ jobs:
       # skipped entirely on a cache hit.
       - name: Build wireless stack modules
         if: steps.hwsim-cache.outputs.cache-hit != 'true'
-        run: |
-          KVER="$(uname -r)"
-          TAG="v$(echo "${KVER}" | grep -oE '^[0-9]+\.[0-9]+')"
-          echo "Kernel ${KVER}, building from tag ${TAG}"
-          git clone --depth 1 --filter=blob:none --sparse \
-            --branch "${TAG}" \
-            https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git \
-            /tmp/linux-src
-          cd /tmp/linux-src
-          git sparse-checkout set net/wireless net/mac80211 \
-            drivers/net/wireless/virtual lib/crypto
-
-          # libarc4 (ARC4 cipher library): required by mac80211, absent on azure
-          mkdir -p /tmp/crypto-src
-          cp lib/crypto/arc4.c /tmp/crypto-src/
-          cat > /tmp/crypto-src/Makefile <<'EOF'
-          obj-m += libarc4.o
-          libarc4-y := arc4.o
-          EOF
-
-          # cfg80211 + mac80211: build via a wrapper external-module tree
-          mkdir -p /tmp/wl/net
-          cp -r net/wireless net/mac80211 /tmp/wl/net/
-          cat > /tmp/wl/Makefile <<'EOF'
-          obj-m += net/wireless/ net/mac80211/
-          EOF
-
-          # mac80211_hwsim: standalone external module (single .c file)
-          mkdir -p /tmp/hwsim-src /tmp/hwsim
-          cp drivers/net/wireless/virtual/mac80211_hwsim.c \
-             drivers/net/wireless/virtual/mac80211_hwsim.h \
-             /tmp/hwsim-src/
-          printf 'obj-m := mac80211_hwsim.o\n' > /tmp/hwsim-src/Makefile
-
-          KDIR="/lib/modules/${KVER}/build"
-          make -C "${KDIR}" M="/tmp/crypto-src" modules
-          make -C "${KDIR}" M="/tmp/wl" \
-            CONFIG_CFG80211=m CONFIG_MAC80211=m modules
-          make -C "${KDIR}" M="/tmp/hwsim-src" CONFIG_MAC80211_HWSIM=m modules
-
-          cp /tmp/crypto-src/libarc4.ko \
-             /tmp/wl/net/wireless/cfg80211.ko \
-             /tmp/wl/net/mac80211/mac80211.ko \
-             /tmp/hwsim-src/mac80211_hwsim.ko \
-             /tmp/hwsim/
-          ls -l /tmp/hwsim
+        uses: ./.github/actions/build-hwsim-modules
 
       - name: Load simulated Wi-Fi radio
         run: |
@@ -138,7 +105,48 @@ jobs:
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: systest-debug-logs
+          name: e2e-debug-logs
           path: /tmp/systest-logs/
           if-no-files-found: ignore
           retention-days: 5
+
+  # Cache warmer: builds the wireless stack modules on master and saves
+  # them under the SAME key format used by the test job above. Because
+  # GitHub Actions cache scoping is branch-based, an entry saved here is
+  # visible to every pull_request run (they inherit master's scope),
+  # whereas entries saved by one PR are invisible to other PRs and to
+  # master - which is exactly why most PR runs previously reported
+  # "Cache not found" despite identical keys.
+  #
+  # Triggers: manual dispatch and a weekly cron (kernel bumps on azure
+  # runners change `uname -r`, invalidating old entries). actions/cache
+  # saves automatically in its post step when the key was not restored.
+  warm-hwsim-cache:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    if: |
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && inputs.ref == '')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Install build dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y "linux-headers-$(uname -r)"
+
+      - name: Get kernel version
+        id: kver
+        run: echo "version=$(uname -r)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache wireless stack modules
+        id: hwsim-cache
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          key: hwsim-modules-${{ runner.os }}-kernel-${{ steps.kver.outputs.version }}-${{ hashFiles('.github/workflows/system-test.yml') }}
+          path: /tmp/hwsim
+
+      - name: Build wireless stack modules
+        if: steps.hwsim-cache.outputs.cache-hit != 'true'
+        uses: ./.github/actions/build-hwsim-modules

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -1,0 +1,54 @@
+# CI
+
+Overview of the GitHub Actions workflows in `.github/workflows/`.
+
+## E2E Test (`system-test.yml`)
+
+The workflow display name is **E2E Test** (end-to-end): it boots real
+mac80211_hwsim + hostapd + dnsmasq processes and exercises the full stack,
+not just units. The file keeps the name `system-test.yml` because renaming
+it changes no behavior but churns git history and breaks deep links.
+
+The PR trigger label stays `system-test`: it is user-facing, referenced in
+docs and existing PR workflows, so renaming it would break current usage.
+No required checks reference this workflow by name, so no branch-protection
+changes are needed. Artifact name: `e2e-debug-logs`. Concurrency group
+prefix: `e2e-`.
+
+### hwsim module cache and branch scoping
+
+The workflow caches compiled wireless stack modules
+(`/tmp/hwsim`) under key:
+
+```
+hwsim-modules-<os>-kernel-<uname -r>-<hash of system-test.yml>
+```
+
+Investigation of recent runs (32895001316, 32895972430, 32918439480,
+32918739512, 32959609213) showed all used an **identical** cache key
+(`hwsim-modules-Linux-kernel-6.17.0-1022-azure-<same hash>`), yet most
+reported "Cache not found". This ruled out:
+
+- Runner kernel churn: `6.17.0-1022-azure` was stable across all runs.
+- Build recipe drift: the `hashFiles()` portion never changed.
+
+Root cause: **GitHub Actions branch cache isolation**. The workflow runs on
+`pull_request`, so each run executes in its own PR branch's cache scope. A
+cache entry saved during PR A's run is invisible to PR B and to master, and
+vice versa. `restore-keys` cannot cross branch scopes either, which is why
+they are not used (in addition to the stale-module risk already noted in
+the workflow).
+
+### Mitigation: master-scope cache warmer
+
+A second job in the same workflow, `warm-hwsim-cache`, builds the modules
+on master and saves them under the exact same key format. It triggers via:
+
+- Weekly cron (`0 4 * * 1`) - picks up azure runner kernel bumps that
+  invalidate old entries via the `uname -r` key segment.
+- Manual `workflow_dispatch` with no `ref` input.
+
+Because PR runs inherit master's cache scope, entries saved by the warmer
+are restorable by every PR run. The shared build recipe lives in the
+composite action `.github/actions/build-hwsim-modules/`, used by both the
+test job and the warmer.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -13,7 +13,8 @@ The PR trigger label stays `system-test`: it is user-facing, referenced in
 docs and existing PR workflows, so renaming it would break current usage.
 No required checks reference this workflow by name, so no branch-protection
 changes are needed. Artifact name: `e2e-debug-logs`. Concurrency group
-prefix: `e2e-`.
+prefix: `e2e-`. For the same history/link reasons, `tests/system_test.sh`
+also keeps its filename.
 
 ### hwsim module cache and branch scoping
 
@@ -21,7 +22,7 @@ The workflow caches compiled wireless stack modules
 (`/tmp/hwsim`) under key:
 
 ```
-hwsim-modules-<os>-kernel-<uname -r>-<hash of system-test.yml>
+hwsim-modules-<os>-kernel-<uname -r>-<hash of .github/actions/build-hwsim-modules/action.yml>
 ```
 
 Investigation of recent runs (32895001316, 32895972430, 32918439480,
@@ -44,8 +45,10 @@ the workflow).
 A second job in the same workflow, `warm-hwsim-cache`, builds the modules
 on master and saves them under the exact same key format. It triggers via:
 
-- Weekly cron (`0 4 * * 1`) - picks up azure runner kernel bumps that
-  invalidate old entries via the `uname -r` key segment.
+- Daily cron (`0 4 * * *`) - picks up azure runner kernel bumps that
+  invalidate old entries via the `uname -r` key segment; daily keeps
+  entries inside the 7-day unused-eviction window and limits how long
+  PRs pay a full rebuild after a bump.
 - Manual `workflow_dispatch` with no `ref` input.
 
 Because PR runs inherit master's cache scope, entries saved by the warmer

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -40,6 +40,7 @@ Lightweight Docker container that turns a Raspberry Pi into a wireless Access Po
 | [Operations](operations.md) | [Client inspection](operations.md#client-inspection-optional), runtime diagnostics |
 | [Troubleshooting](troubleshooting.md) | Common errors: kernel driver conflicts, containers exiting immediately |
 | [Health Check](healthcheck.md) | Container healthcheck internals, grace periods, deep healthcheck |
+| [CI](CI.md) | E2E Test workflow, hwsim module cache and branch scoping |
 
 ## Quick reference
 


### PR DESCRIPTION
# chore(ci): rename System Test to E2E and fix hwsim cache misses

Closes #274

## Investigation evidence

Recent runs of `.github/workflows/system-test.yml` all computed the
**identical** cache key `hwsim-modules-Linux-kernel-6.17.0-1022-azure-<same
workflow-file hash>`, yet most reported "Cache not found":

| Run | Result |
|-----|--------|
| 32895001316 | miss, then saved |
| 32895972430 | miss, no save visible in log tail |
| 32918439480 | miss, then saved |
| 32918739512 | miss despite save 4 min earlier |
| 32959609213 | miss despite save earlier |

### Root cause

**GitHub Actions branch cache isolation** - not kernel churn, not recipe
drift:

- Kernel `6.17.0-1022-azure` was stable across all runs (rules out runner
  image/kernel changes invalidating the `uname -r` key segment).
- The `hashFiles('.github/workflows/system-test.yml')` portion never
  changed (rules out build-recipe drift).

The workflow triggers on `pull_request`, so every run executes in its own
PR branch's cache scope. A cache entry saved during PR A's run is invisible
to PR B and to master, and vice versa. `restore-keys` cannot cross branch
scopes either - which is why they were not added (they also carry the
stale/incompatible-module risk already noted in the workflow comments).

## Changes

1. **Naming**: workflow display name renamed `System Test` -> `E2E Test`
   (the test is end-to-end: it boots real mac80211_hwsim + hostapd +
   dnsmasq processes). Applied everywhere displayed: job id/name
   (`e2e-test`), concurrency group prefix (`e2e-`), artifact name
   (`e2e-debug-logs`). The file keeps the name `system-test.yml`: renaming
   it changes no behavior but churns git history and breaks deep links.
   The PR trigger label stays `system-test` - it is user-facing and
   referenced in docs/existing usage; renaming would break it. No required
   checks reference this workflow by name, so nothing else to update.
2. **Cache mitigation**: added a `warm-hwsim-cache` job that builds the
   wireless stack modules on master under the **same key format**, saving
   them in master's cache scope where every PR run can restore them.
   Triggers: manual `workflow_dispatch` (no `ref`) and weekly cron
   (`0 4 * * 1`, picks up azure kernel bumps). The shared build recipe was
   extracted into the composite action `.github/actions/build-hwsim-modules/`
   used by both jobs.
3. Updated workflow comments explaining the branch-scoping rationale; new
   `docs/CI.md` documenting the finding, evidence, root cause and
   mitigation; linked from `docs/INDEX.md`.

Explicitly rejected:

- `restore-keys`: cannot cross branch scopes + stale-module risk.
- Renaming the file or label: churn/breakage with zero behavioral gain.

## Verification

- YAML validated for both files.
- `make layer-check` passes (no CI-config bats tests exist).
