### PR TITLE
fix(pages): strip markdown heading to prevent duplicated page titles

### DIFF
--- a/docs-site/scripts/copy-content.sh
+++ b/docs-site/scripts/copy-content.sh
@@ -15,6 +15,13 @@ extract_title() {
   grep -m1 '^# ' "$file" | sed 's/^# //' | sed 's/^[[:space:]]*//' | sed 's/[[:space:]]*$//'
 }
 
+# Strip the first heading line (and trailing blank line) from a file.
+# Starlight renders the frontmatter title as <h1>, so keeping the
+# markdown heading causes a duplicated title on every page.
+strip_title_heading() {
+  sed '1{/^# /d;}' | sed '1{/^$/d;}'
+}
+
 # Copy docs/ files with frontmatter (rename CI.md -> ci.md for lowercase URLs)
 shopt -s nullglob
 for f in "$REPO_ROOT"/docs/*.md; do
@@ -28,7 +35,7 @@ for f in "$REPO_ROOT"/docs/*.md; do
     echo "title: \"$title\""
     echo "---"
     echo ""
-    cat "$f"
+    cat "$f" | strip_title_heading
   } > "$CONTENT_DIR/$name"
 done
 shopt -u nullglob
@@ -48,7 +55,7 @@ for src_name in "${ROOT_FILES[@]}"; do
     echo "title: \"$title\""
     echo "---"
     echo ""
-    cat "$REPO_ROOT/$src_name"
+    cat "$REPO_ROOT/$src_name" | strip_title_heading
   } > "$CONTENT_DIR/${name}.mdx"
 done
 
@@ -60,7 +67,7 @@ if [[ -f "$REPO_ROOT/CHANGELOG.md" ]]; then
     echo "title: \"$title\""
     echo "---"
     echo ""
-    cat "$REPO_ROOT/CHANGELOG.md"
+    cat "$REPO_ROOT/CHANGELOG.md" | strip_title_heading
   } > "$CONTENT_DIR/changelog.md"
 fi
 


### PR DESCRIPTION
## Problem

Every page on the GitHub Pages site (built with Astro Starlight) shows its title twice. For example, the Configuration page renders "Configuration Configuration" - once from Starlight's automatic `<h1>` generated from the frontmatter `title` field, and once from the original `# Configuration` heading still present in the markdown body.

**Root cause:** `docs-site/scripts/copy-content.sh` extracts the first `# heading` from each markdown file into the YAML frontmatter `title` field, but then copies the entire file body unchanged via `cat "$f"` - including that same heading line. Starlight renders the frontmatter title as `<h1 id="_top">` automatically, so the markdown heading produces a second `<h1>`.

## Proposed fix

Add a `strip_title_heading()` function that removes the first heading line (and any immediately following blank line) from the markdown body before writing it to the output file. Apply this in all three copy loops:

1. **docs/ files** (line 38): `cat "$f" | strip_title_heading`
2. **Root README/SPEC** (line 58): `cat "$REPO_ROOT/$src_name" | strip_title_heading`
3. **CHANGELOG** (line 70): `cat "$REPO_ROOT/CHANGELOG.md" | strip_title_heading`

The function uses two `sed` passes:
- `sed '1{/^# /d;}'` - delete line 1 only if it starts with `# ` (safe: won't touch non-heading lines)
- `sed '1{/^$/d;}'` - remove the blank line that follows the heading (prevents double-spacing)

## Acceptance criteria

- [x] `make docs-build` completes without errors
- [x] Every generated HTML page in `dist/` contains exactly one `<h1>` tag
- [x] Frontmatter titles are preserved correctly (verified for configuration, changelog, readme, networking, healthcheck, etc.)
- [x] Body content starts correctly after frontmatter (no orphaned blank lines or missing content)
