### PR TITLE
feat(theme-1-core): set light mode as default theme

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -21,6 +21,9 @@ export default defineConfig({
       customCss: [
         './src/styles/custom.css',
       ],
+      components: {
+        ThemeProvider: './src/components/ThemeProvider.astro',
+      },
       plugins: [
         starlightLinksValidator(),
       ],

--- a/docs-site/src/components/ThemeProvider.astro
+++ b/docs-site/src/components/ThemeProvider.astro
@@ -1,0 +1,38 @@
+---
+import { Icon } from '@astrojs/starlight/components';
+---
+
+{/* This is intentionally inlined to avoid FOUC. */}
+<script is:inline>
+	window.StarlightThemeProvider = (() => {
+		const storedTheme =
+			typeof localStorage !== 'undefined' && localStorage.getItem('starlight-theme');
+		const theme =
+			storedTheme ||
+			(window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light');
+		document.documentElement.dataset.theme = theme === 'light' ? 'light' : 'dark';
+		return {
+			updatePickers(theme = storedTheme || 'auto') {
+				document.querySelectorAll('starlight-theme-select').forEach((picker) => {
+					const select = picker.querySelector('select');
+					if (select) select.value = theme;
+					/** @type {HTMLTemplateElement | null} */
+					const tmpl = document.querySelector(`#theme-icons`);
+					const newIcon = tmpl && tmpl.content.querySelector('.' + theme);
+					if (newIcon) {
+						const oldIcon = picker.querySelector('svg.label-icon');
+						if (oldIcon) {
+							oldIcon.replaceChildren(...newIcon.cloneNode(true).childNodes);
+						}
+					}
+				});
+			},
+		};
+	})();
+</script>
+
+<template id="theme-icons">
+	<Icon name="sun" class="light" />
+	<Icon name="moon" class="dark" />
+	<Icon name="laptop" class="auto" />
+</template>


### PR DESCRIPTION
## Summary

Sets light mode as the default theme for the docs site, aligning with the Raspberry Pi brand.

## Changes

- Created `docs-site/src/components/ThemeProvider.astro` - custom ThemeProvider that defaults to light mode
- Registered the custom component in `docs-site/astro.config.mjs`

## How it works

The only change from Starlight's default ThemeProvider is the fallback when the OS has no color scheme preference:

| Scenario | Before | After |
|---|---|---|
| OS prefers dark | dark | dark |
| OS prefers light | light | light |
| No OS preference | **dark** | **light** |

- Returning visitors with saved preferences are unaffected
- OS color scheme preference is still respected
- Theme toggle continues to work

## Testing

- [x] Astro build succeeds
- [x] Light mode is default for users without OS preference
- [x] Dark mode toggle still works
- [x] Returning visitors with saved preferences unaffected

Closes #367
