### PR TITLE
docs: add clients.sh subcommands to INDEX.md task table

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -23,7 +23,7 @@ Lightweight Docker container that turns a Raspberry Pi into a wireless Access Po
 | List connected clients | `CTRL_INTERFACE=1` + `clients.sh` | [Client inspection](operations.md#client-inspection-optional) |
 | Count connected clients | `CTRL_INTERFACE=1` + `clients.sh count` | [Client inspection](operations.md#client-inspection-optional) |
 | Show DHCP leases | `CTRL_INTERFACE=1` + `clients.sh leases` | [DHCP leases](operations.md#dhcp-leases) |
-| Disconnect a client | `CTRL_INTERFACE=1` + `clients.sh deauth <mac>` | [Client inspection](operations.md#client-inspection-optional) |
+| Disconnect a client | `CTRL_INTERFACE=1` + `clients.sh deauth <mac-address>` | [Client inspection](operations.md#client-inspection-optional) |
 | Verify the AP is actually beaconing | `HEALTHCHECK_DEEP=1` | [Deep healthcheck](healthcheck.md#deep-healthcheck-optional) |
 | Give a DFS channel time to start (CAC wait) | `HEALTHCHECK_START_PERIOD` | [Deep healthcheck: DFS channels](healthcheck.md#deep-healthcheck-optional) |
 | Test my configuration without touching the system | `--validate` flag | [Dry-run validation](validation.md#dry-run-validation---validate) |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -21,6 +21,9 @@ Lightweight Docker container that turns a Raspberry Pi into a wireless Access Po
 | Restrict NAT to specific outgoing interfaces | `OUTGOINGS` | [Outgoing interfaces](networking.md#outgoing-interfaces) |
 | Make IP forwarding persist across reboots | host sysctl config | [NAT / IP forwarding](networking.md#nat--ip-forwarding) |
 | List connected clients | `CTRL_INTERFACE=1` + `clients.sh` | [Client inspection](operations.md#client-inspection-optional) |
+| Count connected clients | `CTRL_INTERFACE=1` + `clients.sh count` | [Client inspection](operations.md#client-inspection-optional) |
+| Show DHCP leases | `CTRL_INTERFACE=1` + `clients.sh leases` | [DHCP leases](operations.md#dhcp-leases) |
+| Disconnect a client | `CTRL_INTERFACE=1` + `clients.sh deauth <mac>` | [Client inspection](operations.md#client-inspection-optional) |
 | Verify the AP is actually beaconing | `HEALTHCHECK_DEEP=1` | [Deep healthcheck](healthcheck.md#deep-healthcheck-optional) |
 | Give a DFS channel time to start (CAC wait) | `HEALTHCHECK_START_PERIOD` | [Deep healthcheck: DFS channels](healthcheck.md#deep-healthcheck-optional) |
 | Test my configuration without touching the system | `--validate` flag | [Dry-run validation](validation.md#dry-run-validation---validate) |


### PR DESCRIPTION
# Add clients.sh subcommands to INDEX.md task table

This PR adds the missing `clients.sh` subcommands (`count`, `leases`, `deauth`) to the "How do I..." table in `docs/INDEX.md`.

## Changes

- Added row for "Count connected clients" with link to [Client inspection](operations.md#client-inspection-optional)
- Added row for "Show DHCP leases" with link to [DHCP leases](operations.md#dhcp-leases)
- Added row for "Disconnect a client" with link to [Client inspection](operations.md#client-inspection-optional)

All three subcommands were already documented in `docs/operations.md` but were not discoverable via the index page.

## Testing

- Verified links point to correct sections in `docs/operations.md`
- No code changes, documentation only

Closes #322