### PR TITLE
docs: update INDEX.md with GitHub Pages site links

### DIFF
--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,6 +2,8 @@
 
 Lightweight Docker container that turns a Raspberry Pi into a wireless Access Point with DHCP server. See the main [README](../README.md) for overview, prerequisites, quick start and the environment variable reference.
 
+> **View the full documentation site:** [https://sdelrio.github.io/rpi-hostap/](https://sdelrio.github.io/rpi-hostap/)
+
 ## How do I...
 
 | Goal | Variable(s) | Docs |

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -2,7 +2,7 @@
 
 Lightweight Docker container that turns a Raspberry Pi into a wireless Access Point with DHCP server. See the main [README](../README.md) for overview, prerequisites, quick start and the environment variable reference.
 
-> **View the full documentation site:** [https://sdelrio.github.io/rpi-hostap/](https://sdelrio.github.io/rpi-hostap/)
+> **View the full documentation site:** [rpi-hostap documentation site](https://sdelrio.github.io/rpi-hostap/)
 
 ## How do I...
 


### PR DESCRIPTION
## Summary

Add a prominent link to the GitHub Pages site at the top of `docs/INDEX.md`.

Closes #340

## Changes

- Added a blockquote with a link to `https://sdelrio.github.io/rpi-hostap/` after the first paragraph
- All existing relative links in `docs/INDEX.md` remain unchanged and compatible with the Astro/Starlight site structure

## Acceptance criteria

- [x] `docs/INDEX.md` includes a link to `https://sdelrio.github.io/rpi-hostap/`
- [x] The link is visible near the top of the document
- [x] All existing relative links in `docs/INDEX.md` still work in the Astro site
- [x] No other files in `docs/` are modified
