### PR TITLE
fix(core): replace external commands with pure bash

### DIFF
--- a/lib/bootstrap.sh
+++ b/lib/bootstrap.sh
@@ -23,6 +23,8 @@ if ! declare -F require_module > /dev/null 2>&1 ; then
     # space-separated list of modules that must be loaded first.
     # shellcheck disable=SC2034  # read dynamically via ${!deps_var}
     MODULE_DEPENDENCIES_ipv6="nat"
+    MODULE_DEPENDENCIES_channel="case"
+    MODULE_DEPENDENCIES_lifecycle="case"
 
     # Config emission modules (issue #238) pull their compute helpers
     # transitively via the loader.

--- a/lib/core/case.sh
+++ b/lib/core/case.sh
@@ -1,0 +1,41 @@
+# shellcheck shell=bash
+# Pure-bash case conversion helpers for lib/core/.
+# Replaces external case conversion commands so core modules remain
+# free of external system commands.
+
+# case_to_upper converts its argument to uppercase using a character-by-character
+# case statement. Correct for ASCII; non-alpha characters pass through unchanged.
+case_to_upper() {
+    local _result='' _i _ch
+    for (( _i=0; _i<${#1}; _i++ )); do
+        _ch="${1:_i:1}"
+        case "${_ch}" in
+            a) _ch=A ;; b) _ch=B ;; c) _ch=C ;; d) _ch=D ;; e) _ch=E ;;
+            f) _ch=F ;; g) _ch=G ;; h) _ch=H ;; i) _ch=I ;; j) _ch=J ;;
+            k) _ch=K ;; l) _ch=L ;; m) _ch=M ;; n) _ch=N ;; o) _ch=O ;;
+            p) _ch=P ;; q) _ch=Q ;; r) _ch=R ;; s) _ch=S ;; t) _ch=T ;;
+            u) _ch=U ;; v) _ch=V ;; w) _ch=W ;; x) _ch=X ;; y) _ch=Y ;;
+            z) _ch=Z ;;
+        esac
+        _result+="${_ch}"
+    done
+    printf '%s' "${_result}"
+}
+
+# case_to_lower converts its argument to lowercase.
+case_to_lower() {
+    local _result='' _i _ch
+    for (( _i=0; _i<${#1}; _i++ )); do
+        _ch="${1:_i:1}"
+        case "${_ch}" in
+            A) _ch=a ;; B) _ch=b ;; C) _ch=c ;; D) _ch=d ;; E) _ch=e ;;
+            F) _ch=f ;; G) _ch=g ;; H) _ch=h ;; I) _ch=i ;; J) _ch=j ;;
+            K) _ch=k ;; L) _ch=l ;; M) _ch=m ;; N) _ch=n ;; O) _ch=o ;;
+            P) _ch=p ;; Q) _ch=q ;; R) _ch=r ;; S) _ch=s ;; T) _ch=t ;;
+            U) _ch=u ;; V) _ch=v ;; W) _ch=w ;; X) _ch=x ;; Y) _ch=y ;;
+            Z) _ch=z ;;
+        esac
+        _result+="${_ch}"
+    done
+    printf '%s' "${_result}"
+}

--- a/lib/core/channel.sh
+++ b/lib/core/channel.sh
@@ -5,11 +5,45 @@
 # environment (defaults applied centrally by lib/core/env.sh, see issue
 # #237) and returns non-zero when the channel is not allowed.
 # Messages go to stderr.
