### PR TITLE
feat: fail healthcheck when HEALTHCHECK_MIN_STATIONS set but control interface missing

### DIFF
--- a/docs/healthcheck.md
+++ b/docs/healthcheck.md
@@ -73,7 +73,7 @@ An AP that beacons and reports `state=ENABLED` may still accept no associations.
 docker run ... -e CTRL_INTERFACE=1 -e HEALTHCHECK_MIN_STATIONS=1 ...
 ```
 
-When enabled, after all other checks (and only once the grace period has elapsed), `healthcheck.sh` counts associated stations via `hostapd_cli all_sta` - the same count printed by [`clients.sh count`](operations.md#client-inspection-optional) - and fails with a message naming the expected vs actual count if fewer than `N` stations are connected, marking the container `unhealthy`. The check is skipped when the control interface socket directory does not exist.
+When enabled, after all other checks (and only once the grace period has elapsed), `healthcheck.sh` counts associated stations via `hostapd_cli all_sta` - the same count printed by [`clients.sh count`](operations.md#client-inspection-optional) - and fails with a message naming the expected vs actual count if fewer than `N` stations are connected, marking the container `unhealthy`. If the control interface socket directory does not exist, the check fails as well: an explicit station floor cannot be verified without it (see issue #283). The check is silently disabled only when `HEALTHCHECK_MIN_STATIONS` is set to a non-numeric value.
 
 **DFS/CAC caveat**: the same [DFS](https://en.wikipedia.org/wiki/Dynamic_frequency_selection) caveat as the deep check applies here - on radar channels stations cannot join until beaconing starts after Channel Availability Check (CAC), which can take 60s+. Raise `HEALTHCHECK_START_PERIOD` accordingly or the min-stations check will fail during CAC even on a healthy AP.
 

--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -95,7 +95,10 @@ MIN_STATIONS="${HEALTHCHECK_MIN_STATIONS-}"
 if [[ -n "${MIN_STATIONS}" ]]; then
     if ! [[ "${MIN_STATIONS}" =~ ^[0-9]+$ ]]; then
         echo "[Warning] Invalid HEALTHCHECK_MIN_STATIONS '${MIN_STATIONS}', disabling check" >&2
-    elif client_env_resolve_ctrl_iface_dir && [[ -d "${CTRL_IFACE_DIR}" ]]; then
+    elif ! client_env_resolve_ctrl_iface_dir || [[ ! -d "${CTRL_IFACE_DIR}" ]] ; then
+        echo "[Error] CTRL_IFACE_DIR '${CTRL_IFACE_DIR}' missing; cannot count stations" >&2
+        exit 1
+    else
         STATION_COUNT="$(hostapd_cli -p "${CTRL_IFACE_DIR}" -i "${INTERFACE}" all_sta 2>/dev/null \
             | grep -cE '^([0-9a-fA-F]{2}:){5}' || true)"
         if (( STATION_COUNT < MIN_STATIONS )); then

--- a/tests/healthcheck.bats
+++ b/tests/healthcheck.bats
@@ -313,12 +313,13 @@ EOF
     [[ "$output" == *"got 1"* ]]
 }
 
-@test "min-stations is skipped when control interface dir does not exist" {
+@test "min-stations fails when control interface dir does not exist (issue #283)" {
     export HEALTHCHECK_MIN_STATIONS=1
     mock_bin pidof 'exit 0'
     mock_bin ip 'if [ "$1" = "link" ]; then echo "state UP"; fi; exit 0'
     run env CTRL_IFACE_DIR="$BATS_TEST_TMPDIR/no-such-dir" ./healthcheck.sh
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"cannot count stations"* ]]
 }
 
 @test "invalid HEALTHCHECK_MIN_STATIONS warns and disables the check" {


### PR DESCRIPTION
When `HEALTHCHECK_MIN_STATIONS` is set but the control interface socket directory is missing, the healthcheck previously passed silently. Now it fails with `[Error] CTRL_IFACE_DIR '...' missing; cannot count stations`, matching the intent of an explicit station floor.

- Updated existing test to expect failure + message; docs/healthcheck.md documents the fail behavior

Closes #283
