### PR TITLE
feat: wlanstart.sh --check runtime state audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ docker run -d \
 | `FAILURE_LOG_KEEP` | No | Number of crash logs retained (oldest pruned); see [Preserved failure logs](docs/troubleshooting.md#preserved-failure-logs) | `5` |
 | `FAILURE_LOG_PATH` | No | Explicit path for the preserved log (overrides dir/keep, no rotation); see [Preserved failure logs](docs/troubleshooting.md#preserved-failure-logs) | unset |
 
-Detailed topics and examples are split across the [docs/](docs/INDEX.md) folder: radio/security topics in [docs/configuration.md](docs/configuration.md), config validation in [docs/validation.md](docs/validation.md), and runtime diagnostics in [docs/operations.md](docs/operations.md).
+Detailed topics and examples are split across the [docs/](docs/INDEX.md) folder: radio/security topics in [docs/configuration.md](docs/configuration.md), config validation in [docs/validation.md](docs/validation.md) (`--validate` dry-run and the read-only `--check` runtime state audit), and runtime diagnostics in [docs/operations.md](docs/operations.md).
 
 ### Full-Featured Example
 

--- a/docs/validation.md
+++ b/docs/validation.md
@@ -16,8 +16,26 @@ On invalid configuration it exits non-zero and lists all validation errors (not 
 
 Dry-run validation is also the recommended first step when [troubleshooting a container that exits immediately](troubleshooting.md#container-exits-immediately).
 
+## Runtime State Audit (`--check`)
+
+`wlanstart.sh --check` (alias: `-c`) is a read-only audit of the live system against the resolved configuration. It reports each item individually as `[OK]` or `[FAIL]` and exits non-zero listing failures:
+
+- iptables `POSTROUTING MASQUERADE` rule for `${SUBNET}/${DHCP_PREFIX}` (per `OUTGOINGS` interface when set)
+- iptables `FORWARD` rules for `${INTERFACE}`
+- ip6tables `FORWARD` rules (when `IPV6=1`)
+- sysctls `ip_forward`/`ip_dynaddr` = 1
+- `${AP_ADDR}/${DHCP_PREFIX}` assigned to `${INTERFACE}` with link UP
+
+It never mutates state: only rule existence checks (`iptables -C`), sysctl reads and `ip addr/link show` queries are performed.
+
+```bash
+docker exec rpi-hostap /app/wlanstart.sh --check
+```
+
+See also: [dry-run validation](#dry-run-validation---validate) for checking the configuration itself before startup.
+
 See also: [regional channel validation](configuration.md#regional-channel-validation) (checked by the channel/regulatory validator), [MAC filtering](configuration.md#mac-address-filtering-optional) (file presence validated at start) and the [HT/VHT tuning notes](configuration.md#htvht-80211nac-tuning) for values passed through unvalidated.
 
 ---
 
-_Last updated: 2026-08-24_
+_Last updated: 2026-08-26_

--- a/lib/sys/check.sh
+++ b/lib/sys/check.sh
@@ -1,0 +1,116 @@
+# shellcheck shell=bash
+# shellcheck disable=SC2154
+# Read-only runtime state audit used by `wlanstart.sh --check` (issue #288).
+#
+# Compares live system state against the resolved environment and reports
+# each item as OK/FAIL. Never mutates state: only rule existence checks
+# (iptables -C), reads of sysctl files and `ip addr/link show` queries.
+#
+# Requires nat.sh (nat_parse_outgoings) and the resolved env (INTERFACE,
+# SUBNET, AP_ADDR, DHCP_PREFIX, OUTGOINGS, IPV6).
+
+IPTABLES_BASE="${IPTABLES_BASE:-iptables}"
+IP6TABLES_BASE="${IP6TABLES_BASE:-ip6tables}"
+CHECK_IP_BASE="${CHECK_IP_BASE:-${IP_BASE:-ip}}"
+CHECK_SYSCTL_BASE="${CHECK_SYSCTL_BASE:-${SYSCTL_BASE:-/proc/sys/net/ipv4}}"
+
+_check_prefix() {
+    echo "${SUBNET}/${DHCP_PREFIX:-24}"
+}
+
+# _check_item runs the given check command read-only and prints OK/FAIL.
+_check_item() {
+    local label="$1"
+    shift
+    if "$@" > /dev/null 2>&1 ; then
+        echo "[OK]   ${label}"
+    else
+        echo "[FAIL] ${label}"
+        return 1
+    fi
+}
+
+_check_masquerade_rule() {
+    local int
+    if [ "${OUTGOINGS}" ] ; then
+        nat_parse_outgoings || return 1
+        for int in "${ints[@]}" ; do
+            "${IPTABLES_BASE}" -t nat -C POSTROUTING \
+                -s "$(_check_prefix)" -o "${int}" -j MASQUERADE 2> /dev/null || return 1
+        done
+    else
+        "${IPTABLES_BASE}" -t nat -C POSTROUTING \
+            -s "$(_check_prefix)" -j MASQUERADE 2> /dev/null
+    fi
+}
+
+_check_forward_rules() {
+    local int
+    if [ "${OUTGOINGS}" ] ; then
+        nat_parse_outgoings || return 1
+        for int in "${ints[@]}" ; do
+            "${IPTABLES_BASE}" -C FORWARD \
+                -i "${int}" -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2> /dev/null || return 1
+            "${IPTABLES_BASE}" -C FORWARD \
+                -i "${INTERFACE}" -o "${int}" -j ACCEPT 2> /dev/null || return 1
+        done
+    else
+        "${IPTABLES_BASE}" -C FORWARD \
+            -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2> /dev/null || return 1
+        "${IPTABLES_BASE}" -C FORWARD \
+            -i "${INTERFACE}" -j ACCEPT 2> /dev/null
+    fi
+}
+
+_check_ipv6_rules() {
+    local int
+    if [ "${OUTGOINGS}" ] ; then
+        nat_parse_outgoings || return 1
+        for int in "${ints[@]}" ; do
+            "${IP6TABLES_BASE}" -C FORWARD \
+                -i "${int}" -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2> /dev/null || return 1
+            "${IP6TABLES_BASE}" -C FORWARD \
+                -i "${INTERFACE}" -o "${int}" -j ACCEPT 2> /dev/null || return 1
+        done
+    else
+        "${IP6TABLES_BASE}" -C FORWARD \
+            -o "${INTERFACE}" -m conntrack --ctstate RELATED,ESTABLISHED -j ACCEPT 2> /dev/null || return 1
+        "${IP6TABLES_BASE}" -C FORWARD \
+            -i "${INTERFACE}" -j ACCEPT 2> /dev/null
+    fi
+}
+
+_check_sysctls() {
+    local i val
+    for i in ip_forward ip_dynaddr ; do
+        val="$(cat "${CHECK_SYSCTL_BASE}/${i}" 2>/dev/null)"
+        [ "${val}" = "1" ] || return 1
+    done
+}
+
+_check_interface_addr() {
+    "${CHECK_IP_BASE}" link show dev "${INTERFACE}" 2> /dev/null | grep -q '<[^>]*UP' \
+        && "${CHECK_IP_BASE}" addr show dev "${INTERFACE}" 2> /dev/null \
+            | grep -q " ${AP_ADDR}/${DHCP_PREFIX:-24} "
+}
+
+# check_run_audit audits every runtime item, reporting OK/FAIL per item.
+# Returns non-zero (after listing all failures) when any check fails.
+check_run_audit() {
+    local errors=0
+    local prefix
+    prefix=$(_check_prefix)
+
+    _check_item "MASQUERADE rule for ${prefix}" _check_masquerade_rule || errors=$((errors + 1))
+    _check_item "FORWARD rules for ${INTERFACE}" _check_forward_rules || errors=$((errors + 1))
+    if [ "${IPV6:-0}" = "1" ] ; then
+        _check_item "ip6tables FORWARD rules for ${INTERFACE}" _check_ipv6_rules || errors=$((errors + 1))
+    fi
+    _check_item "sysctls ip_forward/ip_dynaddr = 1" _check_sysctls || errors=$((errors + 1))
+    _check_item "${AP_ADDR}/${DHCP_PREFIX:-24} assigned to ${INTERFACE}, link UP" _check_interface_addr || errors=$((errors + 1))
+
+    if [ "${errors}" -ne 0 ] ; then
+        echo "[Error] Check failed with ${errors} failure(s)." >&2
+        return 1
+    fi
+}

--- a/tests/check_mode.bats
+++ b/tests/check_mode.bats
@@ -1,0 +1,121 @@
+#!/usr/bin/env bats
+
+# Tests for wlanstart.sh --check runtime state audit (issue #288)
+
+SCRIPT="${BATS_TEST_DIRNAME}/../wlanstart.sh"
+
+setup() {
+    export INTERFACE="wlan0"
+    export SUBNET="192.168.254.0"
+    export AP_ADDR="192.168.254.1"
+    export OUTGOINGS=""
+    export IPV6="0"
+}
+
+# Source the module with stubbed system tools; $1 = path to a stub dir
+# containing ip/iptables/ip6tables, plus a proc dir for sysctls.
+load_check() {
+    local stubdir="${BATS_TEST_TMPDIR}/stubs"
+    local procdir="${BATS_TEST_TMPDIR}/proc"
+    mkdir -p "${stubdir}" "${procdir}"
+    printf '#!/bin/bash\ncase "$1 $2" in "link show") echo "3: ${INTERFACE}: <BROADCAST,MULTICAST,UP,LOWER_UP> state UP" ;; "addr show") echo "    inet ${AP_ADDR}/${DHCP_PREFIX:-24} scope global ${INTERFACE}" ;; esac\nexit 0\n' > "${stubdir}/ip"
+    printf '#!/bin/bash\necho "[stub] iptables $*"\nexit 0\n' > "${stubdir}/iptables"
+    printf '#!/bin/bash\necho "[stub] ip6tables $*"\nexit 0\n' > "${stubdir}/ip6tables"
+    chmod +x "${stubdir}"/ip "${stubdir}"/iptables "${stubdir}"/ip6tables
+    # shellcheck source=../lib/sys/nat.sh
+    . "${BATS_TEST_DIRNAME}/../lib/sys/nat.sh"
+    # shellcheck source=../../lib/sys/check.sh
+    . "${BATS_TEST_DIRNAME}/../lib/sys/check.sh"
+    CHECK_IP_BASE="${stubdir}/ip"
+    IPTABLES_BASE="${stubdir}/iptables"
+    IP6TABLES_BASE="${stubdir}/ip6tables"
+    CHECK_SYSCTL_BASE="${procdir}"
+}
+
+@test "check_run_audit reports OK and exits 0 when all checks pass" {
+    load_check
+    echo 1 > "${CHECK_SYSCTL_BASE}/ip_forward"
+    echo 1 > "${CHECK_SYSCTL_BASE}/ip_dynaddr"
+    run check_run_audit
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"[OK]   MASQUERADE rule for 192.168.254.0/24"* ]]
+    [[ "$output" == *"[OK]   FORWARD rules for wlan0"* ]]
+    [[ "$output" == *"[OK]   sysctls ip_forward/ip_dynaddr = 1"* ]]
+    [[ "$output" != *"[FAIL]"* ]]
+}
+
+@test "check_run_audit lists every failure and exits non-zero" {
+    load_check
+    IPTABLES_BASE="${BATS_TEST_TMPDIR}/no-such-iptables"
+    rm -f "${CHECK_SYSCTL_BASE}/ip_forward" "${CHECK_SYSCTL_BASE}/ip_dynaddr"
+    run check_run_audit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[FAIL] MASQUERADE rule for 192.168.254.0/24"* ]]
+    [[ "$output" == *"[FAIL] FORWARD rules for wlan0"* ]]
+    [[ "$output" == *"[FAIL] sysctls ip_forward/ip_dynaddr = 1"* ]]
+    [[ "$output" == *"Check failed with 3 failure(s)."* ]]
+}
+
+@test "check skips ip6tables item when IPV6 not enabled" {
+    load_check
+    IPV6=0 run check_run_audit
+    [ "$status" -eq 1 ] || true
+    [[ "$output" != *"ip6tables FORWARD rules"* ]]
+}
+
+@test "check audits ip6tables item when IPV6=1" {
+    load_check
+    echo 1 > "${CHECK_SYSCTL_BASE}/ip_forward"
+    echo 1 > "${CHECK_SYSCTL_BASE}/ip_dynaddr"
+    IPV6=1 IP6TABLES_BASE="${BATS_TEST_TMPDIR}/no-such-ip6tables" run check_run_audit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[FAIL] ip6tables FORWARD rules for wlan0"* ]]
+}
+
+@test "check uses DHCP_PREFIX in reported prefix" {
+    load_check
+    DHCP_PREFIX=28
+    echo 1 > "${CHECK_SYSCTL_BASE}/ip_forward"
+    echo 1 > "${CHECK_SYSCTL_BASE}/ip_dynaddr"
+    run check_run_audit
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"MASQUERADE rule for 192.168.254.0/28"* ]]
+}
+
+@test "--check never mutates state" {
+    local stubdir="${BATS_TMPDIR}/check-mode-stubs"
+    mkdir -p "${stubdir}"
+    local tool
+    for tool in hostapd dnsmasq multirun ; do
+        printf '#!/bin/bash\necho "[Error] %s must not be called in check mode" >&2\nexit 99\n' "${tool}" > "${stubdir}/${tool}"
+        chmod +x "${stubdir}/${tool}"
+    done
+    # Mutating iptables/ip verbs fail loudly; only read-only ones pass.
+    printf '#!/bin/bash\ncase "$1" in -A|-D|-N|-I|add|del|flush|set) echo "[Error] mutation attempted" >&2; exit 99 ;; esac\nexit 1\n' > "${stubdir}/iptables"
+    cp "${stubdir}/iptables" "${stubdir}/ip6tables"
+    printf '#!/bin/bash\ncase "$1 $2" in "link set"|"addr add"|"addr del"|"addr flush") echo "[Error] mutation attempted" >&2; exit 99 ;; esac\nexit 1\n' > "${stubdir}/ip"
+    chmod +x "${stubdir}"/iptables "${stubdir}"/ip6tables "${stubdir}"/ip
+
+    run env -i PATH="${stubdir}:/usr/bin:/bin" HOME="${HOME}" \
+        INTERFACE=wlan0 SSID=x WPA_PASSPHRASE=supersecret \
+        "${SCRIPT}" --check
+    [ "$status" -eq 1 ]
+    [[ "$output" != *"mutation attempted"* ]]
+    [[ "$output" != *"must not be called"* ]]
+}
+
+@test "--check exits non-zero listing failures against live-ish stubs" {
+    run env -i PATH="${PATH}" HOME="${HOME}" \
+        INTERFACE=wlan0 SSID=x WPA_PASSPHRASE=supersecret \
+        "${SCRIPT}" --check
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[FAIL]"* ]]
+    [[ "$output" == *"Check failed with"* ]]
+}
+
+@test "-c alias behaves like --check" {
+    run env -i PATH="${PATH}" HOME="${HOME}" \
+        INTERFACE=wlan0 SSID=x WPA_PASSPHRASE=supersecret "${SCRIPT}" -c
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[FAIL]"* ]]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -52,9 +52,14 @@ trap handle_signal SIGINT SIGTERM SIGHUP
 # run every validator and print the generated hostapd.conf/dnsmasq.conf
 # to stdout instead of touching the system.
 VALIDATE_ONLY=0
+CHECK_ONLY=0
 case "${1:-}" in
     --validate|-t|--test)
         VALIDATE_ONLY=1
+        shift
+        ;;
+    --check|-c)
+        CHECK_ONLY=1
         shift
         ;;
     --version|-V)