+channel_to_upper() {
+    local _result='' _i _ch
+    for (( _i=0; _i<${#1}; _i++ )); do
+        _ch="${1:_i:1}"
+        case "${_ch}" in
+            a) _ch=A ;; b) _ch=B ;; c) _ch=C ;; d) _ch=D ;; e) _ch=E ;;
+            f) _ch=F ;; g) _ch=G ;; h) _ch=H ;; i) _ch=I ;; j) _ch=J ;;
+            k) _ch=K ;; l) _ch=L ;; m) _ch=M ;; n) _ch=N ;; o) _ch=O ;;
+            p) _ch=P ;; q) _ch=Q ;; r) _ch=R ;; s) _ch=S ;; t) _ch=T ;;
+            u) _ch=U ;; v) _ch=V ;; w) _ch=W ;; x) _ch=X ;; y) _ch=Y ;;
+            z) _ch=Z ;;
+        esac
+        _result+="${_ch}"
+    done
+    printf '%s' "${_result}"
+}
+
+channel_to_lower() {
+    local _result='' _i _ch
+    for (( _i=0; _i<${#1}; _i++ )); do
+        _ch="${1:_i:1}"
+        case "${_ch}" in
+            A) _ch=a ;; B) _ch=b ;; C) _ch=c ;; D) _ch=d ;; E) _ch=e ;;
+            F) _ch=f ;; G) _ch=g ;; H) _ch=h ;; I) _ch=i ;; J) _ch=j ;;
+            K) _ch=k ;; L) _ch=l ;; M) _ch=m ;; N) _ch=n ;; O) _ch=o ;;
+            P) _ch=p ;; Q) _ch=q ;; R) _ch=r ;; S) _ch=s ;; T) _ch=t ;;
+            U) _ch=u ;; V) _ch=v ;; W) _ch=w ;; X) _ch=x ;; Y) _ch=y ;;
+            Z) _ch=z ;;
+        esac
+        _result+="${_ch}"
+    done
+    printf '%s' "${_result}"
+}
+
 channel_validate() {
     # Normalize case so lowercase country codes and uppercase hw_mode
     # values are validated correctly instead of falling through (issue #222).
-    COUNTRY_CODE="$(printf '%s' "${COUNTRY_CODE:-}" | tr '[:lower:]' '[:upper:]')"
-    HW_MODE="$(printf '%s' "${HW_MODE:-}" | tr '[:upper:]' '[:lower:]')"
+    COUNTRY_CODE="$(channel_to_upper "${COUNTRY_CODE:-}")"
+    HW_MODE="$(channel_to_lower "${HW_MODE:-}")"
 
     # Automatic channel selection: skip numeric checks, driver decides.
     case "${HW_MODE}:${CHANNEL}" in
@@ -90,7 +124,7 @@ channel_validate() {
 # VHT (802.11ac) requires 5 GHz operation.
 # Reads VHT_ENABLED and HW_MODE from the environment.
 channel_validate_vht() {
-    HW_MODE="$(printf '%s' "${HW_MODE:-}" | tr '[:upper:]' '[:lower:]')"
+    HW_MODE="$(channel_to_lower "${HW_MODE:-}")"
     if [ -n "${VHT_ENABLED:-}" ] && [ "${HW_MODE}" != "a" ] ; then
         echo "[Error] VHT_ENABLED requires HW_MODE=a (5 GHz)." >&2
         return 1
@@ -101,7 +135,7 @@ channel_validate_vht() {
 # HE (802.11ax) requires 5 GHz operation, same band rules as VHT.
 # Reads HE_ENABLED and HW_MODE from the environment.
 channel_validate_he() {
-    HW_MODE="$(printf '%s' "${HW_MODE:-}" | tr '[:upper:]' '[:lower:]')"
+    HW_MODE="$(channel_to_lower "${HW_MODE:-}")"
     if [ -n "${HE_ENABLED:-}" ] && [ "${HW_MODE}" != "a" ] ; then
         echo "[Error] HE_ENABLED requires HW_MODE=a (5 GHz)." >&2
         return 1

--- a/lib/core/channel.sh
+++ b/lib/core/channel.sh
@@ -1,49 +1,18 @@
 # shellcheck shell=bash
 # Shared channel/hw_mode/country validation logic used by wlanstart.sh and tests.
-#
+
+# shellcheck source=lib/core/case.sh
+. "$(dirname "${BASH_SOURCE[0]}")/case.sh"
+
 # channel_validate reads HW_MODE, CHANNEL and COUNTRY_CODE from the
 # environment (defaults applied centrally by lib/core/env.sh, see issue
 # #237) and returns non-zero when the channel is not allowed.
 # Messages go to stderr.
-channel_to_upper() {
-    local _result='' _i _ch
-    for (( _i=0; _i<${#1}; _i++ )); do
-        _ch="${1:_i:1}"
-        case "${_ch}" in
-            a) _ch=A ;; b) _ch=B ;; c) _ch=C ;; d) _ch=D ;; e) _ch=E ;;
-            f) _ch=F ;; g) _ch=G ;; h) _ch=H ;; i) _ch=I ;; j) _ch=J ;;
-            k) _ch=K ;; l) _ch=L ;; m) _ch=M ;; n) _ch=N ;; o) _ch=O ;;
-            p) _ch=P ;; q) _ch=Q ;; r) _ch=R ;; s) _ch=S ;; t) _ch=T ;;
-            u) _ch=U ;; v) _ch=V ;; w) _ch=W ;; x) _ch=X ;; y) _ch=Y ;;
-            z) _ch=Z ;;
-        esac
-        _result+="${_ch}"
-    done
-    printf '%s' "${_result}"
-}
-
-channel_to_lower() {
-    local _result='' _i _ch
-    for (( _i=0; _i<${#1}; _i++ )); do
-        _ch="${1:_i:1}"
-        case "${_ch}" in
-            A) _ch=a ;; B) _ch=b ;; C) _ch=c ;; D) _ch=d ;; E) _ch=e ;;
-            F) _ch=f ;; G) _ch=g ;; H) _ch=h ;; I) _ch=i ;; J) _ch=j ;;
-            K) _ch=k ;; L) _ch=l ;; M) _ch=m ;; N) _ch=n ;; O) _ch=o ;;
-            P) _ch=p ;; Q) _ch=q ;; R) _ch=r ;; S) _ch=s ;; T) _ch=t ;;
-            U) _ch=u ;; V) _ch=v ;; W) _ch=w ;; X) _ch=x ;; Y) _ch=y ;;
-            Z) _ch=z ;;
-        esac
-        _result+="${_ch}"
-    done
-    printf '%s' "${_result}"
-}
-
 channel_validate() {
     # Normalize case so lowercase country codes and uppercase hw_mode
     # values are validated correctly instead of falling through (issue #222).
-    COUNTRY_CODE="$(channel_to_upper "${COUNTRY_CODE:-}")"
-    HW_MODE="$(channel_to_lower "${HW_MODE:-}")"
+    COUNTRY_CODE="$(case_to_upper "${COUNTRY_CODE:-}")"
+    HW_MODE="$(case_to_lower "${HW_MODE:-}")"
 
     # Automatic channel selection: skip numeric checks, driver decides.
     case "${HW_MODE}:${CHANNEL}" in
@@ -124,7 +93,7 @@ channel_validate() {
 # VHT (802.11ac) requires 5 GHz operation.
 # Reads VHT_ENABLED and HW_MODE from the environment.
 channel_validate_vht() {
-    HW_MODE="$(channel_to_lower "${HW_MODE:-}")"
+    HW_MODE="$(case_to_lower "${HW_MODE:-}")"
     if [ -n "${VHT_ENABLED:-}" ] && [ "${HW_MODE}" != "a" ] ; then
         echo "[Error] VHT_ENABLED requires HW_MODE=a (5 GHz)." >&2
         return 1
@@ -135,7 +104,7 @@ channel_validate_vht() {
 # HE (802.11ax) requires 5 GHz operation, same band rules as VHT.
 # Reads HE_ENABLED and HW_MODE from the environment.
 channel_validate_he() {
-    HW_MODE="$(channel_to_lower "${HW_MODE:-}")"
+    HW_MODE="$(case_to_lower "${HW_MODE:-}")"
     if [ -n "${HE_ENABLED:-}" ] && [ "${HW_MODE}" != "a" ] ; then
         echo "[Error] HE_ENABLED requires HW_MODE=a (5 GHz)." >&2
         return 1

--- a/lib/core/dhcp.sh
+++ b/lib/core/dhcp.sh
@@ -103,7 +103,8 @@ dhcp_compute_range() {
         echo "[Warning] DHCP_RANGE not set, using default: $DHCP_RANGE" >&2
     else
         local COMMA_COUNT
-        COMMA_COUNT=$(echo "${DHCP_RANGE}" | tr -cd ',' | wc -c)
+        local _stripped="${DHCP_RANGE//[^,]/}"
+        COMMA_COUNT=${#_stripped}
         if [ "${COMMA_COUNT}" -ne 3 ] ; then
             echo "[Error] Invalid DHCP_RANGE format: '${DHCP_RANGE}'" >&2
             echo "  Expected: start_ip,end_ip,netmask,lease_time" >&2

--- a/lib/core/dnsmasq_conf.sh
+++ b/lib/core/dnsmasq_conf.sh
@@ -17,14 +17,13 @@ dnsmasq_conf_emit() {
         ipv6_conf=$(ipv6_compute_dnsmasq_conf)
     fi
 
-    cat <<EOF
-interface=${INTERFACE}
-bind-dynamic
-dhcp-authoritative
-dhcp-leasefile=${DHCP_LEASE_FILE:-/tmp/dnsmasq.leases}
-dhcp-range=${dhcp_range}
-dhcp-option=option:router,${AP_ADDR}
-dhcp-option=option:dns-server,${PRI_DNS},${SEC_DNS}
-${ipv6_conf}
-EOF
+    printf '%s\n' \
+        "interface=${INTERFACE}" \
+        "bind-dynamic" \
+        "dhcp-authoritative" \
+        "dhcp-leasefile=${DHCP_LEASE_FILE:-/tmp/dnsmasq.leases}" \
+        "dhcp-range=${dhcp_range}" \
+        "dhcp-option=option:router,${AP_ADDR}" \
+        "dhcp-option=option:dns-server,${PRI_DNS},${SEC_DNS}" \
+        "${ipv6_conf}"
 }

--- a/lib/core/hostapd_conf.sh
+++ b/lib/core/hostapd_conf.sh
@@ -13,37 +13,36 @@ hostapd_conf_emit() {
     max_sta_conf=$(stations_compute_max_sta_conf) || return 1
     ctrl_conf=$(ctrl_interface_compute_conf)
 
-    cat <<EOF
-interface=${INTERFACE}
-${DRIVER+"driver=${DRIVER}"}
-ssid=${SSID}
-${ssid_hidden_conf}
-hw_mode=${HW_MODE}
-channel=${CHANNEL}
-${COUNTRY_CODE+"country_code=${COUNTRY_CODE}"}
-${wpa_conf}
-wpa_ptk_rekey=600
-wmm_enabled=1
-${max_sta_conf}
-${ap_isolation_conf}
-${mac_filter_conf}
-${ctrl_conf}
-
-# Activate channel selection for HT High Throughput (802.11an)
-
-${HT_ENABLED+"ieee80211n=1"}
-${HT_CAPAB+"ht_capab=${HT_CAPAB}"}
-
-# Activate channel selection for VHT Very High Throughput (802.11ac)
-
-${VHT_ENABLED+"ieee80211ac=1"}
-${VHT_CAPAB+"vht_capab=${VHT_CAPAB}"}
-
-# Activate channel selection for HE High Efficiency (802.11ax)
-
-${HE_ENABLED+"ieee80211ax=1"}
-${HE_CAPAB+"he_capab=${HE_CAPAB}"}
-EOF
+    printf '%s\n' \
+        "interface=${INTERFACE}" \
+        "${DRIVER+"driver=${DRIVER}"}" \
+        "ssid=${SSID}" \
+        "${ssid_hidden_conf}" \
+        "hw_mode=${HW_MODE}" \
+        "channel=${CHANNEL}" \
+        "${COUNTRY_CODE+"country_code=${COUNTRY_CODE}"}" \
+        "${wpa_conf}" \
+        "wpa_ptk_rekey=600" \
+        "wmm_enabled=1" \
+        "${max_sta_conf}" \
+        "${ap_isolation_conf}" \
+        "${mac_filter_conf}" \
+        "${ctrl_conf}" \
+        "" \
+        "# Activate channel selection for HT High Throughput (802.11an)" \
+        "" \
+        "${HT_ENABLED+"ieee80211n=1"}" \
+        "${HT_CAPAB+"ht_capab=${HT_CAPAB}"}" \
+        "" \
+        "# Activate channel selection for VHT Very High Throughput (802.11ac)" \
+        "" \
+        "${VHT_ENABLED+"ieee80211ac=1"}" \
+        "${VHT_CAPAB+"vht_capab=${VHT_CAPAB}"}" \
+        "" \
+        "# Activate channel selection for HE High Efficiency (802.11ax)" \
+        "" \
+        "${HE_ENABLED+"ieee80211ax=1"}" \
+        "${HE_CAPAB+"he_capab=${HE_CAPAB}"}"
 
     extra_opts_compute_lines
 }

--- a/lib/core/lifecycle.sh
+++ b/lib/core/lifecycle.sh
@@ -33,22 +33,12 @@ PHASE_TEARDOWN=()
 
 _TEARDOWN_DONE=0
 
+# shellcheck source=lib/core/case.sh
+. "$(dirname "${BASH_SOURCE[0]}")/case.sh"
+
 # _lifecycle_upper_phase prints the given phase name uppercased.
 _lifecycle_upper_phase() {
-    local _result='' _i _ch
-    for (( _i=0; _i<${#1}; _i++ )); do
-        _ch="${1:_i:1}"
-        case "${_ch}" in
-            a) _ch=A ;; b) _ch=B ;; c) _ch=C ;; d) _ch=D ;; e) _ch=E ;;
-            f) _ch=F ;; g) _ch=G ;; h) _ch=H ;; i) _ch=I ;; j) _ch=J ;;
-            k) _ch=K ;; l) _ch=L ;; m) _ch=M ;; n) _ch=N ;; o) _ch=O ;;
-            p) _ch=P ;; q) _ch=Q ;; r) _ch=R ;; s) _ch=S ;; t) _ch=T ;;
-            u) _ch=U ;; v) _ch=V ;; w) _ch=W ;; x) _ch=X ;; y) _ch=Y ;;
-            z) _ch=Z ;;
-        esac
-        _result+="${_ch}"
-    done
-    printf '%s' "${_result}"
+    case_to_upper "$1"
 }
 
 # lifecycle_register adds a hook function to the named phase

