### PR TITLE
docs: explain hostapd macaddr_acl semantics in MAC filtering docs

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -111,6 +111,8 @@ MAC filtering is **off by default**; behavior is unchanged unless you set `MAC_F
 
 - `MAC_FILTER=1` (allowlist): only MACs listed in the file can associate (`macaddr_acl=1` + `accept_mac_file=`).
 - `MAC_FILTER=2` (denylist): listed MACs are rejected (`macaddr_acl=0` + `deny_mac_file=`).
+
+**hostapd `macaddr_acl` semantics**: `macaddr_acl=0` means accept all clients *unless* listed in `deny_mac_file` (denylist mode); `macaddr_acl=1` means deny all clients *unless* listed in `accept_mac_file` (allowlist mode). The two directives are mutually exclusive in hostapd - only one file type is effective per mode.
 - Startup fails with an error if the filter is enabled without `MAC_ACL_FILE`, and warns if the file is missing or unreadable.
 - Note that MAC filtering is a weak control on its own (MACs can be spoofed); combine it with [WPA3/SAE](#wpa3-sae).
 


### PR DESCRIPTION
Add a brief explanation of hostapd's `macaddr_acl` semantics to the MAC filtering section:

- `macaddr_acl=0`: accept all clients unless listed in `deny_mac_file` (denylist)
- `macaddr_acl=1`: deny all clients unless listed in `accept_mac_file` (allowlist)

This makes the two hostapd directives explicit so future changes can be reviewed against actual semantics.

Closes #290
