### PR TITLE
feat(docs): disable pagination links globally

### DIFF
--- a/docs-site/astro.config.mjs
+++ b/docs-site/astro.config.mjs
@@ -12,6 +12,7 @@ export default defineConfig({
     starlight({
       title: 'rpi-hostap',
       description: 'Lightweight Docker container that turns a Raspberry Pi into a wireless Access Point with DHCP server.',
+      pagination: false, // disables nex/prev links globally
       favicon: '/favicon.svg',
       logo: {
         src: './src/assets/logo.svg',


### PR DESCRIPTION
### Summary
Disable pagination links globally in the Starlight documentation theme.

### Motivation
The next/previous article navigation links were considered unnecessary for the current documentation layout and caused visual clutter. Adding `pagination: false` to the Starlight configuration removes these links site‑wide, simplifying the reading experience.

### Changes Made
- Updated `docs-site/astro.config.mjs` to include `pagination: false` in the Starlight integration options.

### Type of Change
Feature (docs)
