### PR TITLE
fix(docs): place config form labels and inputs on same line

### DIFF
--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -81,18 +81,31 @@
 }
 
 .config-section {
+  display: flex;
+  align-items: baseline;
+  flex-wrap: wrap;
+  gap: 0.75rem;
   margin-bottom: 1rem;
 }
 
 .config-section label {
-  display: block;
+  display: inline;
   font-weight: 600;
-  margin-bottom: 0.25rem;
+  margin-bottom: 0;
+  white-space: nowrap;
+}
+
+.config-section label:has(input) {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  white-space: normal;
 }
 
 .config-section select,
 .config-section input {
-  width: 100%;
+  flex: 1;
+  min-width: 10rem;
   max-width: 20rem;
   padding: 0.5rem;
   border-radius: var(--sl-border-radius-sm);
@@ -100,7 +113,7 @@
 }
 
 .passphrase-input {
-  display: flex;
+  display: inline-flex;
   gap: 0.5rem;
   max-width: 20rem;
 }


### PR DESCRIPTION
## Summary

In `configuration-assistant.mdx`, each config section had a label (e.g., "Band") and a form element stacked vertically. This PR places them on the same line using flexbox, so the label appears inline with the form field.

Checkbox labels (e.g., "Auto-derive PMF from WPA version") also use flexbox to align the checkbox and text inline.

## Changes

- `docs-site/src/styles/custom.css`:
  - `.config-section` now uses `display: flex` with `align-items: baseline` and `flex-wrap: wrap`, placing labels and inputs on the same line
  - Labels use `display: inline` and `white-space: nowrap` to stay on one line
  - Checkbox labels use `:has(input)` selector with `display: flex` to align checkbox and text
  - `select/input` changed from `width: 100%` to `flex: 1` with `min-width: 10rem`
  - `.passphrase-input` uses `display: inline-flex` for proper baseline alignment

## Before / After

| Before | After |
|--------|-------|
| Band | Band 802.11g/n (2.4GHz, default) [▼] |
| 802.11g/n (2.4GHz, default) [▼] | |
| Auto-derive PMF... | [x] Auto-derive PMF from WPA version |

Small screens still wrap gracefully since `flex-wrap: wrap` is set.