### PR TITLE
fix(docs): correct script path for config-assistant

### DIFF
--- a/docs/configuration-assistant.mdx
+++ b/docs/configuration-assistant.mdx
@@ -2,8 +2,8 @@
 title: "Configuration Assistant"
 ---
 
-<script src="/config-assistant.js" defer></script>
-<script src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.9/dist/cdn.min.js" defer></script>
+<script src="/rpi-hostap/config-assistant.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.9/dist/cdn.min.js"></script>
 
 <div x-cloak x-data="configAssistant()">
 


### PR DESCRIPTION
## Summary

Fix the Configuration Assistant page where the Alpine.js component `configAssistant()` was not being found, causing all form variables to be undefined.

## Root Cause

1. **Script loading order**: Alpine.js was loading before `config-assistant.js`, so `configAssistant()` wasn't defined when Alpine initialized
2. **Base path issue**: The script src needed to include the Astro base path `/rpi-hostap/` to match the docs site configuration

## Fix

Updated `docs/configuration-assistant.mdx`:
- Load `config-assistant.js` before Alpine.js (correct order)
- Use full base path `/rpi-hostap/config-assistant.js`

## Changes

```diff
-<script src="/config-assistant.js" defer></script>
-<script src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.9/dist/cdn.min.js" defer></script>
+<script src="/rpi-hostap/config-assistant.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/alpinejs@3.14.9/dist/cdn.min.js"></script>
```

## Testing

- [ ] Visit `/rpi-hostap/configuration-assistant` in dev mode
- [ ] Verify no console errors about `configAssistant is not defined`
- [ ] Verify the "Generated Command" section displays the docker run command
- [ ] Test form interactions (country, band selection) work correctly

## Console Errors Before Fix

```
Uncaught ReferenceError: configAssistant is not defined
Uncaught ReferenceError: hwMode is not defined
Uncaught ReferenceError: countryCode is not defined
... (all other component variables)
```
