### PR TITLE
feat(theme-2-layout): increase navigation bar height (#372)

### DIFF
--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -2,6 +2,13 @@
   --sl-font: 'Roboto', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
   --sl-content-width: 50rem;
   --sl-content-pad-x: 2rem;
+  --sl-nav-height: 4rem;
+}
+
+@media (min-width: 72rem) {
+  :root {
+    --sl-nav-height: 5rem;
+  }
 }
 
 @media (min-width: 1200px) {


### PR DESCRIPTION
## Summary

Increase the Starlight navigation bar height to match the Raspberry Pi site's header, providing more vertical padding and better visual balance.

## Changes

- Added `--sl-nav-height: 4rem;` to `:root` in `docs-site/src/styles/custom.css` (default is 3.5rem)
- Added `@media (min-width: 72rem)` breakpoint setting `--sl-nav-height: 5rem` for wider viewports

## Acceptance Criteria

- Header is taller with more vertical padding
- Logo and nav elements are vertically centered
- Mobile menu button is properly positioned

## Testing

- Build verified: `cd docs-site && npm run build` completes successfully
- All internal links validated
