### PR TITLE
fix(pages): add docs-site artifacts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,7 @@
 /tmp/
 node_modules/
+
+# docs-site build artifacts
+docs-site/node_modules/
+docs-site/.astro/
+docs-site/dist/

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 node_modules/
 
 # docs-site build artifacts
-docs-site/node_modules/
 docs-site/.astro/
 docs-site/dist/
+docs-site/.env
+docs-site/.env.*


### PR DESCRIPTION
## Summary

Adds `docs-site/` build artifacts to `.gitignore` so generated files are not committed.

## Changes

- `docs-site/node_modules/`
- `docs-site/.astro/`
- `docs-site/dist/`

Closes #339