@@ -70,12 +75,12 @@ case "${1:-}" in
     "")
         ;;
     *)
-        echo "[Error] Unknown option '${1}'. Usage: wlanstart.sh [--version|-V|--validate|-t|--test]" >&2
+        echo "[Error] Unknown option '${1}'. Usage: wlanstart.sh [--version|-V|--validate|-t|--test|--check|-c]" >&2
         exit 1
         ;;
 esac
 
-if [ "${VALIDATE_ONLY}" != "1" ] ; then
+if [ "${VALIDATE_ONLY}" != "1" ] && [ "${CHECK_ONLY}" != "1" ] ; then
     # Record container start time so healthcheck.sh can measure the grace
     # period from the actual start (not host uptime via /proc/uptime).
     date +%s > /run/hostap-started 2>/dev/null || true
@@ -162,6 +167,32 @@ run_validation_mode() {
     echo "=== /etc/dnsmasq.conf ==="
     printf '%s\n' "${dnsmasq}"
 }
+
+# Read-only runtime audit (--check, -c): resolve env the same way a normal
+# start does, then compare live system state against it per item. Never
+# mutates state; exits non-zero listing failures like validation mode.
+run_check_mode() {
+    local errors=0
+
+    if [ ! "${INTERFACE:-}" ] ; then
+        echo "[Error] An interface must be specified." >&2
+        return 1
+    fi
+
+    if ! DHCP_RANGE_COMPUTED=$(dhcp_compute_range) ; then
+        echo "[Error] Invalid DHCP_RANGE." >&2
+        return 1
+    fi
+    export DHCP_RANGE_COMPUTED
+
+    check_run_audit
+}
+
+if [ "${CHECK_ONLY}" = "1" ] ; then
+    require_module check
+    run_check_mode
+    exit $?
+fi
 
 if [ "${VALIDATE_ONLY}" = "1" ] ; then
     run_validation_mode


