### PR TITLE
feat(bootstrap): add circular dependency detection

### DIFF
--- a/lib/bootstrap.sh
+++ b/lib/bootstrap.sh
@@ -45,11 +45,22 @@ if ! declare -F require_module > /dev/null 2>&1 ; then
         local m=$1
         local loaded_var="_LOADED_${m}"
         [ -n "${!loaded_var:-}" ] && return 0
+
+        local resolving_var="_RESOLVING_${m}"
+        if [ -n "${!resolving_var:-}" ] ; then
+            echo "[Error] Circular dependency detected: ${m}" >&2
+            return 1
+        fi
+        eval "${resolving_var}=1"
+
         local deps_var="MODULE_DEPENDENCIES_${m}"
         local dep
         for dep in ${!deps_var:-} ; do
             require_module "$dep"
         done
+
+        eval "${resolving_var}="
+
         local layer=core
         [ -f "${LIB_BOOTSTRAP_DIR}/sys/${m}.sh" ] && layer=sys
         # shellcheck disable=SC1090

--- a/tests/bootstrap.bats
+++ b/tests/bootstrap.bats
@@ -66,3 +66,33 @@ setup() {
     '
     [ "$status" -eq 0 ]
 }
+
+@test "circular dependency detection produces error and non-zero exit" {
+    run bash -c '
+        set -euo pipefail
+        . "'"${LIB}"'/bootstrap.sh"
+        MODULE_DEPENDENCIES_circ_a="circ_b"
+        MODULE_DEPENDENCIES_circ_b="circ_a"
+        # Create stub module files so the loader does not fail on missing files
+        mkdir -p "'"${LIB}"'/core"
+        echo "# stub" > "'"${LIB}"'/core/circ_a.sh"
+        echo "# stub" > "'"${LIB}"'/core/circ_b.sh"
+        require_module circ_a
+    '
+    [ "$status" -ne 0 ]
+    [[ "$output" == *"Circular dependency detected"* ]]
+    # Cleanup stubs
+    rm -f "${LIB}/core/circ_a.sh" "${LIB}/core/circ_b.sh"
+}
+
+@test "existing module loading still works (no false positives from resolving guard)" {
+    run bash -c '
+        set -euo pipefail
+        . "'"${LIB}"'/bootstrap.sh"
+        require_module validation nat ipv6
+        declare -F validation_check_ipv4_param > /dev/null
+        declare -F nat_apply_rules > /dev/null
+        declare -F ipv6_compute_dnsmasq_conf > /dev/null
+    '
+    [ "$status" -eq 0 ]
+}


### PR DESCRIPTION
## Summary

Add circular dependency detection to `_require_one_module` in `lib/bootstrap.sh`.

## Problem

If module A declares `MODULE_DEPENDENCIES_A="B"` and module B declares `MODULE_DEPENDENCIES_B="A"`, the recursive `require_module` calls loop infinitely until the bash stack overflows. There is no guard against this in `_require_one_module` (`lib/bootstrap.sh:44-58`).

## Solution

Set a `_RESOLVING_<module>` guard variable before recursing into dependencies. If the guard is already set when `_require_one_module` is entered, a circular dependency is detected: print a clear error message to stderr and return non-zero. Clear the guard after all dependencies are resolved but before sourcing the module file.

## Changes

- **`lib/bootstrap.sh`**: Added `_RESOLVING_<module>` guard check at the top of `_require_one_module`, set before recursion, cleared after.
- **`tests/bootstrap.bats`**: Added two new tests:
  - `circular dependency detection produces error and non-zero exit` - verifies that A->B->A produces an error with a clear message
  - `existing module loading still works (no false positives from resolving guard)` - verifies normal dependency chains still work

## Acceptance Criteria

- [x] Circular dependency produces a clear error message and non-zero exit
- [x] Existing module loading still works (no false positives)
- [x] Test added in `tests/bootstrap.bats` that verifies circular dependency detection

Closes #312
