### PR TITLE
feat(theme-1-core): add Roboto font from Google Fonts

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -24,6 +24,23 @@ export default defineConfig({
       components: {
         ThemeProvider: './src/components/ThemeProvider.astro',
       },
+      head: [
+        {
+          tag: 'link',
+          attrs: { rel: 'preconnect', href: 'https://fonts.googleapis.com' },
+        },
+        {
+          tag: 'link',
+          attrs: { rel: 'preconnect', href: 'https://fonts.gstatic.com', crossorigin: true },
+        },
+        {
+          tag: 'link',
+          attrs: {
+            rel: 'stylesheet',
+            href: 'https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap',
+          },
+        },
+      ],
       plugins: [
         starlightLinksValidator(),
       ],

--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -1,3 +1,7 @@
+:root {
+  --sl-font: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+}
+
 :root,
 [data-theme='light'] {
   --sl-hue-blue: 354;


### PR DESCRIPTION
## Summary

Adds Roboto font from Google Fonts to match the Raspberry Pi website.

## Changes

- Added Google Fonts preconnect and stylesheet links in `docs-site/astro.config.mjs` `head` config
- Added `--sl-font` CSS override in `docs-site/src/styles/custom.css` with Roboto and system font fallbacks

## Testing

- [x] Astro build succeeds
- [x] Roboto font loads from Google Fonts
- [x] Fallback fonts work if Google Fonts unavailable
- [x] `display=swap` prevents layout shift

Closes #369
