### PR TITLE
refactor(radio): remove unreachable empty-string case branch

### DIFF
--- a/lib/sys/radio.sh
+++ b/lib/sys/radio.sh
@@ -13,7 +13,7 @@ radio_validate_tx_power() {
     [ -z "${TX_POWER:-}" ] && return 0
     case "${TX_POWER}" in
         auto) return 0 ;;
-        ""|*[!0-9]*)
+        *[!0-9]*)
             echo "[Error] Invalid TX_POWER '${TX_POWER}'. Must be 'auto' or an integer power in dBm." >&2
             return 1
             ;;


### PR DESCRIPTION
# Remove unreachable empty-string case branch in radio_validate_tx_power

This PR removes the unreachable empty string case from `radio_validate_tx_power()` in `lib/sys/radio.sh`.

## Problem

The `case` pattern included `""|*[!0-9]*` which matches empty string, but the function returns early on line 13 when `TX_POWER` is empty. The `""` branch was dead code.

## Changes

- Removed unreachable `""` from case pattern: `""|*[!0-9]*` → `*[!0-9]*`

## Testing

- All 13 existing `bats tests/tx_power.bats` tests pass
- `shellcheck` reports no warnings

Closes #313