### PR TITLE
feat(docs-site): restyle code blocks for cleaner light appearance (#382)

### DIFF
--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -59,3 +59,18 @@
   --sl-color-black: hsl(30, 8%, 10%);
   --sl-color-white: hsl(0, 0%, 100%);
 }
+
+[data-theme='light'] .sl-code,
+[data-theme='light'] pre {
+  background: hsl(220, 20%, 97%);
+  border: 1px solid hsl(220, 10%, 87%);
+  border-radius: 8px;
+  color: hsl(220, 15%, 20%);
+}
+
+[data-theme='light'] code {
+  background: hsl(220, 20%, 94%);
+  padding: 0.15em 0.3em;
+  border-radius: 4px;
+  font-size: 0.875em;
+}


### PR DESCRIPTION
## feat(docs-site): restyle code blocks for cleaner light appearance (#382)

Restyle Starlight code blocks for a cleaner, lighter appearance in light mode.

### Changes

- Light background (`hsl(220, 20%, 97%)`) on code block containers
- Subtle `1px solid` border (`hsl(220, 10%, 87%)`) around code blocks
- `8px` border-radius on code blocks
- Inline `<code>` gets light background, padding, and `4px` border-radius
- Dark mode code blocks remain unchanged for contrast

### Files modified

- `docs-site/src/styles/custom.css`

### Acceptance criteria

- [x] Code blocks have light background in light mode
- [x] Subtle border around code blocks
- [x] Rounded corners on code blocks
- [x] Inline code has light background with padding
- [x] Syntax highlighting remains readable
