### PR TITLE
feat(theme-2-layout): update sidebar to clean white style (#373)

### DIFF
--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -39,6 +39,9 @@
 [data-theme='light'] {
   --sl-color-text: hsl(30, 15%, 20%);
   --sl-color-text-accent: hsl(354, 90%, 45%);
+  --sl-color-bg-sidebar: hsl(0, 0%, 100%);
+  --sl-color-bg-nav: hsl(220, 20%, 96%);
+  --sl-color-border: hsl(220, 10%, 87%);
 }
 [data-theme='dark'] {
   --sl-hue-blue: 354;


### PR DESCRIPTION
## Summary

Add clean white sidebar styling for light mode to match the Raspberry Pi documentation site aesthetic.

## Changes

- Add `--sl-color-bg-sidebar: hsl(0, 0%, 100%)` for pure white sidebar background
- Add `--sl-color-bg-nav: hsl(220, 20%, 96%)` for light gray navigation bar
- Add `--sl-color-border: hsl(220, 10%, 87%)` for subtle warm gray borders

## Testing

- Verified build passes: `npm run build` in docs-site/
- Sidebar background is white in light mode
- Borders between sidebar and content use subtle warm gray
- Active sidebar items inherit red accent color from `--sl-color-accent`

Closes #373