### PR TITLE
fix(pages): add frontmatter to copied docs for Starlight schema

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ else
   BUILDER = $(error Neither docker buildx nor podman found)
 endif
 
-.PHONY: all build test system-test taglatest prepare layer-check docs-build docs-dev
+.PHONY: all build test system-test taglatest prepare layer-check docs-build docs-dev docs-clean
 
 all: build test
 
@@ -93,6 +93,9 @@ docs-build:
 
 docs-dev:
 	cd docs-site && npm run dev
+
+docs-clean:
+	rm -rf docs-site/dist docs-site/.astro docs-site/src/content/docs
 
 test:
 	@sudo $(IF_DOWN)

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ else
   BUILDER = $(error Neither docker buildx nor podman found)
 endif
 
-.PHONY: all build test system-test taglatest prepare layer-check
+.PHONY: all build test system-test taglatest prepare layer-check docs-build docs-dev
 
 all: build test
 
@@ -87,6 +87,12 @@ build-multiarch-push-latest:
 		--tag $(IMGNAME):latest \
 		--push \
 		.
+
+docs-build:
+	cd docs-site && npm ci && npm run build
+
+docs-dev:
+	cd docs-site && npm run dev
 
 test:
 	@sudo $(IF_DOWN)

--- a/docs-site/scripts/copy-content.sh
+++ b/docs-site/scripts/copy-content.sh
@@ -33,8 +33,9 @@ for f in "$REPO_ROOT"/docs/*.md; do
 done
 shopt -u nullglob
 
-# Copy root-level markdown files (as .mdx for Starlight)
-ROOT_FILES=(README.md SPEC.md CHANGELOG.md)
+# Copy root-level markdown files
+# CHANGELOG.md uses .md extension to avoid MDX parsing issues with shell syntax
+ROOT_FILES=(README.md SPEC.md)
 for src_name in "${ROOT_FILES[@]}"; do
   if [[ ! -f "$REPO_ROOT/$src_name" ]]; then
     echo "Warning: $src_name not found, skipping" >&2
@@ -50,5 +51,17 @@ for src_name in "${ROOT_FILES[@]}"; do
     cat "$REPO_ROOT/$src_name"
   } > "$CONTENT_DIR/${name}.mdx"
 done
+
+# Copy CHANGELOG as .md (not .mdx) to avoid MDX parsing issues with shell syntax
+if [[ -f "$REPO_ROOT/CHANGELOG.md" ]]; then
+  title="$(extract_title "$REPO_ROOT/CHANGELOG.md")"
+  {
+    echo "---"
+    echo "title: \"$title\""
+    echo "---"
+    echo ""
+    cat "$REPO_ROOT/CHANGELOG.md"
+  } > "$CONTENT_DIR/changelog.md"
+fi
 
 echo "Copied content files to $CONTENT_DIR"

--- a/docs-site/scripts/copy-content.sh
+++ b/docs-site/scripts/copy-content.sh
@@ -8,14 +8,28 @@ CONTENT_DIR="$(cd "$(dirname "$0")/.." && pwd)/src/content/docs"
 rm -rf "$CONTENT_DIR"
 mkdir -p "$CONTENT_DIR"
 
-# Copy docs/ files (rename CI.md -> ci.md for lowercase URLs)
+# Extract title from first heading in markdown file
+extract_title() {
+  local file="$1"
+  # Get first line starting with # and strip the heading markers and leading/trailing spaces
+  grep -m1 '^# ' "$file" | sed 's/^# //' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//'
+}
+
+# Copy docs/ files with frontmatter (rename CI.md -> ci.md for lowercase URLs)
 shopt -s nullglob
 for f in "$REPO_ROOT"/docs/*.md; do
   name="$(basename "$f")"
   if [ "$name" = "CI.md" ]; then
     name="ci.md"
   fi
-  cp "$f" "$CONTENT_DIR/$name"
+  title="$(extract_title "$f")"
+  {
+    echo "---"
+    echo "title: \"$title\""
+    echo "---"
+    echo ""
+    cat "$f"
+  } > "$CONTENT_DIR/$name"
 done
 shopt -u nullglob
 
@@ -27,7 +41,14 @@ for src_name in "${ROOT_FILES[@]}"; do
     continue
   fi
   name="${src_name%.md}"
-  cp "$REPO_ROOT/$src_name" "$CONTENT_DIR/${name}.mdx"
+  title="$(extract_title "$REPO_ROOT/$src_name")"
+  {
+    echo "---"
+    echo "title: \"$title\""
+    echo "---"
+    echo ""
+    cat "$REPO_ROOT/$src_name"
+  } > "$CONTENT_DIR/${name}.mdx"
 done
 
 echo "Copied content files to $CONTENT_DIR"


### PR DESCRIPTION
## Summary

Updates  to extract title from first heading and add Starlight-compatible frontmatter to all copied files. Also adds Makefile targets for local docs testing.

## Changes

- Copied content files to /Users/sdelrio/github/sdelrio/rpi-hostap/docs-site/src/content/docs: Extract title from first  heading and wrap content in frontmatter with  field
- : Add  and  targets

## Problem

Starlight requires a  field in frontmatter for all docs. The copied markdown files had no frontmatter, causing build failures.

Fixes #338