### PR TITLE
fix(ci): add prebuild step and scope deploy permissions

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -22,8 +22,6 @@ on:
 
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 concurrency:
   group: pages
@@ -41,6 +39,8 @@ jobs:
           cache-dependency-path: docs-site/package-lock.json
       - run: npm ci
         working-directory: docs-site
+      - run: npm run prebuild
+        working-directory: docs-site
       - run: npm run build
         working-directory: docs-site
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
@@ -50,6 +50,9 @@ jobs:
   deploy:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}


### PR DESCRIPTION
## Summary

Fixes 404 on content pages (e.g. `/rpi-hostap/configuration/`) by adding the missing `npm run prebuild` step to the existing `pages.yml` workflow. Also tightens permissions.

## Changes to `.github/workflows/pages.yml`

1. **Added `npm run prebuild`** before `npm run build` (line 42-43) — the `copy-content.sh` script must run explicitly because `ignore-scripts=true` in `docs-site/.npmrc` prevents npm from auto-triggering `prebuild` before `build`.

2. **Scoped permissions** — moved `pages: write` and `id-token: write` from workflow level to the `deploy` job only. The `build` job only needs `contents: read`.

## Root cause

`scripts/copy-content.sh` copies `docs/*.md` into `src/content/docs/` at build time. Without the `prebuild` step, the Astro build produces only a 404 page with no content pages.

## Testing

- Verified locally: `rm -rf src/content/docs dist && npm run prebuild && npm run build` produces all 12 pages including `/configuration/index.html`
- `starlight-links-validator` passes — all internal links valid

Closes #360
