### PR TITLE
docs: add --check mode to INDEX.md task table

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -32,6 +32,7 @@ Lightweight Docker container that turns a Raspberry Pi into a wireless Access Po
 | Diagnose missing IPv6 connectivity on clients | `IPV6` | [IPv6 troubleshooting](troubleshooting.md#ipv6-no-connectivity-or-only-link-local-addresses) |
 | Understand why the container is `unhealthy` | `HEALTHCHECK_START_PERIOD`, `HEALTHCHECK_DEEP` | [Health Check](healthcheck.md) |
 | Preserve crash logs for debugging | `FAILURE_LOG_DIR`, `FAILURE_LOG_KEEP`, `FAILURE_LOG_PATH` | [Preserved failure logs](troubleshooting.md#preserved-failure-logs) |
+| Audit a running system against its config | `--check` flag | [Runtime state audit](validation.md#runtime-state-audit---check) |
 
 ## Contents
 


### PR DESCRIPTION
# Add --check mode to INDEX.md task table

This PR adds the runtime state audit feature (`--check` flag) to the "How do I..." table in `docs/INDEX.md`.

## Changes

- Added row for "Audit a running system against its config" with link to [Runtime state audit](validation.md#runtime-state-audit---check)

This feature was already documented in `docs/validation.md` but was not discoverable via the index page.

## Testing

- Verified link points to correct section in `docs/validation.md`
- No code changes, documentation only

Closes #319