### PR TITLE
docs(docs-site): update sidebar navigation structure

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -66,6 +66,7 @@ export default defineConfig({
         {
           label: 'Networking',
           items: [
+            { label: 'Overview', link: '/networking' },
             { label: 'NAT / IP Forwarding', link: '/networking#nat--ip-forwarding' },
             { label: 'IPv6 Support', link: '/networking#ipv6-support-optional' },
             { label: 'Outgoing Interfaces', link: '/networking#outgoing-interfaces' },
@@ -75,12 +76,12 @@ export default defineConfig({
         { label: 'Operations', link: '/operations' },
         { label: 'Health Check', link: '/healthcheck' },
         { label: 'Troubleshooting', link: '/troubleshooting' },
-        { label: 'CI / E2E Tests', link: '/ci' },
         {
           label: 'Reference',
           items: [
             { label: 'Specification', link: '/spec' },
             { label: 'Changelog', link: '/changelog' },
+            { label: 'CI / E2E Tests', link: '/ci' },
           ],
         },
       ],


### PR DESCRIPTION
## Summary

Updates the documentation site sidebar navigation structure in `docs-site/astro.config.mjs` for improved hierarchy and discoverability.

## Changes

- Added an "Overview" link to the Networking sidebar section pointing to `/networking`.
- Moved "CI / E2E Tests" (`/ci`) from the top-level navigation into the "Reference" group alongside "Specification" and "Changelog".

## Testing

- Ran `npm --prefix docs-site run build` successfully.
- Verified link validation passed with zero broken links.
