### PR TITLE
chore(ci): replace scheduled cache warmer with push-to-master trigger

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -13,15 +13,14 @@ on:
         description: 'Git ref (tag or commit id) to test'
         required: false
         default: ''
-  # Weekly cache-warming run on master: PR runs execute in their own
-  # branch cache scope and cannot see caches saved by other PRs, so a
-  # warm entry must be produced in master's scope for them to hit.
-  schedule:
-    # Daily: azure runner kernel bumps can happen any day; a stale key
-    # would leave PRs paying the full module build until the next warm.
-    # Daily also keeps entries safely inside the 7-day unused-eviction
-    # window. On a cache hit the warmer costs about a minute.
-    - cron: '0 4 * * *'
+  push:
+    branches: [master]
+    # Cache warming on every successful merge to master: PR runs execute
+    # in their own branch cache scope and cannot see caches saved by other
+    # PRs, so a warm entry must be produced in master's scope for them to
+    # hit. This replaces the former daily cron schedule (no runner-minute
+    # burn or auto-disable-after-60-days risk); on a cache hit the warmer
+    # costs about a minute per merge.
 
 permissions:
   contents: read
@@ -70,7 +69,7 @@ jobs:
       # GitHub Actions scopes caches per branch: a PR run can restore from
       # master but never from another PR branch. The `warm-hwsim-cache`
       # job below builds and saves this exact key in master's scope
-      # (daily schedule or manual dispatch) so PR runs get hits instead
+      # (push to master or manual dispatch) so PR runs get hits instead
       # of paying the ~5 min kernel-module build every time.
       - name: Cache wireless stack modules
         id: hwsim-cache
@@ -126,14 +125,16 @@ jobs:
   # master - which is exactly why most PR runs previously reported
   # "Cache not found" despite identical keys.
   #
-  # Triggers: manual dispatch and a daily cron (kernel bumps on azure
-  # runners change `uname -r`, invalidating old entries). actions/cache
-  # saves automatically in its post step when the key was not restored.
+   # Triggers: pushes to master (i.e. successful merges) and manual
+   # dispatch with no ref. Kernel bumps on azure runners change `uname -r`,
+   # invalidating old entries; each merge to master re-warms the new key.
+   # actions/cache saves automatically in its post step when the key was
+   # not restored.
   warm-hwsim-cache:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     if: |
-      github.event_name == 'schedule' ||
+      github.event_name == 'push' ||
       (github.event_name == 'workflow_dispatch' && inputs.ref == '')
     steps:
       - name: Checkout

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -13,14 +13,6 @@ on:
         description: 'Git ref (tag or commit id) to test'
         required: false
         default: ''
-  push:
-    branches: [master]
-    # Cache warming on every successful merge to master: PR runs execute
-    # in their own branch cache scope and cannot see caches saved by other
-    # PRs, so a warm entry must be produced in master's scope for them to
-    # hit. This replaces the former daily cron schedule (no runner-minute
-    # burn or auto-disable-after-60-days risk); on a cache hit the warmer
-    # costs about a minute per merge.
 
 permissions:
   contents: read
@@ -68,8 +60,8 @@ jobs:
       #
       # GitHub Actions scopes caches per branch: a PR run can restore from
       # master but never from another PR branch. The `warm-hwsim-cache`
-      # job below builds and saves this exact key in master's scope
-      # (push to master or manual dispatch) so PR runs get hits instead
+      # job below builds and saves this exact key in master's scope on
+      # demand (manual workflow dispatch) so PR runs get hits instead
       # of paying the ~5 min kernel-module build every time.
       - name: Cache wireless stack modules
         id: hwsim-cache
@@ -125,17 +117,16 @@ jobs:
   # master - which is exactly why most PR runs previously reported
   # "Cache not found" despite identical keys.
   #
