### PR TITLE
chore(tests): expand layering.bats FORBIDDEN regex for core modules

### DIFF
--- a/tests/layering.bats
+++ b/tests/layering.bats
@@ -11,7 +11,8 @@ setup() {
 # Forbidden patterns in lib/core/: system/network commands and /proc access.
 # Note the word-boundary on "ip" so it does not match variables like
 # DHCP_PREFIX or comments mentioning "ipv4".
-FORBIDDEN='(^|[^[:alnum:]_/-])(iptables|ip6tables|iw|sysctl|hostapd_cli|dnsmasq|ifconfig|tc|nft|head|tail|cat|tr|wc|grep|sed|awk|sort|uniq|cut|find|xargs)([^[:alnum:]_-]|$)|/proc/'
+FORBIDDEN='(^|[^[:alnum:]_/-])(iptables|ip6tables|iw|sysctl|hostapd_cli|dnsmasq|ifconfig|tc|nft|head|tail|cat|tr|wc|grep|sed|awk|sort|uniq|cut|find|xargs|cp|mv|rm|chmod|chown|mkdir|stat|touch|date|basename)([^[:alnum:]_-]|$)|/proc/'
+# Safe bash builtins (not blocked): echo, printf, read, true, false, return, test/[, command -v
 
 @test "lib/core exists with at least one module" {
     [ -d "$ROOT/lib/core" ]


### PR DESCRIPTION
## Summary

Expand the FORBIDDEN regex in `tests/layering.bats` to block common POSIX utilities from being used in `lib/core/` modules.

## Changes

- Added `cp`, `mv`, `rm`, `chmod`, `chown`, `mkdir`, `stat`, `touch`, `date`, and `basename` to the FORBIDDEN regex
- Added a comment documenting safe bash builtins (`echo`, `printf`, `read`, `true`, `false`, `command -v`) that are not blocked

## Rationale

`lib/core/` modules must be pure - they should only use bash builtins and language constructs, not external system commands. The previous regex missed common POSIX utilities that are filesystem-modifying or environment-dependent. This expansion ensures those violations are caught by CI.

Closes #314
