### PR TITLE
chore(ci): add manual workflow_dispatch to release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,6 +3,7 @@ name: Release Please
 on:
   push:
     branches: [master]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
Adds `workflow_dispatch:` trigger to the release-please workflow, allowing it to be manually triggered from the GitHub Actions UI.