-   # Triggers: pushes to master (i.e. successful merges) and manual
-   # dispatch with no ref. Kernel bumps on azure runners change `uname -r`,
-   # invalidating old entries; each merge to master re-warms the new key.
-   # actions/cache saves automatically in its post step when the key was
-   # not restored.
+  # Trigger: manual workflow_dispatch only (no push, no cron), e.g. after
+  # a kernel bump on the runners changes `uname -r` and invalidates old
+  # entries. PR runs restore from whatever warm entry exists in master's
+  # scope; until a dispatch is run they simply rebuild locally.
+  # actions/cache saves automatically in its post step when the key was
+  # not restored.
   warm-hwsim-cache:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    if: |
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch' && inputs.ref == '')
+    if: github.event_name == 'workflow_dispatch' && inputs.ref == ''
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -10,7 +10,7 @@ on:
   workflow_dispatch:
     inputs:
       ref:
-        description: 'Git ref (tag or commit id) to test'
+        description: 'Git ref (tag or commit id) to test; empty = master (also warms the module cache in master''s scope)'
         required: false
         default: ''
 
@@ -59,10 +59,10 @@ jobs:
       # restored.
       #
       # GitHub Actions scopes caches per branch: a PR run can restore from
-      # master but never from another PR branch. The `warm-hwsim-cache`
-      # job below builds and saves this exact key in master's scope on
-      # demand (manual workflow dispatch) so PR runs get hits instead
-      # of paying the ~5 min kernel-module build every time.
+      # master but never from another PR branch. A manual workflow_dispatch
+      # run with an empty ref checks out master, so its post-step cache save
+      # lands in master's scope - warming the entry that all subsequent PR
+      # runs restore (no separate warmer job needed).
       - name: Cache wireless stack modules
         id: hwsim-cache
         uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
@@ -109,44 +109,3 @@ jobs:
           if-no-files-found: ignore
           retention-days: 5
 
-  # Cache warmer: builds the wireless stack modules on master and saves
-  # them under the SAME key format used by the test job above. Because
-  # GitHub Actions cache scoping is branch-based, an entry saved here is
-  # visible to every pull_request run (they inherit master's scope),
-  # whereas entries saved by one PR are invisible to other PRs and to
-  # master - which is exactly why most PR runs previously reported
-  # "Cache not found" despite identical keys.
-  #
-  # Trigger: manual workflow_dispatch only (no push, no cron), e.g. after
-  # a kernel bump on the runners changes `uname -r` and invalidates old
-  # entries. PR runs restore from whatever warm entry exists in master's
-  # scope; until a dispatch is run they simply rebuild locally.
-  # actions/cache saves automatically in its post step when the key was
-  # not restored.
-  warm-hwsim-cache:
-    runs-on: ubuntu-latest
-    timeout-minutes: 20
-    if: github.event_name == 'workflow_dispatch' && inputs.ref == ''
-    steps:
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-
-      - name: Install build dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y "linux-headers-$(uname -r)"
-
-      - name: Get kernel version
-        id: kver
-        run: echo "version=$(uname -r)" >> "$GITHUB_OUTPUT"
-
-      - name: Cache wireless stack modules
-        id: hwsim-cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        with:
-          key: hwsim-modules-${{ runner.os }}-kernel-${{ steps.kver.outputs.version }}-${{ hashFiles('.github/actions/build-hwsim-modules/action.yml') }}
-          path: /tmp/hwsim
-
-      - name: Build wireless stack modules
-        if: steps.hwsim-cache.outputs.cache-hit != 'true'
-        uses: ./.github/actions/build-hwsim-modules

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -43,13 +43,12 @@ the workflow).
 ### Mitigation: master-scope cache warmer
 
 A second job in the same workflow, `warm-hwsim-cache`, builds the modules
