### PR TITLE
feat(theme-4-polish): add consistent border-radius across components (#381)

### DIFF
--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -3,6 +3,9 @@
   --sl-content-width: 50rem;
   --sl-content-pad-x: 2rem;
   --sl-nav-height: 4rem;
+  --sl-border-radius-sm: 4px;
+  --sl-border-radius-md: 8px;
+  --sl-border-radius-lg: 12px;
 }
 
 @media (min-width: 72rem) {
@@ -64,14 +67,14 @@
 [data-theme='light'] pre {
   background: hsl(220, 20%, 97%);
   border: 1px solid hsl(220, 10%, 87%);
-  border-radius: 8px;
+  border-radius: var(--sl-border-radius-md);
   color: hsl(220, 15%, 20%);
 }
 
 [data-theme='light'] code {
   background: hsl(220, 20%, 94%);
   padding: 0.15em 0.3em;
-  border-radius: 4px;
+  border-radius: var(--sl-border-radius-sm);
   font-size: 0.875em;
 }
 
@@ -99,5 +102,22 @@
 
   .hero .sl-flex {
     justify-content: center;
+  }
+
+  .card {
+    border-radius: var(--sl-border-radius-md);
+  }
+
+  .aside {
+    border-radius: var(--sl-border-radius-md);
+  }
+
+  button {
+    border-radius: var(--sl-border-radius-sm);
+  }
+
+  .sl-code,
+  pre {
+    border-radius: var(--sl-border-radius-md);
   }
 }


### PR DESCRIPTION
## feat(theme-4-polish): add consistent border-radius across components (#381)

### Summary

Add consistent border-radius CSS custom properties and apply them across all docs-site components.

### Changes

- Added three border-radius custom properties to `:root`:
  - `--sl-border-radius-sm: 4px` - for inline code, buttons
  - `--sl-border-radius-md: 8px` - for cards, admonitions, code blocks
  - `--sl-border-radius-lg: 12px` - available for larger components
- Added global overrides inside `@layer starlight.core` for:
  - `.card` - cards use `--sl-border-radius-md`
  - `.aside` - admonitions use `--sl-border-radius-md`
  - `button` - buttons use `--sl-border-radius-sm`
  - `.sl-code, pre` - code blocks use `--sl-border-radius-md`
- Updated existing light theme code block styles to use the new custom properties instead of hardcoded values

### Acceptance Criteria

- [x] Cards have rounded corners (8px)
- [x] Code blocks have rounded corners
- [x] Buttons have rounded corners
- [x] Admonitions have rounded corners
- [x] Consistent radius throughout the site

### Testing

- Build completed successfully with `npm run build`
- All internal links validated
