### PR TITLE
fix: clients.sh reports error when hostapd_cli fails

### DIFF
--- a/clients.sh
+++ b/clients.sh
@@ -19,6 +19,16 @@ clients_show_usage() {
     echo "Usage: clients.sh [--json] [count] [deauth <mac>] [leases [--json]]" >&2
 }
 
+# Fetch all_sta output from hostapd_cli; exit non-zero on failure.
+clients_fetch_all_sta() {
+    local out
+    out="$(hostapd_cli -p "${CTRL_IFACE_DIR}" -i "${INTERFACE}" all_sta)" || {
+        echo "[Error] hostapd_cli failed; is CTRL_INTERFACE enabled?" >&2
+        return 1
+    }
+    printf '%s' "${out}"
+}
+
 # Emit a JSON array of station objects parsed from hostapd_cli all_sta output.
 # Blocks start with the station MAC line, followed by key=value lines. Only a
 # fixed set of well-known fields (aid, signal, connected_time) are exposed as
@@ -31,7 +41,8 @@ clients_json_escape() {
 }
 
 clients_emit_json() {
-    local line key value in_obj=0 sep=""
+    local line key value in_obj=0 sep="" all_sta
+    all_sta="$(clients_fetch_all_sta)" || return 1
     printf '['
     while IFS= read -r line ; do
         if [[ -z "${line}" ]] ; then
@@ -53,7 +64,7 @@ clients_emit_json() {
                     ;;
             esac
         fi
-    done < <(hostapd_cli -p "${CTRL_IFACE_DIR}" -i "${INTERFACE}" all_sta)
+    done <<< "${all_sta}"
     [[ ${in_obj} -eq 1 ]] && printf '}'
     printf ']\n'
 }
@@ -104,8 +115,9 @@ clients_emit_leases_json() {
 # (same parsing pattern as clients_emit_json, which treats non-key=value lines as
 # station blocks starting with the MAC).
 clients_count_stations() {
-    hostapd_cli -p "${CTRL_IFACE_DIR}" -i "${INTERFACE}" all_sta \
-        | grep -cE '^([0-9a-fA-F]{2}:){5}' || true
+    local out
+    out="$(clients_fetch_all_sta)" || return 1
+    echo "${out}" | grep -cE '^([0-9a-fA-F]{2}:){5}' || true
 }
 
 client_env_require_interface

--- a/tests/clients.bats
+++ b/tests/clients.bats
@@ -38,6 +38,34 @@ EOF
     [[ "$output" == *"stub hostapd_cli: -p ${CTRL_IFACE_DIR} -i wlan0 all_sta"* ]]
 }
 
+@test "--json exits non-zero when hostapd_cli fails (issue #281)" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    cat > "${BATS_TEST_TMPDIR}/hostapd_cli" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/hostapd_cli"
+    run "${BATS_TEST_DIRNAME}/../clients.sh" --json
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"hostapd_cli failed"* ]]
+}
+
+@test "count exits non-zero when hostapd_cli fails (issue #281)" {
+    export INTERFACE=wlan0
+    mkdir -p "${BATS_TEST_TMPDIR}/hostapd"
+    export CTRL_IFACE_DIR="${BATS_TEST_TMPDIR}/hostapd"
+    cat > "${BATS_TEST_TMPDIR}/hostapd_cli" <<'EOF'
+#!/bin/bash
+exit 1
+EOF
+    chmod +x "${BATS_TEST_TMPDIR}/hostapd_cli"
+    run "${BATS_TEST_DIRNAME}/../clients.sh" count
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"hostapd_cli failed"* ]]
+}
+
 @test "INTERFACE unset fails before control interface check" {
     run "${BATS_TEST_DIRNAME}/../clients.sh"
     [ "$status" -eq 1 ]


### PR DESCRIPTION
Previously `clients.sh --json` and `clients.sh count` reported an empty station list when `hostapd_cli` failed (missing socket, hostapd dead). Now both subcommands exit non-zero with `[Error] hostapd_cli failed; is CTRL_INTERFACE enabled?` instead of silently reporting zero stations.

- Added `clients_fetch_all_sta` helper that checks exit status
- Updated `clients_emit_json` and `clients_count_stations` to use it
- Added bats tests for both subcommands when hostapd_cli fails

Closes #281
