### PR TITLE
fix(commands): close issues after merge in loop-issues

### DIFF
--- a/.opencode/command/loop-issues.md
+++ b/.opencode/command/loop-issues.md
@@ -41,7 +41,7 @@ the limit is reached. For each issue:
    until the current one is merged.
 7. **Finalize after merge**: squash-merge only if explicitly told
    (`gh pr merge <n> --squash --delete-branch`), then
-   `gh issue edit <n> --remove-label in_progress --add-label done`,
+   `gh issue close <n>`,
    `git checkout master && git pull`, and continue with the next issue.
 
 When no more matching open issues remain (or `--limit` is reached), summarize


### PR DESCRIPTION
## Problem

The `loop-issues` command was only adding a `done` label to issues after PR merge, but never actually closing them. This caused issues to remain open even after successful merge.

## Fix

Changed step 7 to use `gh issue close <n>` instead of just relabeling.

## Testing

- Verified the command syntax is correct
- No shell tests needed (documentation-only change)
