### PR TITLE
docs: remove redundant manual ip addr add from Quick Start

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ sudo systemctl disable wpa_supplicant
 
 ```bash
 sudo ip link set wlan0 up
-sudo ip addr add 192.168.254.1/24 dev wlan0
 ```
+
+The container assigns `AP_ADDR` (default `192.168.254.1/24`) to the interface itself on startup; it is configurable via the `AP_ADDR` and `DHCP_RANGE` environment variables.
 
 2. Run the container:
 


### PR DESCRIPTION
Remove redundant manual `ip addr add` from Quick Start

Closes #289

The container's interface setup (`lib/sys/interface.sh`) flushes addresses
and assigns `AP_ADDR/${DHCP_PREFIX}` itself at startup, so the manual
`sudo ip addr add 192.168.254.1/24 dev wlan0` instruction in the README
Quick Start was redundant and confusing.

- Quick Start step 1 now only brings the link up with `ip link set wlan0 up`
- Added a note that the container assigns AP_ADDR itself, configurable via
  `AP_ADDR` and `DHCP_RANGE` environment variables

Acceptance criteria:
- Quick Start no longer instructs a manual `ip addr add` - met
- Text explains that AP_ADDR is assigned by the container - met
