### PR TITLE
fix: check nat_apply_rules/ipv6_apply_rules exit status

### DIFF
--- a/tests/ipv6.bats
+++ b/tests/ipv6.bats
@@ -113,3 +113,9 @@ setup() {
     [ "$status" -eq 0 ]
     [[ "${output}" == *"[Warning] Cannot set net.ipv6.conf.all.forwarding"* ]]
 }
+
+@test "ipv6_apply_rules returns non-zero when ip6tables fails (issue #279)" {
+    ip6tables() { return 1; }
+    run ipv6_apply_rules
+    [ "$status" -eq 1 ]
+}

--- a/tests/nat.bats
+++ b/tests/nat.bats
@@ -187,3 +187,9 @@ setup() {
     [ "$status" -eq 0 ]
     [[ "${output}" == *"[Warning] Cannot set ip_dynaddr"* ]]
 }
+
+@test "nat_apply_rules returns non-zero when iptables fails (issue #279)" {
+    iptables() { return 1; }
+    run nat_apply_rules
+    [ "$status" -eq 1 ]
+}

--- a/wlanstart.sh
+++ b/wlanstart.sh
@@ -267,14 +267,14 @@ check_interrupted
 nat_set_sysctls ip_dynaddr ip_forward
 nat_show_sysctls ip_dynaddr ip_forward
 
-nat_apply_rules
+nat_apply_rules || { cleanup ; exit 1 ; }
 
 # Optional IPv6 support (off by default, enable with IPV6=1)
 if [ "${IPV6:-0}" = "1" ] ; then
     echo "Enabling IPv6 forwarding..."
     ipv6_enable_forwarding
     echo "Setting ip6tables rules for outgoing traffics..."
-    ipv6_apply_rules
+    ipv6_apply_rules || { cleanup ; exit 1 ; }
 fi
 
 # Modules can register extra post-setup hooks without editing this file (#241).


### PR DESCRIPTION
Previously `nat_apply_rules` and `ipv6_apply_rules` failures during startup were silently ignored, allowing the AP to start without NAT. Now both calls check exit status and run `cleanup; exit 1` on failure, symmetric with post_setup.

- Added `|| { cleanup ; exit 1 ; }` after both calls in wlanstart.sh
- Added bats tests verifying non-zero return on iptables/ip6tables failure

Closes #279
