### PR TITLE
feat(theme-4-polish): restyle admonitions to match RPi muted palette (#379)

### DIFF
--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -112,6 +112,52 @@
     border-radius: var(--sl-border-radius-md);
   }
 
+  /* Admonitions - RPi muted palette */
+  .starlight-aside {
+    border-radius: var(--sl-border-radius-md);
+    border-left-width: 4px;
+  }
+
+  .starlight-aside--note {
+    background: hsl(220, 20%, 95%);
+    border-left-color: hsl(220, 30%, 60%);
+  }
+
+  [data-theme='dark'] .starlight-aside--note {
+    background: hsl(220, 10%, 15%);
+    border-left-color: hsl(220, 20%, 50%);
+  }
+
+  .starlight-aside--tip {
+    background: hsl(150, 20%, 94%);
+    border-left-color: hsl(150, 30%, 55%);
+  }
+
+  [data-theme='dark'] .starlight-aside--tip {
+    background: hsl(150, 10%, 14%);
+    border-left-color: hsl(150, 20%, 48%);
+  }
+
+  .starlight-aside--caution {
+    background: hsl(38, 25%, 94%);
+    border-left-color: hsl(38, 40%, 55%);
+  }
+
+  [data-theme='dark'] .starlight-aside--caution {
+    background: hsl(38, 12%, 14%);
+    border-left-color: hsl(38, 25%, 48%);
+  }
+
+  .starlight-aside--danger {
+    background: hsl(0, 25%, 94%);
+    border-left-color: hsl(0, 35%, 58%);
+  }
+
+  [data-theme='dark'] .starlight-aside--danger {
+    background: hsl(0, 12%, 14%);
+    border-left-color: hsl(0, 25%, 50%);
+  }
+
   button {
     border-radius: var(--sl-border-radius-sm);
   }


### PR DESCRIPTION
# Restyle admonitions to match RPi muted palette

Closes #379

## Changes

- Added muted/pastel admonition styles inside `@layer starlight.core` in `docs-site/src/styles/custom.css`
- All four admonition types (note, tip, caution, danger) now have:
  - Rounded corners via `border-radius: var(--sl-border-radius-md)`
  - 4px solid left border
  - Very light tinted backgrounds (low saturation HSL)
  - Light and dark theme variants

## Colors

| Type | Light BG | Light Border | Dark BG | Dark Border |
|------|----------|-------------|---------|-------------|
| Note | hsl(220, 20%, 95%) | hsl(220, 30%, 60%) | hsl(220, 10%, 15%) | hsl(220, 20%, 50%) |
| Tip | hsl(150, 20%, 94%) | hsl(150, 30%, 55%) | hsl(150, 10%, 14%) | hsl(150, 20%, 48%) |
| Caution | hsl(38, 25%, 94%) | hsl(38, 40%, 55%) | hsl(38, 12%, 14%) | hsl(38, 25%, 48%) |
| Danger | hsl(0, 25%, 94%) | hsl(0, 35%, 58%) | hsl(0, 12%, 14%) | hsl(0, 25%, 50%) |

## Verification

- `npm run build` passes successfully
