### PR TITLE
feat(theme-1-core): update grayscale palette to warmer tones

### DIFF
--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -4,9 +4,30 @@
   --sl-color-accent-low: hsl(354, 80%, 90%);
   --sl-color-accent: hsl(354, 90%, 40%);
   --sl-color-accent-high: hsl(354, 80%, 30%);
+
+  --sl-color-gray-1: hsl(30, 12%, 20%);
+  --sl-color-gray-2: hsl(30, 10%, 40%);
+  --sl-color-gray-3: hsl(30, 8%, 55%);
+  --sl-color-gray-4: hsl(30, 8%, 75%);
+  --sl-color-gray-5: hsl(30, 15%, 89%);
+  --sl-color-gray-6: hsl(30, 15%, 93%);
+  --sl-color-gray-7: hsl(30, 12%, 95%);
+  --sl-color-black: hsl(30, 8%, 96%);
+  --sl-color-white: hsl(30, 14%, 12%);
 }
 [data-theme='dark'] {
+  --sl-hue-blue: 354;
   --sl-color-accent-low: hsl(354, 50%, 20%);
   --sl-color-accent: hsl(354, 100%, 60%);
   --sl-color-accent-high: hsl(354, 100%, 80%);
+
+  --sl-color-gray-1: hsl(30, 5%, 94%);
+  --sl-color-gray-2: hsl(30, 4%, 77%);
+  --sl-color-gray-3: hsl(30, 3%, 56%);
+  --sl-color-gray-4: hsl(30, 4%, 36%);
+  --sl-color-gray-5: hsl(30, 6%, 23%);
+  --sl-color-gray-6: hsl(30, 8%, 16%);
+  --sl-color-gray-7: hsl(30, 8%, 12%);
+  --sl-color-black: hsl(30, 8%, 10%);
+  --sl-color-white: hsl(0, 0%, 100%);
 }


### PR DESCRIPTION
## Summary

Updates the grayscale palette from cool blue-grays to warmer tones matching the Raspberry Pi brand.

## Changes

- Overrode `--sl-color-gray-1` through `--sl-color-gray-7` in `docs-site/src/styles/custom.css`
- Shifted hue from 224 (cool blue) to 30 (warm amber) for both light and dark modes
- Added `--sl-hue-blue: 354` to dark mode block for consistency

## Testing

- [x] Astro build succeeds
- [x] Light mode has warm white/gray backgrounds
- [x] Dark mode has warm dark tones
- [x] Text contrast is acceptable

Closes #368
