### PR TITLE
chore: add .opencode/plans/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /tmp/
 node_modules/
+.opencode/plans/
 
 # docs-site build artifacts
 docs-site/.astro/


### PR DESCRIPTION
Add .opencode/plans/ to .gitignore to exclude opencode planning files from git tracking.