### PR TITLE
feat(docs-site): add custom favicon for branding (#383)

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -12,6 +12,7 @@ export default defineConfig({
     starlight({
       title: 'rpi-hostap',
       description: 'Lightweight Docker container that turns a Raspberry Pi into a wireless Access Point with DHCP server.',
+      favicon: '/favicon.svg',
       logo: {
         src: './src/assets/logo.svg',
         alt: 'rpi-hostap logo',

--- a/docs-site/public/favicon.svg
+++ b/docs-site/public/favicon.svg
@@ -1,4 +1,5 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <title>rpi-hostap WiFi icon</title>
   <rect width="32" height="32" rx="6" fill="#1a1a1a"/>
   <circle cx="16" cy="10" r="2.5" fill="#d62839"/>
   <path d="M11 14.5 Q16 9.5 21 14.5" stroke="#d62839" stroke-width="2" fill="none" stroke-linecap="round"/>

--- a/docs-site/public/favicon.svg
+++ b/docs-site/public/favicon.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
+  <rect width="32" height="32" rx="6" fill="#1a1a1a"/>
+  <circle cx="16" cy="10" r="2.5" fill="#d62839"/>
+  <path d="M11 14.5 Q16 9.5 21 14.5" stroke="#d62839" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M8.5 17.5 Q16 7 23.5 17.5" stroke="#d62839" stroke-width="2" fill="none" stroke-linecap="round"/>
+  <path d="M6 20.5 Q16 4.5 26 20.5" stroke="#d62839" stroke-width="2" fill="none" stroke-linecap="round"/>
+</svg>


### PR DESCRIPTION
## Summary

Adds a custom SVG favicon for the rpi-hostap documentation site to improve branding. The favicon features the WiFi/radio wave icon from the project logo on a dark background, matching the existing color scheme (#1a1a1a background, #d62839 accent).

## Changes

- Added `docs-site/public/favicon.svg` - 32x32 SVG favicon with WiFi symbol
- Updated `docs-site/astro.config.mjs` to configure `favicon: '/favicon.svg'`

## Verification

- Favicon loads correctly at `/rpi-hostap/favicon.svg` in the built output
- SVG format ensures crisp rendering at all sizes
- Build succeeds with no errors
- All internal links remain valid

## Acceptance Criteria

- [x] Custom favicon is displayed in browser tabs
- [x] Favicon is SVG format
- [x] Favicon loads correctly with the base path (`/rpi-hostap/`)

Closes #383