### PR TITLE
docs: add failure log variables to INDEX.md task table

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,6 +31,7 @@ Lightweight Docker container that turns a Raspberry Pi into a wireless Access Po
 | Fix a container that exits immediately | - | [Troubleshooting](troubleshooting.md#container-exits-immediately) |
 | Diagnose missing IPv6 connectivity on clients | `IPV6` | [IPv6 troubleshooting](troubleshooting.md#ipv6-no-connectivity-or-only-link-local-addresses) |
 | Understand why the container is `unhealthy` | `HEALTHCHECK_START_PERIOD`, `HEALTHCHECK_DEEP` | [Health Check](healthcheck.md) |
+| Preserve crash logs for debugging | `FAILURE_LOG_DIR`, `FAILURE_LOG_KEEP`, `FAILURE_LOG_PATH` | [Preserved failure logs](troubleshooting.md#preserved-failure-logs) |
 
 ## Contents
 


### PR DESCRIPTION
# Add failure log variables to INDEX.md task table

This PR adds the preserved failure log feature variables (`FAILURE_LOG_DIR`, `FAILURE_LOG_KEEP`, `FAILURE_LOG_PATH`) to the "How do I..." table in `docs/INDEX.md`.

## Changes

- Added row for "Preserve crash logs for debugging" with link to [Preserved failure logs](troubleshooting.md#preserved-failure-logs)

This feature was already documented in `docs/troubleshooting.md` but was not discoverable via the index page.

## Testing

- Verified link points to correct section in `docs/troubleshooting.md`
- No code changes, documentation only

Closes #321