### PR TITLE
fix(passphrase): compute length after locale pin

### DIFF
--- a/lib/core/passphrase.sh
+++ b/lib/core/passphrase.sh
@@ -7,9 +7,10 @@
 # characters (which could inject hostapd.conf directives). Messages go to
 # stderr.
 passphrase_validate() {
-    local len=${#WPA_PASSPHRASE}
-    # Pin the locale so the [[:cntrl:]] class behaves consistently.
+    # Pin the locale so the length count and [[:cntrl:]] class behave
+    # consistently (WPA counts bytes, not characters).
     local LC_ALL=C
+    local len=${#WPA_PASSPHRASE}
     if [ "${len}" -lt 8 ] || [ "${len}" -gt 63 ] ; then
         echo "[Error] Invalid WPA_PASSPHRASE: must be 8-63 characters (got ${len})." >&2
         return 1


### PR DESCRIPTION
## Problem

`lib/core/passphrase.sh:10` - `${#WPA_PASSPHRASE}` was evaluated before `LC_ALL=C` on line 12. In a multi-byte UTF-8 locale, `${#var}` counts characters, not bytes. The WPA spec counts bytes, so a passphrase with multi-byte characters could pass the 8-63 check incorrectly.

Compare with `lib/core/validation.sh:34` which correctly sets `LC_ALL=C` before the SSID length check.

## Fix

Move `local LC_ALL=C` before the length assignment.

## Testing

- All 5 `passphrase_validation.bats` tests pass
- All 479 tests pass