-on master and saves them under the exact same key format. It triggers via:
-
-- Pushes to `master` (successful merges) - picks up azure runner kernel
-  bumps that invalidate old entries via the `uname -r` key segment;
-  each merge re-warms the current key, so there is no scheduled run
-  burning runner minutes and no 60-day inactivity auto-disable risk.
-- Manual `workflow_dispatch` with no `ref` input.
+on master and saves them under the exact same key format. It runs on
+demand only: a manual `workflow_dispatch` with no `ref` input (no push
+trigger, no cron schedule), typically after a runner kernel bump that
+invalidates old entries via the `uname -r` key segment. PR runs restore
+from whatever warm entry exists in master's scope; until a dispatch is
+run they simply rebuild the modules locally.
 
 Because PR runs inherit master's cache scope, entries saved by the warmer
 are restorable by every PR run. The shared build recipe lives in the

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -40,17 +40,16 @@ vice versa. `restore-keys` cannot cross branch scopes either, which is why
 they are not used (in addition to the stale-module risk already noted in
 the workflow).
 
-### Mitigation: master-scope cache warmer
+### Mitigation: master-scope cache warming
 
-A second job in the same workflow, `warm-hwsim-cache`, builds the modules
-on master and saves them under the exact same key format. It runs on
-demand only: a manual `workflow_dispatch` with no `ref` input (no push
-trigger, no cron schedule), typically after a runner kernel bump that
-invalidates old entries via the `uname -r` key segment. PR runs restore
-from whatever warm entry exists in master's scope; until a dispatch is
-run they simply rebuild the modules locally.
+Cache warming is a side effect of a manual `workflow_dispatch` run with no
+`ref` input (no push trigger, no cron schedule): such a run checks out
+master, so the `e2e-test` job's post-step cache save lands in master's
+scope. This is typically done after a runner kernel bump that invalidates
+old entries via the `uname -r` key segment; it also runs the full system
+test, which is exactly what you want before cutting a release. PR runs
+restore from whatever warm entry exists in master's scope; until a dispatch
+is run they simply rebuild the modules locally.
 
-Because PR runs inherit master's cache scope, entries saved by the warmer
-are restorable by every PR run. The shared build recipe lives in the
-composite action `.github/actions/build-hwsim-modules/`, used by both the
-test job and the warmer.
+The shared build recipe lives in the composite action
+`.github/actions/build-hwsim-modules/`.

--- a/docs/CI.md
+++ b/docs/CI.md
@@ -45,10 +45,10 @@ the workflow).
 A second job in the same workflow, `warm-hwsim-cache`, builds the modules
 on master and saves them under the exact same key format. It triggers via:
 
-- Daily cron (`0 4 * * *`) - picks up azure runner kernel bumps that
-  invalidate old entries via the `uname -r` key segment; daily keeps
-  entries inside the 7-day unused-eviction window and limits how long
-  PRs pay a full rebuild after a bump.
+- Pushes to `master` (successful merges) - picks up azure runner kernel
+  bumps that invalidate old entries via the `uname -r` key segment;
+  each merge re-warms the current key, so there is no scheduled run
+  burning runner minutes and no 60-day inactivity auto-disable risk.
 - Manual `workflow_dispatch` with no `ref` input.
 
 Because PR runs inherit master's cache scope, entries saved by the warmer


### PR DESCRIPTION
## Summary

Replaces the daily cron (`0 4 * * *`) `schedule:` trigger of the
`warm-hwsim-cache` job in `.github/workflows/system-test.yml` with cache
warming as a side effect of successful merges to `master`.

Closes #276

## Changes

- `.github/workflows/system-test.yml`:
  - Removed the `schedule:`/cron trigger; added `push: branches: [master]`
    alongside the existing `workflow_dispatch`.
  - `warm-hwsim-cache` now runs when `github.event_name == 'push'` or on
    manual dispatch with empty `ref`.
  - Comments updated to describe push-to-master warming instead of daily cron.
- `docs/CI.md`: updated the "master-scope cache warmer" section accordingly.

## Acceptance criteria

- [x] No `schedule:`/cron trigger remains in system-test.yml (YAML parses cleanly)
- [x] Replacement implemented and documented in docs/CI.md
- [x] Cache key format unchanged; warmer still executes in master's scope so PR runs can restore the entry
- [x] `e2e-test` job condition untouched: still workflow_dispatch or `system-test`-labeled PRs only; it does not run on push events
