### PR TITLE
feat(docs-site): configure logo to replace site title text

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -16,6 +16,7 @@ export default defineConfig({
       logo: {
         src: './src/assets/logo.svg',
         alt: 'rpi-hostap logo',
+        replacesTitle: true,
       },
       editLink: {
         baseUrl: 'https://github.com/sdelrio/rpi-hostap/edit/master/',


### PR DESCRIPTION
## Description

Configure `replacesTitle: true` on the Starlight `logo` setting in `docs-site/astro.config.mjs`.

Since `logo.svg` already includes the "RPi hostap" brand lettering, displaying the adjacent site title text resulted in redundant wording (`RPi hostap rpi-hostap`). With `replacesTitle: true`, Starlight adds the `sr-only` class to the site title text so it is hidden visually while preserving accessibility for screen readers.

Closes #401.

## Changes

- Update `docs-site/astro.config.mjs`: set `replacesTitle: true` in `starlight.logo`.

## Verification

- Ran `npm run build` in `docs-site/` (12 pages generated, links valid).
- Verified generated HTML output gives `<span class="sr-only ...">rpi-hostap</span>`.
- Ran `make layer-check` (passes).
