### PR TITLE
fix: deep healthcheck now honors CTRL_IFACE_DIR

### DIFF
--- a/healthcheck.sh
+++ b/healthcheck.sh
@@ -79,7 +79,8 @@ if [[ -n "${HEALTHCHECK_DEEP:-}" ]]; then
         echo "HEALTHCHECK_DEEP requires INTERFACE to be set" >&2
         exit 1
     fi
-    HOSTAPD_STATUS="$(hostapd_cli -p /var/run/hostapd -i "${INTERFACE}" status 2>/dev/null || true)"
+    client_env_resolve_ctrl_iface_dir
+    HOSTAPD_STATUS="$(hostapd_cli -p "${CTRL_IFACE_DIR}" -i "${INTERFACE}" status 2>/dev/null || true)"
     if ! echo "${HOSTAPD_STATUS}" | grep -q "^state=ENABLED"; then
         echo "hostapd is not in ENABLED state" >&2
         exit 1

--- a/tests/healthcheck.bats
+++ b/tests/healthcheck.bats
@@ -252,6 +252,17 @@ EOF
     [[ "$output" == *"HEALTHCHECK_DEEP requires INTERFACE to be set"* ]]
 }
 
+@test "deep check honors custom CTRL_IFACE_DIR (issue #280)" {
+    export HEALTHCHECK_DEEP=1
+    export CTRL_IFACE_DIR="$BATS_TEST_TMPDIR/custom-hostapd"
+    mkdir -p "${CTRL_IFACE_DIR}"
+    mock_bin pidof 'exit 0'
+    mock_bin ip 'if [ "$1" = "link" ]; then echo "state UP"; fi; exit 0'
+    mock_bin hostapd_cli 'echo "state=ENABLED"; echo "ssid=raspberry"'
+    run ./healthcheck.sh
+    [ "$status" -eq 0 ]
+}
+
 @test "deep check is skipped by default (no HEALTHCHECK_DEEP)" {
     mock_bin pidof 'exit 0'
     mock_bin ip 'if [ "$1" = "link" ]; then echo "state UP"; fi; exit 0'


### PR DESCRIPTION
The deep healthcheck (`HEALTHCHECK_DEEP`) hardcoded `-p /var/run/hostapd` for the `hostapd_cli` call, ignoring any custom `CTRL_IFACE_DIR`. Now it resolves the directory via `client_env_resolve_ctrl_iface_dir` before the deep check, matching the MIN_STATIONS branch behavior.

- Added `client_env_resolve_ctrl_iface_dir` call before the deep check
- Added bats test covering deep check with custom CTRL_IFACE_DIR

Closes #280
