### PR TITLE
feat(ci): add GitHub Actions workflow for docs-site deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,53 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches: [master]
+    paths:
+      - 'docs-site/**'
+      - 'docs/**'
+      - 'README.md'
+      - 'SPEC.md'
+      - 'CHANGELOG.md'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24
+          cache: npm
+          cache-dependency-path: docs-site/package-lock.json
+      - run: npm ci
+        working-directory: docs-site
+      - run: npm run prebuild
+        working-directory: docs-site
+      - run: npm run build
+        working-directory: docs-site
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: docs-site/dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@368f82528645a54fb793d4d04e342629a3f51346 # v5.0.1


### PR DESCRIPTION
## Summary

Adds a GitHub Actions workflow to build and deploy the docs-site (Astro/Starlight) to GitHub Pages.

## What changed

- `.github/workflows/docs.yml` — new workflow with:
  - SHA-pinned actions per repo policy
  - Node 24 with npm cache via `setup-node`
  - Explicit `npm run prebuild` step (needed because `ignore-scripts=true` in `.npmrc` prevents auto-triggering of `prebuild` before `build`)
  - `npm run build` produces all 12 content pages
  - Separate build and deploy jobs with concurrency control
  - Triggers on push to `master` when `docs-site/`, `docs/`, `README.md`, `SPEC.md`, or `CHANGELOG.md` change, plus manual dispatch

## Testing

- Locally verified: `npm run prebuild && npm run build` produces 12 pages including `/configuration/index.html`
- All internal links validated by `starlight-links-validator`

## Notes

- This also fixes #360 (404 on content pages) since the explicit `prebuild` step ensures `copy-content.sh` runs before build
- Repo Settings > Pages must be set to "GitHub Actions" source (#361)
