### PR TITLE
docs: add HEALTHCHECK_MIN_STATIONS to INDEX.md task table

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -33,6 +33,7 @@ Lightweight Docker container that turns a Raspberry Pi into a wireless Access Po
 | Understand why the container is `unhealthy` | `HEALTHCHECK_START_PERIOD`, `HEALTHCHECK_DEEP` | [Health Check](healthcheck.md) |
 | Preserve crash logs for debugging | `FAILURE_LOG_DIR`, `FAILURE_LOG_KEEP`, `FAILURE_LOG_PATH` | [Preserved failure logs](troubleshooting.md#preserved-failure-logs) |
 | Audit a running system against its config | `--check` flag | [Runtime state audit](validation.md#runtime-state-audit---check) |
+| Require minimum connected clients | `HEALTHCHECK_MIN_STATIONS` | [Minimum station count](healthcheck.md#minimum-stations-check-optional) |
 
 ## Contents
 


### PR DESCRIPTION
# Add HEALTHCHECK_MIN_STATIONS to INDEX.md task table

This PR adds the minimum station count check feature (`HEALTHCHECK_MIN_STATIONS`) to the "How do I..." table in `docs/INDEX.md`.

## Changes

- Added row for "Require minimum connected clients" with link to [Minimum station count](healthcheck.md#minimum-stations-check-optional)

This feature was already documented in `docs/healthcheck.md` but was not discoverable via the index page.

## Testing

- Verified link points to correct section in `docs/healthcheck.md`
- No code changes, documentation only

Closes #320