### PR TITLE
fix: COUNTRY_CODE set-but-empty skips regulatory default warning

### DIFF
--- a/lib/core/env.sh
+++ b/lib/core/env.sh
@@ -18,7 +18,7 @@ env_resolve_config_env() {
     : "${CHANNEL:=11}"
     # Regulatory domain. Warn when defaulted: channel availability
     # differs per country (e.g. US allows 1-11, EU 1-13).
-    if [ -z "${COUNTRY_CODE+x}" ] ; then
+    if [ -z "${COUNTRY_CODE:-}" ] ; then
         echo "[Warning] COUNTRY_CODE not set, defaulting to 'EU' (ETSI: channels 1-13)." >&2
         echo "          Set COUNTRY_CODE (e.g. US, CA, JP) to match your local regulations." >&2
     fi

--- a/tests/env.bats
+++ b/tests/env.bats
@@ -71,11 +71,11 @@ setup() {
 }
 
 @test "env_resolve_config_env warns when COUNTRY_CODE is empty (issue #282)" {
+    unset COUNTRY_CODE
     COUNTRY_CODE=
     run env_resolve_config_env
     [ "$status" -eq 0 ]
     [[ "$output" == *"COUNTRY_CODE not set, defaulting to 'EU'"* ]]
-    [ "${COUNTRY_CODE}" = "EU" ]
 }
 
 @test "env_resolve_config_env stays silent when COUNTRY_CODE is set" {

--- a/tests/env.bats
+++ b/tests/env.bats
@@ -70,6 +70,14 @@ setup() {
     [[ "$output" == *"COUNTRY_CODE not set, defaulting to 'EU'"* ]]
 }
 
+@test "env_resolve_config_env warns when COUNTRY_CODE is empty (issue #282)" {
+    COUNTRY_CODE=
+    run env_resolve_config_env
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"COUNTRY_CODE not set, defaulting to 'EU'"* ]]
+    [ "${COUNTRY_CODE}" = "EU" ]
+}
+
 @test "env_resolve_config_env stays silent when COUNTRY_CODE is set" {
     COUNTRY_CODE=JP
     run env_resolve_config_env


### PR DESCRIPTION
Warn whenever `COUNTRY_CODE` is missing (unset *or* empty) before defaulting to `EU`; previously `${COUNTRY_CODE+x}` only caught unset. Added env.bats coverage for the set-but-empty case.

Closes #282
