### PR TITLE
feat: clients.sh leases subcommand showing dnsmasq DHCP leases

### DIFF
--- a/clients.sh
+++ b/clients.sh
@@ -73,20 +73,21 @@ _clients_lease_file_require() {
     fi
 }
 
-# Print raw dnsmasq lease lines: expires_remaining mac ip hostname clientid
+# Print raw dnsmasq lease lines: expiry_epoch mac ip hostname clientid
 clients_leases_show() {
     _clients_lease_file_require
     cat "$(_clients_lease_file)"
 }
 
 # Emit a JSON array of {mac, ip, hostname, expires} objects parsed from the
-# dnsmasq lease file (fields: expires_remaining mac ip hostname clientid).
+# dnsmasq lease file (fields: expiry epoch seconds, mac, ip, hostname, clientid).
 clients_emit_leases_json() {
     local line mac ip hostname expires sep=""
     _clients_lease_file_require
     printf '['
     while IFS= read -r line ; do
         [[ -z "${line}" || "${line}" == \#* ]] && continue
+        [[ "${line}" == duid\ * ]] && continue
         read -r expires mac ip hostname _ <<<"${line}"
         [[ -z "${mac:-}" ]] && continue
         printf '%s{"mac":"%s","ip":"%s","hostname":"%s","expires":"%s"}' \
@@ -99,8 +100,6 @@ clients_emit_leases_json() {
     done < <(cat "$(_clients_lease_file)")
     printf ']\n'
 }
-
-
 
 # (same parsing pattern as clients_emit_json, which treats non-key=value lines as
 # station blocks starting with the MAC).

--- a/clients.sh
+++ b/clients.sh
@@ -5,6 +5,7 @@
 #   clients.sh --json       list stations as a JSON array
 #   clients.sh count        print the number of associated stations
 #   clients.sh deauth <mac> deauthenticate a station
+#   clients.sh leases       show dnsmasq DHCP leases
 # Requires CTRL_INTERFACE=1 so hostapd.conf exposes ctrl_interface.
 set -euo pipefail
 
@@ -15,7 +16,7 @@ source "${SCRIPT_DIR}/lib/bootstrap.sh"
 require_module client_env
 
 clients_show_usage() {
-    echo "Usage: clients.sh [--json] [count] [deauth <mac>]" >&2
+    echo "Usage: clients.sh [--json] [count] [deauth <mac>] [leases [--json]]" >&2
 }
 
 # Emit a JSON array of station objects parsed from hostapd_cli all_sta output.
@@ -57,7 +58,50 @@ clients_emit_json() {
     printf ']\n'
 }
 
-# Count associated stations: number of MAC-address lines in all_sta output
+# Resolve the dnsmasq lease file path (overridable for tests).
+_clients_lease_file() {
+    echo "${DHCP_LEASE_FILE:-/tmp/dnsmasq.leases}"
+}
+
+# Fail with a canonical error when the lease file is absent.
+_clients_lease_file_require() {
+    local file
+    file=$(_clients_lease_file)
+    if [[ ! -f "${file}" ]] ; then
+        echo "[Error] Lease file not found at ${file}." >&2
+        exit 1
+    fi
+}
+
+# Print raw dnsmasq lease lines: expires_remaining mac ip hostname clientid
+clients_leases_show() {
+    _clients_lease_file_require
+    cat "$(_clients_lease_file)"
+}
+
+# Emit a JSON array of {mac, ip, hostname, expires} objects parsed from the
+# dnsmasq lease file (fields: expires_remaining mac ip hostname clientid).
+clients_emit_leases_json() {
+    local line mac ip hostname expires sep=""
+    _clients_lease_file_require
+    printf '['
+    while IFS= read -r line ; do
+        [[ -z "${line}" || "${line}" == \#* ]] && continue
+        read -r expires mac ip hostname _ <<<"${line}"
+        [[ -z "${mac:-}" ]] && continue
+        printf '%s{"mac":"%s","ip":"%s","hostname":"%s","expires":"%s"}' \
+            "${sep}" \
+            "$(clients_json_escape "${mac}")" \
+            "$(clients_json_escape "${ip}")" \
+            "$(clients_json_escape "${hostname}")" \
+            "$(clients_json_escape "${expires}")"
+        sep=","
+    done < <(cat "$(_clients_lease_file)")
+    printf ']\n'
+}
+
+
+
 # (same parsing pattern as clients_emit_json, which treats non-key=value lines as
 # station blocks starting with the MAC).
 clients_count_stations() {
@@ -79,6 +123,18 @@ case "${CMD}" in
         ;;
     count)
         clients_count_stations
+        ;;
+    leases)
+        shift
+        if [[ "${1:-}" == "--json" ]] ; then
+            [[ $# -eq 1 ]] || { clients_show_usage ; exit 1 ; }
+            clients_emit_leases_json
+        elif [[ $# -eq 0 ]] ; then
+            clients_leases_show
+        else
+            clients_show_usage
+            exit 1
+        fi
         ;;
     deauth)
         if [[ $# -ne 2 ]] ; then

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -46,7 +46,7 @@ To inspect current dnsmasq DHCP leases, use the `leases` subcommand:
 docker exec rpi-hostap clients.sh leases
 ```
 
-It prints the raw lease lines in dnsmasq format (`expires_remaining mac ip hostname clientid`). The lease file path defaults to `/tmp/dnsmasq.leases` (emitted as `dhcp-leasefile` in the generated config) and can be overridden with `DHCP_LEASE_FILE`. If the lease file is absent, an error is reported.
+It prints the raw lease lines in dnsmasq format (`expiry_epoch mac ip hostname clientid`). The lease file path defaults to `/tmp/dnsmasq.leases` (emitted as `dhcp-leasefile` in the generated config) and can be overridden with `DHCP_LEASE_FILE`. If the lease file is absent, an error is reported.
 
 For machine-readable output, pass `--json`:
 
@@ -57,7 +57,7 @@ docker exec rpi-hostap clients.sh leases --json
 Example output:
 
 ```json
-[{"mac":"aa:bb:cc:dd:ee:ff","ip":"192.168.254.100","hostname":"laptop","expires":"3600"}]
+[{"mac":"aa:bb:cc:dd:ee:ff","ip":"192.168.254.100","hostname":"laptop","expires":"1756200000"}]
 ```
 
 To deauthenticate a specific station, pass its MAC address as a `deauth` subcommand:

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -38,6 +38,28 @@ docker exec rpi-hostap clients.sh count
 
 It prints a single integer (the number of station MAC blocks in `hostapd_cli all_sta` output), suitable for scripting and monitoring.
 
+### DHCP leases
+
+To inspect current dnsmasq DHCP leases, use the `leases` subcommand:
+
+```bash
+docker exec rpi-hostap clients.sh leases
+```
+
+It prints the raw lease lines in dnsmasq format (`expires_remaining mac ip hostname clientid`). The lease file path defaults to `/tmp/dnsmasq.leases` (emitted as `dhcp-leasefile` in the generated config) and can be overridden with `DHCP_LEASE_FILE`. If the lease file is absent, an error is reported.
+
+For machine-readable output, pass `--json`:
+
+```bash
+docker exec rpi-hostap clients.sh leases --json
+```
+
+Example output:
+
+```json
+[{"mac":"aa:bb:cc:dd:ee:ff","ip":"192.168.254.100","hostname":"laptop","expires":"3600"}]
+```
+
 To deauthenticate a specific station, pass its MAC address as a `deauth` subcommand:
 
 ```bash

--- a/lib/core/dnsmasq_conf.sh
+++ b/lib/core/dnsmasq_conf.sh
@@ -21,6 +21,7 @@ dnsmasq_conf_emit() {
 interface=${INTERFACE}
 bind-dynamic
 dhcp-authoritative
+dhcp-leasefile=${DHCP_LEASE_FILE:-/tmp/dnsmasq.leases}
 dhcp-range=${dhcp_range}
 dhcp-option=option:router,${AP_ADDR}
 dhcp-option=option:dns-server,${PRI_DNS},${SEC_DNS}

--- a/tests/clients.bats
+++ b/tests/clients.bats
@@ -183,6 +183,60 @@ EOF
     [ "$output" = "0" ]
 }
 
+@test "leases prints dnsmasq lease lines" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    export DHCP_LEASE_FILE="${BATS_TEST_TMPDIR}/dnsmasq.leases"
+    printf '1756000000 aa:bb:cc:dd:ee:ff 192.168.254.100 laptop 01:aa:bb:cc:dd:ee:ff\n' > "${DHCP_LEASE_FILE}"
+    run "${BATS_TEST_DIRNAME}/../clients.sh" leases
+    [ "$status" -eq 0 ]
+    [ "${lines[0]}" = "1756000000 aa:bb:cc:dd:ee:ff 192.168.254.100 laptop 01:aa:bb:cc:dd:ee:ff" ]
+}
+
+@test "leases --json emits valid JSON array of lease objects" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    export DHCP_LEASE_FILE="${BATS_TEST_TMPDIR}/dnsmasq.leases"
+    cat > "${DHCP_LEASE_FILE}" <<'LEASES'
+1756000000 aa:bb:cc:dd:ee:ff 192.168.254.100 laptop 01:aa:bb:cc:dd:ee:ff
+1756000100 11:22:33:44:55:66 192.168.254.101 phone *
+LEASES
+    run "${BATS_TEST_DIRNAME}/../clients.sh" leases --json
+    [ "$status" -eq 0 ]
+    [ "$(printf '%s' "$output" | python3 -c 'import json,sys; d=json.load(sys.stdin); print(len(d), d[0]["mac"], d[0]["ip"], d[1]["hostname"], d[1]["expires"])')" = "2 aa:bb:cc:dd:ee:ff 192.168.254.100 phone 1756000100" ]
+}
+
+@test "leases errors gracefully when lease file is absent" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    export DHCP_LEASE_FILE="${BATS_TEST_TMPDIR}/missing.leases"
+    run "${BATS_TEST_DIRNAME}/../clients.sh" leases
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"[Error] Lease file not found at ${DHCP_LEASE_FILE}."* ]]
+}
+
+@test "leases --json also errors gracefully when lease file is absent" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    export DHCP_LEASE_FILE="${BATS_TEST_TMPDIR}/missing.leases"
+    run "${BATS_TEST_DIRNAME}/../clients.sh" leases --json
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"[Error] Lease file not found at ${DHCP_LEASE_FILE}."* ]]
+}
+
+@test "leases with unexpected extra argument prints usage and exits non-zero" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    run "${BATS_TEST_DIRNAME}/../clients.sh" leases bogus
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Usage: clients.sh"* ]]
+}
+
 @test "count does not count key=value lines as stations" {
     export INTERFACE=wlan0
     mkdir -p "${BATS_TEST_TMPDIR}/hostapd"

--- a/tests/config_emission.bats
+++ b/tests/config_emission.bats
@@ -102,6 +102,7 @@ CONF
 interface=wlan0
 bind-dynamic
 dhcp-authoritative
+dhcp-leasefile=/tmp/dnsmasq.leases
 dhcp-range=192.168.254.100,192.168.254.200,255.255.255.0,12h
 dhcp-option=option:router,192.168.254.1
 dhcp-option=option:dns-server,8.8.8.8,8.8.4.4


### PR DESCRIPTION
## Summary

Adds a `leases` subcommand to `clients.sh` that shows current dnsmasq DHCP leases.

- `lib/core/dnsmasq_conf.sh` now emits `dhcp-leasefile=${DHCP_LEASE_FILE:-/tmp/dnsmasq.leases}` so the lease file location is deterministic and overridable.
- `clients.sh leases` prints raw lease lines in dnsmasq format (`expires_remaining mac ip hostname clientid`).
- `clients.sh leases --json` emits a JSON array of `{mac, ip, hostname, expires}` objects using `clients_json_escape`.
- Graceful `[Error] Lease file not found at <path>.` when the lease file is absent.
- Reuses existing `client_env_require_interface` / ctrl-interface plumbing in `clients.sh`.
- Docs: new "DHCP leases" subsection under Client Inspection in `docs/operations.md`.

## Tests

- tests/clients.bats: 6 new cases (leases output, leases --json valid array, missing-file error for both modes, extra-arg usage rejection).
- tests/config_emission.bats updated for the new `dhcp-leasefile` line.

Full suite: 472/472 pass; `make layer-check` OK.

Closes #286
