### PR TITLE
docs: add HOSTAPD_EXTRA_OPTS section to configuration.md

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -36,6 +36,7 @@ Lightweight Docker container that turns a Raspberry Pi into a wireless Access Po
 | Require minimum connected clients | `HEALTHCHECK_MIN_STATIONS` | [Minimum station count](healthcheck.md#minimum-stations-check-optional) |
 | Auto-select WiFi channel | `CHANNEL=acs` | [ACS](configuration.md#automatic-channel-selection-acs) |
 | Use a non-standard WiFi driver | `DRIVER` | [Driver override](configuration.md#driver-override) |
+| Inject custom hostapd options | `HOSTAPD_EXTRA_OPTS` | [Extra hostapd options](configuration.md#extra-hostapd-options) |
 
 ## Contents
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -311,6 +311,37 @@ When `DRIVER` is unset, hostapd uses the default `nl80211` driver. This is the r
 
 If you set an invalid driver name, hostapd will fail with a clear error message in `docker logs`. The container will exit immediately rather than running in a broken state.
 
+## Extra hostapd Options
+
+`HOSTAPD_EXTRA_OPTS` allows you to inject custom hostapd.conf lines that are appended verbatim after all generated configuration. This is useful for power users who need to set options not exposed by environment variables.
+
+### Syntax
+
+The value is a newline-separated list of `key=value` pairs in raw hostapd.conf format:
+
+```bash
+docker run ... \
+  -e HOSTAPD_EXTRA_OPTS="auth_algs=3\nbeacon_int=100" \
+  ...
+```
+
+### Common use cases
+
+| Option | Description | Example |
+|--------|-------------|---------|
+| `beacon_int` | Beacon interval in TU (1 TU = 1024 µs) | `beacon_int=100` |
+| `auth_algs` | Authentication algorithms (1=Open, 2=Shared, 3=Both) | `auth_algs=3` |
+| `wmm_uapsd` | Enable WMM U-APSD (unscheduled power save) | `wmm_uapsd=1` |
+| `dtim_period` | DTIM period (beacons between DTIMs) | `dtim_period=2` |
+| `rts_threshold` | RTS/CTS threshold in bytes | `rts_threshold=2347` |
+
+### Important notes
+
+- Values are **unvalidated** - they are passed directly to hostapd without checking
+- Invalid values will cause hostapd to fail at startup with errors in `docker logs`
+- Lines are appended after all generated config, so they can override earlier directives
+- Use this only when you understand the hostapd.conf format and the specific option
+
 ---
 
 _Last updated: 2026-08-24_


### PR DESCRIPTION
# Add HOSTAPD_EXTRA_OPTS section to configuration.md

This PR adds documentation for the `HOSTAPD_EXTRA_OPTS` environment variable to `docs/configuration.md` and adds a corresponding row to the "How do I..." table in `docs/INDEX.md`.

## Changes

- Added new section "Extra hostapd options" in `docs/configuration.md` covering:
  - What `HOSTAPD_EXTRA_OPTS` does (appends raw lines to generated hostapd.conf)
  - Syntax requirements (newline-separated `key=value` pairs)
  - Common use cases table (beacon_int, auth_algs, wmm_uapsd, etc.)
  - Warning that values are unvalidated
  - Note about hostapd startup failure for invalid config
- Added row to `docs/INDEX.md` "How do I..." table: "Inject custom hostapd options" → [Extra hostapd options](configuration.md#extra-hostapd-options)

## Testing

- Verified link points to correct section in `docs/configuration.md`
- No code changes, documentation only

Closes #316