### PR TITLE
feat: 802.11ax (HE) support via HE_ENABLED/HE_CAPAB

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,8 @@ docker run -d \
 | `HT_CAPAB` | No | 802.11n capabilities string (`ht_capab=` in hostapd.conf); requires `HT_ENABLED` | unset |
 | `VHT_ENABLED` | No | Enable 802.11ac Very High Throughput (`ieee80211ac=1`); requires 5 GHz (`HW_MODE=a`) | unset |
 | `VHT_CAPAB` | No | 802.11ac capabilities string (`vht_capab=` in hostapd.conf); requires `VHT_ENABLED` | unset |
+| `HE_ENABLED` | No | Enable 802.11ax High Efficiency (`ieee80211ax=1`); requires 5 GHz (`HW_MODE=a`); see [HE (802.11ax) tuning](docs/configuration.md#he-80211ax-tuning) | unset |
+| `HE_CAPAB` | No | 802.11ax capabilities string (`he_capab=` in hostapd.conf); requires `HE_ENABLED` | unset |
 | `HOSTAPD_EXTRA_OPTS` | No | Extra hostapd.conf lines, newline-separated, appended verbatim after all generated lines. Unvalidated: invalid values surface as hostapd config errors in logs (e.g. `"auth_algs=3\nbeacon_int=100"`) | unset |
 | `HEALTHCHECK_START_PERIOD` | No | Grace period (seconds) after container start during which the healthcheck always passes. Measured from the container's own recorded start time (`/run/hostap-started`), not host uptime; see [Health Check](docs/healthcheck.md) and [Script grace vs Docker start-period](docs/healthcheck.md#script-grace-vs-docker-start-period). Note: this only extends the script-side grace window - Docker's own `--start-period` stays baked at 15s in the image, so failures after the script grace but during slow bring-up (e.g. DFS CAC) count toward Docker's retries; override with `--health-start-period` or compose `start_period` | `15` |
 | `CTRL_INTERFACE` | No | Enable hostapd control interface (any non-empty value); allows `clients.sh` to list stations, see [Client Inspection](docs/operations.md#client-inspection-optional) | unset |

--- a/SPEC.md
+++ b/SPEC.md
@@ -31,7 +31,9 @@ It runs on Alpine Linux for minimal footprint.
 - Channel validation: channels are validated against the regulatory domain
   (`US`/`CA`/`MX`: 1-11, `JP`: 1-14, others: 1-13) and hardware mode.
 - Optional 802.11n (`HT_ENABLED`, `HT_CAPAB`) and 802.11ac (`VHT_ENABLED`,
-  `VHT_CAPAB`; requires `HW_MODE=a`) High Throughput tuning lines.
+`VHT_CAPAB`; requires `HW_MODE=a`) High Throughput tuning lines.
+- Optional 802.11ax (`HE_ENABLED`, `HE_CAPAB`; requires `HW_MODE=a`) High
+Efficiency tuning lines, mirroring the HT/VHT pattern.
 - An optional `DRIVER` override replaces the default nl80211 driver line
   (e.g. for Realtek adapters needing `rtl871xdrv`).
 - Optional hidden SSID (`HIDE_SSID=1`), client limit (`MAX_STATIONS`, `0` =

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -74,15 +74,15 @@ By default the AP runs without HE (802.11ax/Wi-Fi 6). To enable it:
 docker run ... \
   -e HW_MODE=a -e CHANNEL=36 \
   -e HE_ENABLED=1 \
-  -e HE_CAPAB="[MAX-MPDU-11454][SHORT-GI-80]" \
-  ...
+  -e HE_CAPAB="[HE80:[0x11ff:0xf]]" \
+   ...
 ```
 
 ### Notes
 
 - `HE_ENABLED=1` emits `ieee80211ax=1` and requires 5 GHz operation (`HW_MODE=a`), the same band rule as VHT; `HE_CAPAB` sets the optional `he_capab=` line.
 - Capabilities depend on what your WiFi adapter supports - check `iw list` output for an `HE capabilities` block before enabling. If there is no such block, the adapter cannot do 802.11ax and you must not set `HE_ENABLED=1`.
-- Common `he_capab` flags: `[MAX-MPDU-11454]`, `[SHORT-GI-80]`. See the hostapd `hostapd.conf` documentation for the full list.
+- `HE_CAPAB` is optional - `ieee80211ax=1` alone works with driver defaults. When set, `he_capab` uses band-specific syntax, e.g. `[HE80:[0x11ff:0xf]]` for 5 GHz (MAC capabilities in hex). See the hostapd `hostapd.conf` documentation for the full format.
 - `HE_CAPAB` values are passed through to hostapd unvalidated; invalid strings surface as hostapd config errors in `docker logs`.
 
 ## Transmit Power (optional)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -66,6 +66,25 @@ Interpretation:
 
 If hostapd rejects your capability string, it shows up as a config error in `docker logs rpi-hostap` on start.
 
+## HE (802.11ax) Tuning
+
+By default the AP runs without HE (802.11ax/Wi-Fi 6). To enable it:
+
+```bash
+docker run ... \
+  -e HW_MODE=a -e CHANNEL=36 \
+  -e HE_ENABLED=1 \
+  -e HE_CAPAB="[MAX-MPDU-11454][SHORT-GI-80]" \
+  ...
+```
+
+### Notes
+
+- `HE_ENABLED=1` emits `ieee80211ax=1` and requires 5 GHz operation (`HW_MODE=a`), the same band rule as VHT; `HE_CAPAB` sets the optional `he_capab=` line.
+- Capabilities depend on what your WiFi adapter supports - check `iw list` output for an `HE capabilities` block before enabling. If there is no such block, the adapter cannot do 802.11ax and you must not set `HE_ENABLED=1`.
+- Common `he_capab` flags: `[MAX-MPDU-11454]`, `[SHORT-GI-80]`. See the hostapd `hostapd.conf` documentation for the full list.
+- `HE_CAPAB` values are passed through to hostapd unvalidated; invalid strings surface as hostapd config errors in `docker logs`.
+
 ## Transmit Power (optional)
 
 Regulatory-constrained deployments (labs, embedded products) may need to cap the AP's EIRP. Set `TX_POWER` to a fixed transmit power in dBm, or `auto` to restore driver/regulatory automatic power control:

--- a/lib/core/channel.sh
+++ b/lib/core/channel.sh
@@ -98,6 +98,17 @@ channel_validate_vht() {
     return 0
 }
 
+# HE (802.11ax) requires 5 GHz operation, same band rules as VHT.
+# Reads HE_ENABLED and HW_MODE from the environment.
+channel_validate_he() {
+    HW_MODE="$(printf '%s' "${HW_MODE:-}" | tr '[:upper:]' '[:lower:]')"
+    if [ -n "${HE_ENABLED:-}" ] && [ "${HW_MODE}" != "a" ] ; then
+        echo "[Error] HE_ENABLED requires HW_MODE=a (5 GHz)." >&2
+        return 1
+    fi
+    return 0
+}
+
 # Strict variant used by validation mode: unknown HW_MODE is an error.
 channel_validate_strict() {
     if ! channel_validate ; then

--- a/lib/core/hostapd_conf.sh
+++ b/lib/core/hostapd_conf.sh
@@ -38,6 +38,11 @@ ${HT_CAPAB+"ht_capab=${HT_CAPAB}"}
 
 ${VHT_ENABLED+"ieee80211ac=1"}
 ${VHT_CAPAB+"vht_capab=${VHT_CAPAB}"}
+
+# Activate channel selection for HE High Efficiency (802.11ax)
+
+${HE_ENABLED+"ieee80211ax=1"}
+${HE_CAPAB+"he_capab=${HE_CAPAB}"}
 EOF
 
     extra_opts_compute_lines

--- a/tests/channel_validation.bats
+++ b/tests/channel_validation.bats
@@ -570,3 +570,50 @@ setup() {
     run channel_validate_vht
     [ "$status" -eq 0 ]
 }
+
+# --- HE_ENABLED requires HW_MODE=a (mirrors VHT rules) ---
+
+@test "HE_ENABLED set with default HW_MODE fails" {
+    unset HW_MODE
+    env_resolve_config_env
+    HE_ENABLED="1"
+    run channel_validate_he
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"[Error] HE_ENABLED requires HW_MODE=a (5 GHz)."* ]]
+}
+
+@test "HE_ENABLED set with HW_MODE=g fails" {
+    HW_MODE="g"
+    HE_ENABLED="1"
+    run channel_validate_he
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Error"* ]]
+}
+
+@test "HE_ENABLED set with HW_MODE=b fails" {
+    HW_MODE="b"
+    HE_ENABLED="1"
+    run channel_validate_he
+    [ "$status" -eq 1 ]
+}
+
+@test "HE_ENABLED set with HW_MODE=a passes" {
+    HW_MODE="a"
+    HE_ENABLED="1"
+    run channel_validate_he
+    [ "$status" -eq 0 ]
+}
+
+@test "HE_ENABLED set with uppercase HW_MODE=A passes" {
+    HW_MODE="A"
+    HE_ENABLED="1"
+    run channel_validate_he
+    [ "$status" -eq 0 ]
+}
+
+@test "HE_ENABLED unset with HW_MODE=g passes" {
+    HW_MODE="g"
+    unset HE_ENABLED
+    run channel_validate_he
+    [ "$status" -eq 0 ]
+}

--- a/tests/config_emission.bats
+++ b/tests/config_emission.bats
@@ -48,6 +48,7 @@ wmm_enabled=1
 
 
 
+
 # Activate channel selection for HE High Efficiency (802.11ax)
 
 

--- a/tests/config_emission.bats
+++ b/tests/config_emission.bats
@@ -48,6 +48,10 @@ wmm_enabled=1
 
 
 
+# Activate channel selection for HE High Efficiency (802.11ax)
+
+
+
 CONF
 }
 
@@ -62,6 +66,24 @@ CONF
     [[ "$output" == *"ht_capab=[SHORT-GI-20]"* ]]
     [[ "$output" == *"max_num_sta=10"* ]]
     [[ "$output" == *"ap_isolate=1"* ]]
+}
+
+@test "hostapd_conf_emit emits ieee80211ax and he_capab when HE is enabled" {
+    load_modules
+    export HW_MODE=a CHANNEL=36 HE_ENABLED=1 HE_CAPAB="[MAX-MPDU-11454][SHORT-GI-80]"
+    run hostapd_conf_emit
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"ieee80211ax=1"* ]]
+    [[ "$output" == *"he_capab=[MAX-MPDU-11454][SHORT-GI-80]"* ]]
+}
+
+@test "hostapd_conf_emit omits HE lines when unset" {
+    load_modules
+    export HW_MODE=g
+    run hostapd_conf_emit
+    [ "$status" -eq 0 ]
+    [[ "$output" != *"ieee80211ax"* ]]
+    [[ "$output" != *"he_capab"* ]]
 }
 
 @test "hostapd_conf_emit fails on invalid WPA_VERSION" {

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -134,6 +134,7 @@ run_validation_mode() {
 
     channel_validate_strict || errors=$((errors + 1))
     channel_validate_vht || errors=$((errors + 1))
+    channel_validate_he || errors=$((errors + 1))
 
     validation_check_ipv4_param SUBNET "${SUBNET}" || errors=$((errors + 1))
     validation_check_ipv4_param AP_ADDR "${AP_ADDR}" || errors=$((errors + 1))
@@ -221,6 +222,9 @@ fi
 check_interrupted
 
 if ! channel_validate_vht ; then
+    exit 1
+fi
+if ! channel_validate_he ; then
     exit 1
 fi
 if ! radio_validate_tx_power ; then


### PR DESCRIPTION
## Summary

Adds 802.11ax (Wi-Fi 6 / HE) support following the existing HT/VHT precedent exactly.

- New env vars `HE_ENABLED` and `HE_CAPAB`, documented in the README env table and SPEC.md §2.1.
- `lib/core/hostapd_conf.sh` emits `ieee80211ax=1` / `he_capab=${HE_CAPAB}` guarded like the VHT equivalents.
- New `channel_validate_he` in `lib/core/channel.sh` mirrors `channel_validate_vht`: requires `HW_MODE=a` (5 GHz), case-normalized. Wired into both wlanstart.sh validation paths (normal start and `--validate`).
- Bats tests mirroring the VHT cases in `config_emission.bats` and `channel_validation.bats`.
- New "HE (802.11ax) Tuning" section in docs/configuration.md.

## Acceptance criteria

- [x] `HE_ENABLED=1` emits `ieee80211ax=1`; `HE_CAPAB` emits `he_capab=...`
- [x] Band validation consistent with VHT rules and covered by tests
- [x] Documented in README, docs/configuration.md and SPEC.md

## Testing

- Full bats suite: 466 passing, 0 failures
- `make layer-check`: OK (no forbidden commands in lib/core/)
- shellcheck clean

Closes #287
