### PR TITLE
feat(theme-1-core): update accent color to Raspberry Pi red

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -18,6 +18,9 @@ export default defineConfig({
       social: [
         { icon: 'github', label: 'GitHub', href: 'https://github.com/sdelrio/rpi-hostap' },
       ],
+      customCss: [
+        './src/styles/custom.css',
+      ],
       plugins: [
         starlightLinksValidator(),
       ],

--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -1,0 +1,12 @@
+:root,
+[data-theme='light'] {
+  --sl-hue-blue: 354;
+  --sl-color-accent-low: hsl(354, 80%, 90%);
+  --sl-color-accent: hsl(354, 90%, 40%);
+  --sl-color-accent-high: hsl(354, 80%, 30%);
+}
+[data-theme='dark'] {
+  --sl-color-accent-low: hsl(354, 50%, 20%);
+  --sl-color-accent: hsl(354, 100%, 60%);
+  --sl-color-accent-high: hsl(354, 100%, 80%);
+}


### PR DESCRIPTION
## Summary

Updates the Starlight theme accent color from blue to Raspberry Pi red (hue 354).

## Changes

- Created `docs-site/src/styles/custom.css` with CSS custom property overrides
- Updated `--sl-hue-blue`, `--sl-color-accent-low`, `--sl-color-accent`, and `--sl-color-accent-high` for both light and dark modes

## Testing

- [x] Astro build succeeds (`npm run build` in docs-site)
- [x] Light mode accent is red (hue 354)
- [x] Dark mode accent is red (hue 354)
- [x] No blue accent colors remain

Closes #366