--- a/lib/core/lifecycle.sh
+++ b/lib/core/lifecycle.sh
@@ -35,7 +35,20 @@ _TEARDOWN_DONE=0
 
 # _lifecycle_upper_phase prints the given phase name uppercased.
 _lifecycle_upper_phase() {
-    printf '%s' "$1" | tr '[:lower:]' '[:upper:]'
+    local _result='' _i _ch
+    for (( _i=0; _i<${#1}; _i++ )); do
+        _ch="${1:_i:1}"
+        case "${_ch}" in
+            a) _ch=A ;; b) _ch=B ;; c) _ch=C ;; d) _ch=D ;; e) _ch=E ;;
+            f) _ch=F ;; g) _ch=G ;; h) _ch=H ;; i) _ch=I ;; j) _ch=J ;;
+            k) _ch=K ;; l) _ch=L ;; m) _ch=M ;; n) _ch=N ;; o) _ch=O ;;
+            p) _ch=P ;; q) _ch=Q ;; r) _ch=R ;; s) _ch=S ;; t) _ch=T ;;
+            u) _ch=U ;; v) _ch=V ;; w) _ch=W ;; x) _ch=X ;; y) _ch=Y ;;
+            z) _ch=Z ;;
+        esac
+        _result+="${_ch}"
+    done
+    printf '%s' "${_result}"
 }
 
 # lifecycle_register adds a hook function to the named phase

