### PR TITLE
feat(docs-site): improve logo visibility and readability

### DIFF
--- a/docs-site/src/assets/logo.svg
+++ b/docs-site/src/assets/logo.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 40" fill="none" role="img" aria-labelledby="logo-title">
   <title id="logo-title">rpi-hostap logo</title>
   <rect width="120" height="40" rx="6" fill="#1a1a1a"/>
-  <text x="12" y="28" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#fff" letter-spacing="-0.5">RPi</text>
-  <text x="68" y="28" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="400" fill="#d62839" letter-spacing="-0.5">hostap</text>
-  <circle cx="108" cy="12" r="3" fill="#d62839"/>
-  <path d="M103 16 Q108 11 113 16" stroke="#d62839" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M100 19 Q108 8 116 19" stroke="#d62839" stroke-width="1.5" fill="none" stroke-linecap="round"/>
-  <path d="M97 22 Q108 5 119 22" stroke="#d62839" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <text x="6" y="27" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="700" fill="#fff" letter-spacing="-0.5">RPi</text>
+  <text x="54" y="27" font-family="system-ui, -apple-system, sans-serif" font-size="20" font-weight="400" fill="#d62839" letter-spacing="-0.5">hostap</text>
+  <circle cx="46" cy="25" r="1.5" fill="#d62839"/>
+  <path d="M39 16 Q46 10 53 16" stroke="#d62839" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M41 19 Q46 14 51 19" stroke="#d62839" stroke-width="1.5" fill="none" stroke-linecap="round"/>
+  <path d="M43 22 Q46 18 49 22" stroke="#d62839" stroke-width="1.5" fill="none" stroke-linecap="round"/>
 </svg>


### PR DESCRIPTION
## Summary

Improves the visibility and readability of the documentation site logo SVG across different viewport sizes.

closes #397

## Changes

- Repositioned "RPi" and "hostap" text elements within `docs-site/src/assets/logo.svg` for better horizontal alignment and balance.
- Relocated and resized the WiFi signal arcs and dot to sit centered between "RPi" and "hostap", making the radio theme prominent and identifiable at smaller sizes.

## Acceptance Criteria

- [x] Logo text "RPi hostap" is clearly readable at small display sizes
- [x] WiFi signal icon is visible and recognizable
- [x] Logo maintains good contrast on dark background
- [x] Logo scales properly without losing detail

## Testing

- Built documentation site successfully with `npm --prefix docs-site run build`
- Verified link validation and static asset generation