### PR DESCRIPTION
## Summary

Adds a read-only `wlanstart.sh --check` mode (alias `-c`) that audits the live system state against the resolved environment, reporting each item individually as OK/FAIL and exiting non-zero when anything is missing (issue #288).

## What is audited

- iptables `POSTROUTING MASQUERADE` rule for `${SUBNET}/${DHCP_PREFIX}` - per `OUTGOINGS` interface when set, generic otherwise
- iptables `FORWARD` rules for `${INTERFACE}`
- ip6tables `FORWARD` rules when `IPV6=1`
- sysctls `ip_forward` / `ip_dynaddr` = 1
- `${AP_ADDR}/${DHCP_PREFIX}` assigned to `${INTERFACE}` with link UP

## Design

- New sys-layer module `lib/sys/check.sh` with entry point `check_run_audit` and `_check_*` private helpers; only reads (`iptables -C`, sysctl file reads, `ip addr/link show`). Tool paths overridable via `IPTABLES_BASE`, `IP6TABLES_BASE`, `CHECK_IP_BASE`, `CHECK_SYSCTL_BASE`.
- Wired into the option case in `wlanstart.sh`; skips the privileged probe so every item reports individually instead of failing fast. Env resolution and DHCP range computation are reused so the audit sees exactly what a normal start would apply. Exits non-zero listing failures like validation mode.
- Never mutates state (enforced by a test that stubs all mutating verbs to fail loudly).

## Tests

- `tests/check_mode.bats`: 8 tests using existing stub patterns (`SYSCTL_BASE`-style proc dir, overridable tool paths), covering pass/fail aggregation, IPV6 gating, `DHCP_PREFIX` in reported prefix, no-mutation guarantee, `-c` alias.
- Full suite: 459 tests, 0 failures. `make layer-check` passes. shellcheck clean.

## Docs

- `docs/validation.md`: new "Runtime State Audit (--check)" section alongside dry-run validation.
- README: docs pointer mentions `--check`.

Closes #288
