### PR TITLE
fix(docs): remove duplicate heading in configuration-assistant.mdx

### DIFF
--- a/docs-site/src/content/docs/configuration-assistant.mdx
+++ b/docs-site/src/content/docs/configuration-assistant.mdx
@@ -244,12 +244,6 @@ Configure SSID, station limits, MAC filtering, and other advanced access point s
   <div class="help-text">hostapd driver override. Leave empty for the default nl80211 driver.</div>
 </div>
 
-### Generated Command
-
-The generated `docker run` command will appear here once all form sections are implemented.
-
-<pre><code x-text="generateCommand()"></code></pre>
-
 ### Generated Env File
 
 The generated environment file content for use with `--env-file` flag. Only non-default values are shown by default.


### PR DESCRIPTION
fix(docs): remove duplicate heading in configuration-assistant.mdx

The configuration assistant page had two headings with overlapping content:
- `### Generated Command` (placeholder with incomplete `generateCommand()`)
- `### Docker Run Command` (the actual working implementation with `dockerRunCommand`)

Removed the placeholder section since it was never fully implemented and `### Docker Run Command` is the correct one.
