### PR TITLE
fix(docs): guard against duplicate starlight-menu-button registration

### DIFF
--- a/docs-site/src/components/Header.astro
+++ b/docs-site/src/components/Header.astro
@@ -189,7 +189,9 @@ const navLinksJson = JSON.stringify(navLinks);
 		}
 	}
 
-	customElements.define("starlight-menu-button", StarlightMenuButton);
+	if (!customElements.get("starlight-menu-button")) {
+		customElements.define("starlight-menu-button", StarlightMenuButton);
+	}
 </script>
 
 <style>


### PR DESCRIPTION
## Problem

The console shows:
```
NotSupportedError: Failed to execute 'define' on 'CustomElementRegistry':
the name "starlight-menu-button" has already been used with this registry
```

This occurs because `customElements.define("starlight-menu-button", ...)` in `Header.astro` is called unconditionally. In development mode, scripts may be re-executed (HMR, page reload, etc.) causing the custom element to be registered a second time.

## Solution

Guard the registration with `customElements.get()` to check if the element is already defined before registering.

```javascript
if (!customElements.get("starlight-menu-button")) {
    customElements.define("starlight-menu-button", StarlightMenuButton);
}
```
