### PR TITLE
fix(dhcp): declare local variables in explicit DHCP_RANGE path

### DIFF
--- a/lib/core/dhcp.sh
+++ b/lib/core/dhcp.sh
@@ -155,7 +155,7 @@ dhcp_compute_range() {
             return 1
         fi
         if [ -n "${SUBNET:-}" ] && validation_check_ipv4 "${SUBNET}" ; then
-            local subnet_int addr masked mask_int
+            local subnet_int addr masked mask_int m1 m2 m3 m4
             subnet_int=$(dhcp_ip_to_int "${SUBNET}")
             IFS=. read -r m1 m2 m3 m4 <<<"${netmask}"
             mask_int=$(( (m1 << 24) | (m2 << 16) | (m3 << 8) | m4 ))


### PR DESCRIPTION
## Problem

`lib/core/dhcp.sh:160` - `m1 m2 m3 m4` from `IFS=. read -r m1 m2 m3 m4 <<<"${netmask}"` leak to global scope. The adjacent `subnet_int addr masked mask_int` on line 158 are already declared `local`, but `m1 m2 m3 m4` were missed.

## Fix

Add `m1 m2 m3 m4` to the existing `local` declaration on line 158.

## Testing

- All 46 `dhcp_range.bats` tests pass
- All 479 tests pass
- Shellcheck clean
