### PR TITLE
feat(theme-4-polish): add reusable Card component for content links (#378)

### DIFF
--- a/docs-site/src/components/Card.astro
+++ b/docs-site/src/components/Card.astro
@@ -1,0 +1,108 @@
+---
+interface Props {
+	title: string;
+	description: string;
+	href: string;
+	image?: string;
+}
+
+const { title, description, href, image } = Astro.props;
+---
+
+<a href={href} class="card-link">
+	<article class="card">
+		{image && (
+			<div class="card-image">
+				<img src={image} alt="" loading="lazy" />
+			</div>
+		)}
+		<div class="card-body">
+			<h3 class="card-title">{title}</h3>
+			<p class="card-description">{description}</p>
+			<span class="card-arrow" aria-hidden="true">
+				<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+					<line x1="5" y1="12" x2="19" y2="12"></line>
+					<polyline points="12 5 19 12 12 19"></polyline>
+				</svg>
+			</span>
+		</div>
+	</article>
+</a>
+
+<style>
+	@layer starlight.core {
+		.card-link {
+			display: block;
+			text-decoration: none;
+			color: inherit;
+			height: 100%;
+		}
+
+		.card {
+			display: flex;
+			flex-direction: column;
+			height: 100%;
+			background: var(--sl-color-bg, hsl(0 0% 100%));
+			border: 1px solid var(--sl-color-gray-5);
+			border-radius: var(--sl-border-radius-md);
+			overflow: hidden;
+			transition:
+				box-shadow 0.2s ease,
+				border-color 0.2s ease;
+		}
+
+		.card:hover {
+			box-shadow: var(--sl-shadow-lg);
+			border-color: var(--sl-color-text-accent);
+		}
+
+		.card-image {
+			aspect-ratio: 16 / 9;
+			overflow: hidden;
+		}
+
+		.card-image img {
+			width: 100%;
+			height: 100%;
+			object-fit: cover;
+		}
+
+		.card-body {
+			display: flex;
+			flex-direction: column;
+			flex: 1;
+			padding: 1.25rem;
+			gap: 0.5rem;
+		}
+
+		.card-title {
+			font-size: var(--sl-text-lg);
+			font-weight: 600;
+			margin: 0;
+			line-height: 1.3;
+		}
+
+		.card-description {
+			font-size: var(--sl-text-sm);
+			color: var(--sl-color-gray-2);
+			margin: 0;
+			flex: 1;
+			line-height: 1.5;
+		}
+
+		.card-arrow {
+			display: flex;
+			align-items: center;
+			gap: 0.25rem;
+			margin-top: 0.5rem;
+			color: var(--sl-color-text-accent);
+			font-size: var(--sl-text-sm);
+			font-weight: 500;
+			transition: gap 0.2s ease;
+		}
+
+		.card-link:hover .card-arrow {
+			gap: 0.5rem;
+		}
+	}
+</style>

--- a/docs-site/src/components/CardGrid.astro
+++ b/docs-site/src/components/CardGrid.astro
@@ -1,0 +1,29 @@
+---
+---
+
+<div class="card-grid">
+	<slot />
+</div>
+
+<style>
+	@layer starlight.core {
+		.card-grid {
+			display: grid;
+			grid-template-columns: 1fr;
+			gap: 1.5rem;
+			margin: 2rem 0;
+		}
+
+		@media (min-width: 50rem) {
+			.card-grid {
+				grid-template-columns: repeat(2, 1fr);
+			}
+		}
+
+		@media (min-width: 72rem) {
+			.card-grid {
+				grid-template-columns: repeat(3, 1fr);
+			}
+		}
+	}
+</style>

--- a/docs-site/src/content/docs/README.mdx
+++ b/docs-site/src/content/docs/README.mdx
@@ -17,7 +17,28 @@ hero:
 [![GitHub Release](https://img.shields.io/github/v/release/sdelrio/rpi-hostap)](https://github.com/sdelrio/rpi-hostap/releases)
 [![License](https://img.shields.io/github/license/sdelrio/rpi-hostap)](LICENSE)
 
+import Card from '../../components/Card.astro';
+import CardGrid from '../../components/CardGrid.astro';
+
 Lightweight Docker container that turns a Raspberry Pi into a wireless Access Point with DHCP server. Built on Alpine Linux for minimal footprint.
+
+<CardGrid>
+  <Card
+    title="Configuration"
+    description="Environment variables, WiFi settings, WPA3/SAE, MAC filtering, and advanced hostapd options."
+    href="/rpi-hostap/configuration/"
+  />
+  <Card
+    title="Networking"
+    description="NAT/IP forwarding, IPv6 support, and outgoing interface configuration."
+    href="/rpi-hostap/networking/"
+  />
+  <Card
+    title="Operations"
+    description="Client inspection, runtime management, and day-to-day operational tasks."
+    href="/rpi-hostap/operations/"
+  />
+</CardGrid>
 
 ## Overview
 


### PR DESCRIPTION
## Summary

Adds a reusable Card component and CardGrid layout for the docs-site homepage, providing visually distinct entry points to Configuration, Networking, and Operations sections.

## Changes

- **`docs-site/src/components/Card.astro`** - Card component accepting title, description, href, and optional image props. Styled with white background, border-radius using `var(--sl-border-radius-md)`, hover effect with shadow increase and accent border, and arrow link indicator at bottom.
- **`docs-site/src/components/CardGrid.astro`** - Responsive grid wrapper (1 col mobile, 2 cols tablet, 3 cols desktop).
- **`docs-site/src/content/docs/README.mdx`** - Homepage updated to display CardGrid with cards linking to Configuration, Networking, and Operations.

## Acceptance Criteria

- [x] Card renders with title, description, and link
- [x] Optional image support via `image` prop
- [x] Hover effect (shadow increase + border color change)
- [x] Responsive grid: 3 cols desktop, 2 tablet, 1 mobile
- [x] Arrow/link indicator at bottom
- [x] `npm run build` passes

## Testing

- Verified `npm run build` completes successfully
- All internal links validated by `starlight-links-validator`