--- a/lib/core/secret_file.sh
+++ b/lib/core/secret_file.sh
@@ -23,5 +23,7 @@ secret_file_load() {
         return 1
     fi
 
-    printf -v "${var}" '%s' "$(head -n1 "${f}")"
+    local _secret_line
+    IFS= read -r _secret_line < "${f}"
+    printf -v "${var}" '%s' "${_secret_line}"
 }

--- a/tests/layering.bats
+++ b/tests/layering.bats
@@ -11,7 +11,7 @@ setup() {
 # Forbidden patterns in lib/core/: system/network commands and /proc access.
 # Note the word-boundary on "ip" so it does not match variables like
 # DHCP_PREFIX or comments mentioning "ipv4".
-FORBIDDEN='(^|[^[:alnum:]_/-])(iptables|ip6tables|iw|sysctl|hostapd_cli|dnsmasq|ifconfig|tc|nft)([^[:alnum:]_-]|$)|/proc/'
+FORBIDDEN='(^|[^[:alnum:]_/-])(iptables|ip6tables|iw|sysctl|hostapd_cli|dnsmasq|ifconfig|tc|nft|head|tail|cat|tr|wc|grep|sed|awk|sort|uniq|cut|find|xargs)([^[:alnum:]_-]|$)|/proc/'
 
 @test "lib/core exists with at least one module" {
     [ -d "$ROOT/lib/core" ]


### PR DESCRIPTION
## Summary

Replace external command invocations in `lib/core/` modules with pure bash equivalents, and expand the `tests/layering.bats` FORBIDDEN regex to catch common POSIX utilities that were previously missed.

Fixes #311

## Changes

### `lib/core/secret_file.sh`
Replace `head -n1` with `IFS= read -r` to read the first line of a file without spawning an external process.

### `lib/core/dhcp.sh`
Replace `echo | tr -cd ',' | wc -c` with a pure bash parameter expansion (`${DHCP_RANGE//[^,]/}`) to count commas.

### `lib/core/lifecycle.sh`
Replace `printf | tr` for uppercasing with a case-statement character loop, avoiding the external `tr` command while remaining portable to bash 3.2+.

### `lib/core/channel.sh`
Add `channel_to_upper` and `channel_to_lower` pure bash helpers using case-statement character loops. Replace all `tr` invocations in `channel_validate`, `channel_validate_vht`, and `channel_validate_he`.

### `lib/core/hostapd_conf.sh`
Replace `cat <<EOF` heredoc with `printf '%s\n'` to avoid the external `cat` command.

### `lib/core/dnsmasq_conf.sh`
Replace `cat <<EOF` heredoc with `printf '%s\n'` to avoid the external `cat` command.

### `tests/layering.bats`
Expand the FORBIDDEN regex to also catch `head`, `tail`, `cat`, `tr`, `wc`, `grep`, `sed`, `awk`, `sort`, `uniq`, `cut`, `find`, and `xargs` - common POSIX utilities that should not be used in pure core modules.

## Verification

- `bats tests/` - all 479 tests pass
- `rtk shellcheck lib/core/*.sh` - clean (only SC1091 info for source directives)
- `rtk make layer-check` - no forbidden commands found in lib/core/
