### PR TITLE
feat(docs-site): add site logo to header (#384)

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -12,6 +12,10 @@ export default defineConfig({
     starlight({
       title: 'rpi-hostap',
       description: 'Lightweight Docker container that turns a Raspberry Pi into a wireless Access Point with DHCP server.',
+      logo: {
+        src: './src/assets/logo.svg',
+        alt: 'rpi-hostap',
+      },
       editLink: {
         baseUrl: 'https://github.com/sdelrio/rpi-hostap/edit/master/',
       },

--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -14,7 +14,7 @@ export default defineConfig({
       description: 'Lightweight Docker container that turns a Raspberry Pi into a wireless Access Point with DHCP server.',
       logo: {
         src: './src/assets/logo.svg',
-        alt: 'rpi-hostap',
+        alt: 'rpi-hostap logo',
       },
       editLink: {
         baseUrl: 'https://github.com/sdelrio/rpi-hostap/edit/master/',

--- a/docs-site/src/assets/logo.svg
+++ b/docs-site/src/assets/logo.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40" fill="none">
+  <rect width="120" height="40" rx="6" fill="#1a1a1a"/>
+  <text x="12" y="28" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#fff" letter-spacing="-0.5">RPi</text>
+  <text x="68" y="28" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="400" fill="#d62839" letter-spacing="-0.5">hostap</text>
+  <circle cx="108" cy="12" r="3" fill="#d62839"/>
+  <path d="M103 16 Q108 11 113 16" stroke="#d62839" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M100 19 Q108 8 116 19" stroke="#d62839" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M97 22 Q108 5 119 22" stroke="#d62839" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+</svg>

--- a/docs-site/src/assets/logo.svg
+++ b/docs-site/src/assets/logo.svg
@@ -1,4 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40" fill="none" role="img" aria-labelledby="logo-title">
+  <title id="logo-title">rpi-hostap logo</title>
   <rect width="120" height="40" rx="6" fill="#1a1a1a"/>
   <text x="12" y="28" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#fff" letter-spacing="-0.5">RPi</text>
   <text x="68" y="28" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="400" fill="#d62839" letter-spacing="-0.5">hostap</text>


### PR DESCRIPTION
## Summary

Adds a custom SVG logo to the site header next to the title text.

Closes #384 

## Changes

- Created `docs-site/src/assets/logo.svg` - text-based "RPi hostap" logo with WiFi signal icon
- Updated `docs-site/astro.config.mjs` - added `logo` config with `src` and `alt` properties

## Acceptance Criteria

- [x] Logo appears in the header next to text title
- [x] Logo is responsive (SVG scales with viewBox, no overflow on mobile)
- [x] Logo links to homepage (Starlight wraps logo in `<a href="/">`)
- [x] Alt text is set for accessibility (`alt="rpi-hostap"`)

## Testing

- `npm run build` in `docs-site/` completes successfully
- Logo renders in all pages as `<img>` with correct src and alt attributes
- Header layout remains intact on desktop and mobile viewports
