### PR TITLE
fix: MAC_FILTER=2 denylist emits inverted macaddr_acl

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -110,7 +110,7 @@ docker run ... \
 MAC filtering is **off by default**; behavior is unchanged unless you set `MAC_FILTER`. When enabled:
 
 - `MAC_FILTER=1` (allowlist): only MACs listed in the file can associate (`macaddr_acl=1` + `accept_mac_file=`).
-- `MAC_FILTER=2` (denylist): listed MACs are rejected (`macaddr_acl=1` + `deny_mac_file=`).
+- `MAC_FILTER=2` (denylist): listed MACs are rejected (`macaddr_acl=0` + `deny_mac_file=`).
 - Startup fails with an error if the filter is enabled without `MAC_ACL_FILE`, and warns if the file is missing or unreadable.
 - Note that MAC filtering is a weak control on its own (MACs can be spoofed); combine it with [WPA3/SAE](#wpa3-sae).
 

--- a/lib/core/mac_filter.sh
+++ b/lib/core/mac_filter.sh
@@ -41,7 +41,7 @@ mac_filter_compute_conf() {
             echo "accept_mac_file=${MAC_ACL_FILE}"
             ;;
         2)
-            echo "macaddr_acl=1"
+            echo "macaddr_acl=0"
             echo "deny_mac_file=${MAC_ACL_FILE}"
             ;;
         *)

--- a/tests/mac_filter.bats
+++ b/tests/mac_filter.bats
@@ -31,12 +31,12 @@ setup() {
     [ "${lines[1]}" = "accept_mac_file=/etc/hostapd.accept" ]
 }
 
-@test "MAC_FILTER=2 emits macaddr_acl=1 and deny_mac_file" {
+@test "MAC_FILTER=2 emits macaddr_acl=0 and deny_mac_file" {
     MAC_FILTER=2
     MAC_ACL_FILE="/etc/hostapd.deny"
     run mac_filter_compute_conf
     [ "$status" -eq 0 ]
-    [ "${lines[0]}" = "macaddr_acl=1" ]
+    [ "${lines[0]}" = "macaddr_acl=0" ]
     [ "${lines[1]}" = "deny_mac_file=/etc/hostapd.deny" ]
 }
 


### PR DESCRIPTION
MAC_FILTER=2 (denylist) previously emitted `macaddr_acl=1` which tells hostapd to deny all clients not in the accept list. Changed to `macaddr_acl=0` so only listed MACs are rejected while others are allowed.

- Fixed `mac_filter_compute_conf` in lib/core/mac_filter.sh
- Updated test assertion in tests/mac_filter.bats
- Fixed docs/configuration.md MAC filtering section

Closes #278
