### PR TITLE
docs: add ACS (automatic channel selection) section to configuration.md

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -34,6 +34,7 @@ Lightweight Docker container that turns a Raspberry Pi into a wireless Access Po
 | Preserve crash logs for debugging | `FAILURE_LOG_DIR`, `FAILURE_LOG_KEEP`, `FAILURE_LOG_PATH` | [Preserved failure logs](troubleshooting.md#preserved-failure-logs) |
 | Audit a running system against its config | `--check` flag | [Runtime state audit](validation.md#runtime-state-audit---check) |
 | Require minimum connected clients | `HEALTHCHECK_MIN_STATIONS` | [Minimum station count](healthcheck.md#minimum-stations-check-optional) |
+| Auto-select WiFi channel | `CHANNEL=acs` | [ACS](configuration.md#automatic-channel-selection-acs) |
 
 ## Contents
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -217,6 +217,45 @@ docker run -d --name hostap \
 
 When `COUNTRY_CODE` is set, channels are validated against regional limits.
 
+### Automatic Channel Selection (ACS)
+
+Setting `CHANNEL=acs` enables automatic channel selection. The WiFi driver scans available channels and selects the best one based on current interference and signal conditions.
+
+```bash
+docker run ... \
+  -e CHANNEL=acs \
+  ...
+```
+
+#### How it works
+
+When `CHANNEL=acs` is set, the driver performs a channel scan at startup and selects the channel with the least interference. This is useful in dynamic environments where the optimal channel may change over time.
+
+#### Driver support
+
+Not all WiFi drivers support ACS. Check your driver's documentation or run `iw list` to see if ACS is supported. If ACS is not supported, the container will fail with an error.
+
+#### DFS/CAC caveat
+
+ACS may select a DFS (Dynamic Frequency Selection) radar channel. When this happens:
+
+- The AP must perform Channel Availability Check (CAC) before transmitting, which can take 60+ seconds
+- Clients cannot connect until CAC completes
+- The container may report as `unhealthy` during this period
+
+To accommodate DFS channels, set `HEALTHCHECK_START_PERIOD` to at least 90 seconds:
+
+```bash
+docker run ... \
+  -e CHANNEL=acs \
+  -e HEALTHCHECK_START_PERIOD=90 \
+  ...
+```
+
+#### Startup delay
+
+Startup may be delayed while the driver scans channels. The delay depends on the number of channels scanned and driver implementation. Plan for 10-30 seconds of additional startup time when using ACS.
+
 ### 2.4 GHz Channels
 
 For 2.4 GHz (`hw_mode=g` or `b`):


### PR DESCRIPTION
# Add ACS (automatic channel selection) section to configuration.md

This PR adds documentation for the `CHANNEL=acs` feature to `docs/configuration.md` and adds a corresponding row to the "How do I..." table in `docs/INDEX.md`.

## Changes

- Added new section "Automatic Channel Selection (ACS)" in `docs/configuration.md` covering:
  - How ACS works (driver scans and selects best channel)
  - Driver support requirements
  - DFS/CAC caveat: ACS may select a radar channel, requiring CAC delay
  - Recommended `HEALTHCHECK_START_PERIOD` (90s for DFS-safe deployments)
  - Note about startup delay during channel scan
- Added row to `docs/INDEX.md` "How do I..." table: "Auto-select WiFi channel" → [ACS](configuration.md#automatic-channel-selection-acs)

## Testing

- Verified link points to correct section in `docs/configuration.md`
- No code changes, documentation only

Closes #318