### PR TITLE
feat(assistant): network settings section

### DIFF
--- a/docs-site/public/config-assistant.js
+++ b/docs-site/public/config-assistant.js
@@ -35,6 +35,15 @@ function configAssistant() {
     showPassphrase: false,
     pmfAuto: true,
     pmf: '0',
+    subnet: '192.168.254.0',
+    apAddr: '192.168.254.1',
+    dhcpRangeAuto: true,
+    dhcpRangeStart: '192.168.254.100',
+    dhcpRangeEnd: '192.168.254.200',
+    dhcpLease: '12h',
+    priDns: '8.8.8.8',
+    secDns: '8.8.4.4',
+    ipv6: false,
     htEnabled: false,
     htCapab: '',
     vhtEnabled: false,
@@ -45,6 +54,12 @@ function configAssistant() {
       const group = _countryGroup[this.countryCode]
       const list = this.hwMode === 'a' ? channels5G : channels2G
       return group ? (list[group] || []) : []
+    },
+
+    get subnetPrefix() {
+      const parts = this.subnet.split('.')
+      parts.length = 3
+      return parts.join('.')
     },
 
     init() {
@@ -69,6 +84,16 @@ function configAssistant() {
       this.$watch('countryCode', () => this._syncChannel())
       this.$watch('wpaVersion', () => { if (this.pmfAuto) this._derivePmf() })
       this.$watch('pmfAuto', (on) => { if (on) this._derivePmf() })
+      this.$watch('subnet', () => {
+        if (this.dhcpRangeAuto) this._syncDhcpRange()
+      })
+      this.$watch('dhcpRangeAuto', (on) => { if (on) this._syncDhcpRange() })
+    },
+
+    _syncDhcpRange() {
+      const prefix = this.subnetPrefix
+      this.dhcpRangeStart = prefix + '.100'
+      this.dhcpRangeEnd = prefix + '.200'
     },
 
     _syncChannel() {
@@ -122,6 +147,23 @@ function configAssistant() {
           cmd += ` \\
   -e HE_CAPAB="${this.heCapab}"`
         }
+      }
+
+      cmd += ` \\
+  -e SUBNET=${this.subnet} \\
+  -e AP_ADDR=${this.apAddr} \\
+  -e PRI_DNS=${this.priDns} \\
+  -e SEC_DNS=${this.secDns} \\
+  -e DHCP_LEASE=${this.dhcpLease}`
+
+      if (!this.dhcpRangeAuto) {
+        cmd += ` \\
+  -e DHCP_RANGE=${this.dhcpRangeStart},${this.dhcpRangeEnd},255.255.255.0,${this.dhcpLease}`
+      }
+
+      if (this.ipv6) {
+        cmd += ` \\
+  -e IPV6=1`
       }
       
       cmd += ` \\

--- a/docs-site/public/config-assistant.js
+++ b/docs-site/public/config-assistant.js
@@ -35,6 +35,12 @@ function configAssistant() {
     showPassphrase: false,
     pmfAuto: true,
     pmf: '0',
+    htEnabled: false,
+    htCapab: '',
+    vhtEnabled: false,
+    vhtCapab: '',
+    heEnabled: false,
+    heCapab: '',
     get availableChannels() {
       const group = _countryGroup[this.countryCode]
       const list = this.hwMode === 'a' ? channels5G : channels2G
@@ -51,7 +57,15 @@ function configAssistant() {
           </template>
         `
       }
-      this.$watch('hwMode', () => this._syncChannel())
+      this.$watch('hwMode', (mode) => {
+        this._syncChannel()
+        if (mode !== 'a') {
+          this.vhtEnabled = false
+          this.vhtCapab = ''
+          this.heEnabled = false
+          this.heCapab = ''
+        }
+      })
       this.$watch('countryCode', () => this._syncChannel())
       this.$watch('wpaVersion', () => { if (this.pmfAuto) this._derivePmf() })
       this.$watch('pmfAuto', (on) => { if (on) this._derivePmf() })
@@ -71,7 +85,7 @@ function configAssistant() {
 
     generateCommand() {
       const channelValue = this.channel === 'acs' ? 'acs' : this.channel
-      return `docker run -d \
+      let cmd = `docker run -d \
   --name rpi-hostap \
   --net=host \
   --cap-add=NET_ADMIN \
@@ -81,9 +95,40 @@ function configAssistant() {
   -e PMF=${this.pmf} \
   -e CHANNEL=${channelValue} \
   -e HW_MODE=${this.hwMode} \
-  -e COUNTRY_CODE=${this.countryCode} \
-  -v /dev/net/tun:/dev/net/tun \
+  -e COUNTRY_CODE=${this.countryCode}`
+      
+      if (this.htEnabled) {
+        cmd += ` \\
+  -e HT_ENABLED=1`
+        if (this.htCapab) {
+          cmd += ` \\
+  -e HT_CAPAB="${this.htCapab}"`
+        }
+      }
+      
+      if (this.vhtEnabled) {
+        cmd += ` \\
+  -e VHT_ENABLED=1`
+        if (this.vhtCapab) {
+          cmd += ` \\
+  -e VHT_CAPAB="${this.vhtCapab}"`
+        }
+      }
+      
+      if (this.heEnabled) {
+        cmd += ` \\
+  -e HE_ENABLED=1`
+        if (this.heCapab) {
+          cmd += ` \\
+  -e HE_CAPAB="${this.heCapab}"`
+        }
+      }
+      
+      cmd += ` \\
+  -v /dev/net/tun:/dev/net/tun \\
   sdelrio/rpi-hostap`
+      
+      return cmd
     }
   }
 }

--- a/docs-site/public/config-assistant.js
+++ b/docs-site/public/config-assistant.js
@@ -30,6 +30,11 @@ function configAssistant() {
     hwMode: 'g',
     countryCode: '',
     channel: '11',
+    wpaVersion: '2',
+    wpaPassphrase: 'passw0rd',
+    showPassphrase: false,
+    pmfAuto: true,
+    pmf: '0',
     get availableChannels() {
       const group = _countryGroup[this.countryCode]
       const list = this.hwMode === 'a' ? channels5G : channels2G
@@ -48,6 +53,8 @@ function configAssistant() {
       }
       this.$watch('hwMode', () => this._syncChannel())
       this.$watch('countryCode', () => this._syncChannel())
+      this.$watch('wpaVersion', () => { if (this.pmfAuto) this._derivePmf() })
+      this.$watch('pmfAuto', (on) => { if (on) this._derivePmf() })
     },
 
     _syncChannel() {
@@ -57,6 +64,11 @@ function configAssistant() {
       }
     },
 
+    _derivePmf() {
+      const map = { '2': '0', '3': '2', mixed: '1' }
+      this.pmf = map[this.wpaVersion] || '0'
+    },
+
     generateCommand() {
       const channelValue = this.channel === 'acs' ? 'acs' : this.channel
       return `docker run -d \
@@ -64,7 +76,9 @@ function configAssistant() {
   --net=host \
   --cap-add=NET_ADMIN \
   -e SSID=rpi-hostap \
-  -e WPA_PASSPHRASE=changeme \
+  -e WPA_PASSPHRASE=${this.wpaPassphrase} \
+  -e WPA_VERSION=${this.wpaVersion} \
+  -e PMF=${this.pmf} \
   -e CHANNEL=${channelValue} \
   -e HW_MODE=${this.hwMode} \
   -e COUNTRY_CODE=${this.countryCode} \

--- a/docs-site/src/content/docs/configuration-assistant.mdx
+++ b/docs-site/src/content/docs/configuration-assistant.mdx
@@ -122,6 +122,62 @@ Configure advanced 802.11n/ac/ax capabilities for higher throughput.
   VHT (802.11ac) and HE (802.11ax) require the 5GHz band. Select "802.11a/n/ac/ax (5GHz)" in Radio Settings to enable these options.
 </div>
 
+### Network Settings
+
+Configure the LAN subnet, access point address, DHCP pool, and DNS servers.
+
+<div class="config-section">
+  <label for="subnet">Subnet</label>
+  <input id="subnet" type="text" x-model="subnet" placeholder="192.168.254.0" />
+  <div class="help-text">Network address for the access point LAN (e.g. 192.168.254.0).</div>
+</div>
+
+<div class="config-section">
+  <label for="ap-addr">AP Address</label>
+  <input id="ap-addr" type="text" x-model="apAddr" placeholder="192.168.254.1" />
+  <div class="help-text">IP address assigned to the access point interface. Must be inside the subnet.</div>
+</div>
+
+<div class="config-section">
+  <label for="dhcp-range-auto">
+    <input id="dhcp-range-auto" type="checkbox" x-model="dhcpRangeAuto" />
+    Auto-compute DHCP range from subnet
+  </label>
+  <div x-show="!dhcpRangeAuto">
+    <label for="dhcp-range-start">DHCP Range Start</label>
+    <input id="dhcp-range-start" type="text" x-model="dhcpRangeStart" placeholder="192.168.254.100" />
+    <label for="dhcp-range-end">DHCP Range End</label>
+    <input id="dhcp-range-end" type="text" x-model="dhcpRangeEnd" placeholder="192.168.254.200" />
+  </div>
+  <div class="help-text" x-show="dhcpRangeAuto">
+    Range will be computed as <span x-text="subnetPrefix + '.100'"></span> to <span x-text="subnetPrefix + '.200'"></span>.
+  </div>
+</div>
+
+<div class="config-section">
+  <label for="dhcp-lease">DHCP Lease Time</label>
+  <input id="dhcp-lease" type="text" x-model="dhcpLease" placeholder="12h" />
+  <div class="help-text">Lease duration for DHCP clients (e.g. 12h, 24h, 30m).</div>
+</div>
+
+<div class="config-section">
+  <label for="pri-dns">Primary DNS</label>
+  <input id="pri-dns" type="text" x-model="priDns" placeholder="8.8.8.8" />
+</div>
+
+<div class="config-section">
+  <label for="sec-dns">Secondary DNS</label>
+  <input id="sec-dns" type="text" x-model="secDns" placeholder="8.8.4.4" />
+</div>
+
+<div class="config-section">
+  <label for="ipv6">
+    <input id="ipv6" type="checkbox" x-model="ipv6" />
+    Enable IPv6
+  </label>
+  <div class="help-text">Enables IPv6 NAT and routing when checked.</div>
+</div>
+
 ### Generated Command
 
 The generated `docker run` command will appear here once all form sections are implemented.

--- a/docs-site/src/content/docs/configuration-assistant.mdx
+++ b/docs-site/src/content/docs/configuration-assistant.mdx
@@ -57,19 +57,8 @@ Configure WPA authentication and passphrase.
 <div class="config-section">
   <label for="wpa-passphrase">Passphrase</label>
   <div class="passphrase-input">
-    <input
-      id="wpa-passphrase"
-      :type="showPassphrase ? 'text' : 'password'"
-      x-model="wpaPassphrase"
-      minlength="8"
-      required
-    />
-    <button
-      type="button"
-      class="passphrase-toggle"
-      @click="showPassphrase = !showPassphrase"
-      x-text="showPassphrase ? 'Hide' : 'Show'"
-    ></button>
+    <input id="wpa-passphrase" :type="showPassphrase ? 'text' : 'password'" x-model="wpaPassphrase" minlength="8" required />
+    <button type="button" class="passphrase-toggle" @click="showPassphrase = !showPassphrase" x-text="showPassphrase ? 'Hide' : 'Show'"></button>
   </div>
 </div>
 

--- a/docs-site/src/content/docs/configuration-assistant.mdx
+++ b/docs-site/src/content/docs/configuration-assistant.mdx
@@ -57,8 +57,8 @@ Configure WPA authentication and passphrase.
 <div class="config-section">
   <label for="wpa-passphrase">Passphrase</label>
   <div class="passphrase-input">
-    <input id="wpa-passphrase" :type="showPassphrase ? 'text' : 'password'" x-model="wpaPassphrase" minlength="8" required />
-    <button type="button" class="passphrase-toggle" @click="showPassphrase = !showPassphrase" x-text="showPassphrase ? 'Hide' : 'Show'"></button>
+    <input id="wpa-passphrase" x-bind:type="showPassphrase ? 'text' : 'password'" x-model="wpaPassphrase" minlength="8" required />
+    <button type="button" class="passphrase-toggle" x-on:click="showPassphrase = !showPassphrase" x-text="showPassphrase ? 'Hide' : 'Show'"></button>
   </div>
 </div>
 

--- a/docs-site/src/content/docs/configuration-assistant.mdx
+++ b/docs-site/src/content/docs/configuration-assistant.mdx
@@ -77,6 +77,51 @@ Configure WPA authentication and passphrase.
   </div>
 </div>
 
+### Radio Capabilities
+
+Configure advanced 802.11n/ac/ax capabilities for higher throughput.
+
+<div class="config-section">
+  <label for="ht-enabled">
+    <input id="ht-enabled" type="checkbox" x-model="htEnabled" />
+    Enable HT (802.11n)
+  </label>
+  <div x-show="htEnabled">
+    <label for="ht-capab">HT Capabilities</label>
+    <input id="ht-capab" type="text" x-model="htCapab" placeholder="[HT40+][SHORT-GI-20][SHORT-GI-40]" />
+  </div>
+</div>
+
+<template x-if="hwMode === 'a'">
+  <div>
+    <div class="config-section">
+      <label for="vht-enabled">
+        <input id="vht-enabled" type="checkbox" x-model="vhtEnabled" />
+        Enable VHT (802.11ac)
+      </label>
+      <div x-show="vhtEnabled">
+        <label for="vht-capab">VHT Capabilities</label>
+        <input id="vht-capab" type="text" x-model="vhtCapab" placeholder="[MAX-MPDU-3895][SHORT-GI-80]" />
+      </div>
+    </div>
+
+    <div class="config-section">
+      <label for="he-enabled">
+        <input id="he-enabled" type="checkbox" x-model="heEnabled" />
+        Enable HE (802.11ax)
+      </label>
+      <div x-show="heEnabled">
+        <label for="he-capab">HE Capabilities</label>
+        <input id="he-capab" type="text" x-model="heCapab" placeholder="[HE80:[0x11ff:0xf]]" />
+      </div>
+    </div>
+  </div>
+</template>
+
+<div class="help-text" x-show="hwMode !== 'a'">
+  VHT (802.11ac) and HE (802.11ax) require the 5GHz band. Select "802.11a/n/ac/ax (5GHz)" in Radio Settings to enable these options.
+</div>
+
 ### Generated Command
 
 The generated `docker run` command will appear here once all form sections are implemented.

--- a/docs-site/src/content/docs/configuration-assistant.mdx
+++ b/docs-site/src/content/docs/configuration-assistant.mdx
@@ -1,0 +1,97 @@
+---
+title: "Configuration Assistant"
+---
+
+<script defer src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.9/dist/cdn.min.js"></script>
+<script defer src="/rpi-hostap/config-assistant.js"></script>
+
+<div x-cloak x-data="configAssistant()">
+
+This interactive tool helps you compose the Docker environment variables needed to run rpi-hostap. Select your options below and the tool will generate the corresponding `docker run` command with all the correct flags.
+
+### Radio Settings
+
+Configure the basic wireless radio parameters.
+
+<div class="config-section">
+  <label for="hw-mode">Band</label>
+  <select id="hw-mode" x-model="hwMode">
+    <option value="b">802.11b (legacy, 2.4GHz only)</option>
+    <option value="g" selected>802.11g/n (2.4GHz, default)</option>
+    <option value="a">802.11a/n/ac/ax (5GHz)</option>
+  </select>
+</div>
+
+<div class="config-section">
+  <label for="country-code">Country</label>
+  <select id="country-code" x-model="countryCode">
+    <option value="">-- Select a country --</option>
+    <option value="US">United States</option>
+    <option value="CA">Canada</option>
+    <option value="MX">Mexico</option>
+    <option value="JP">Japan</option>
+    <option value="AU">Australia</option>
+  </select>
+</div>
+
+<div class="config-section">
+  <label for="channel">Channel</label>
+  <select id="channel" x-model="channel">
+    <option value="acs">Auto (ACS)</option>
+  </select>
+</div>
+
+### Security Settings
+
+Configure WPA authentication and passphrase.
+
+<div class="config-section">
+  <label for="wpa-version">WPA Version</label>
+  <select id="wpa-version" x-model="wpaVersion">
+    <option value="2">WPA2-PSK</option>
+    <option value="3">WPA3-SAE</option>
+    <option value="mixed">WPA2/WPA3 Transition Mode</option>
+  </select>
+</div>
+
+<div class="config-section">
+  <label for="wpa-passphrase">Passphrase</label>
+  <div class="passphrase-input">
+    <input
+      id="wpa-passphrase"
+      :type="showPassphrase ? 'text' : 'password'"
+      x-model="wpaPassphrase"
+      minlength="8"
+      required
+    />
+    <button
+      type="button"
+      class="passphrase-toggle"
+      @click="showPassphrase = !showPassphrase"
+      x-text="showPassphrase ? 'Hide' : 'Show'"
+    ></button>
+  </div>
+</div>
+
+<div class="config-section">
+  <label for="pmf-auto">
+    <input id="pmf-auto" type="checkbox" x-model="pmfAuto" />
+    Auto-derive PMF from WPA version
+  </label>
+  <div x-show="!pmfAuto">
+    <label for="pmf">Protected Management Frames (PMF)</label>
+    <select id="pmf" x-model="pmf">
+      <option value="0">Disabled (0)</option>
+      <option value="1">Optional (1)</option>
+      <option value="2">Required (2)</option>
+    </select>
+  </div>
+</div>
+
+### Generated Command
+
+The generated `docker run` command will appear here once all form sections are implemented.
+
+<pre><code x-text="generateCommand()"></code></pre>
+
+</div>


### PR DESCRIPTION
## Summary

Add a Network Settings section to the configuration assistant page, covering subnet/AP address, DHCP pool, DNS, and IPv6.

## Changes

**`docs-site/src/content/docs/configuration-assistant.mdx`** - new form section:
- Subnet input (default `192.168.254.0`)
- AP Address input (default `192.168.254.1`) with help text explaining it must be inside the subnet
- DHCP range auto-compute checkbox (default on) - computes `.100` to `.200` from subnet prefix
- Manual DHCP range start/end inputs shown when auto-compute is off
- DHCP lease time input (default `12h`)
- Primary DNS input (default `8.8.8.8`)
- Secondary DNS input (default `8.8.4.4`)
- IPv6 toggle checkbox (default off)

**`docs-site/public/config-assistant.js`** - Alpine.js data and logic:
- Added `subnet`, `apAddr`, `dhcpRangeAuto`, `dhcpRangeStart`, `dhcpRangeEnd`, `dhcpLease`, `priDns`, `secDns`, `ipv6` properties
- Added `subnetPrefix` getter for DHCP auto-compute
- Added `_syncDhcpRange()` method and watchers on `subnet`/`dhcpRangeAuto`
- Updated `generateCommand()` to emit SUBNET, AP_ADDR, PRI_DNS, SEC_DNS, DHCP_LEASE, DHCP_RANGE, and IPV6 env vars

## Defaults

All defaults match `lib/core/env.sh`:
| Variable | Default |
|----------|---------|
| SUBNET | 192.168.254.0 |
| AP_ADDR | 192.168.254.1 |
| PRI_DNS | 8.8.8.8 |
| SEC_DNS | 8.8.4.4 |
| DHCP_LEASE | 12h |
| DHCP_RANGE | auto: <subnet>.100,<subnet>.200,255.255.255.0,12h |

Closes #417
