### PR TITLE
feat(docs): add CardGrid with Starlight components

### DIFF
--- a/docs-site/src/content/docs/home.mdx
+++ b/docs-site/src/content/docs/home.mdx
@@ -1,5 +1,6 @@
 ---
 title: "rpi-hostap"
+tableOfContents: false
 hero:
   title: "rpi-hostap"
   tagline: "Lightweight Docker container that turns a Raspberry Pi into a wireless Access Point with DHCP server. Built on Alpine Linux for minimal footprint."

--- a/docs-site/src/content/docs/home.mdx
+++ b/docs-site/src/content/docs/home.mdx
@@ -12,3 +12,15 @@ hero:
       variant: primary
 ---
 
+import { LinkCard, CardGrid } from '@astrojs/starlight/components';
+
+<CardGrid>
+  <LinkCard title="Configuration" icon="pencil" href="/rpi-hostap/configuration" description=" Environment variables, WiFi settings, WPA3/SAE, MAC filtering, and advanced hostapd options.">
+  </LinkCard>
+  <LinkCard title="Networking" icon="server" href="/rpi-hostap/networking" description="NAT/IP forwarding, IPv6 support, and outgoing interface configuration.">
+  </LinkCard>
+  <LinkCard title="Operations" icon="laptop" href="/rpi-hostap/operations" description="Client inspection, runtime management, and day-to-day operational tasks.">
+  </LinkCard>
+  <LinkCard title="Assistant" icon="rocket" href="/rpi-hostap/configuration-assistant" description="Interactive configuration assistant to guide you through setup. ">
+  </LinkCard>
+</CardGrid>

--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -259,3 +259,46 @@
     --sl-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.1);
   }
 }
+
+/* Custom CardGrid and LinkCard overrides */
+@layer starlight.core {
+
+  /* CardGrid overrides */
+  .card-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 1.5rem;
+    margin: 2rem 0;
+  }
+
+  @media (min-width: 50rem) {
+    .card-grid {
+      grid-template-columns: repeat(2, 1fr);
+    }
+  }
+
+  @media (min-width: 72rem) {
+    .card-grid {
+      grid-template-columns: repeat(3, 1fr);
+    }
+  }
+
+  /* LinkCard overrides */
+  .link-card {
+    display: block;
+    text-decoration: none;
+    color: inherit;
+    height: 100%;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: var(--sl-border-radius-md);
+    transition: box-shadow 0.2s ease, border-color 0.2s ease;
+  }
+
+  .link-card:hover,
+  .link-card:focus-visible {
+    box-shadow: var(--sl-shadow-lg);
+    border-color: var(--sl-color-text-accent);
+    outline: 2px solid var(--sl-color-text-accent);
+    outline-offset: 2px;
+  }
+}


### PR DESCRIPTION
Replaces custom card implementation with Starlight's LinkCard and CardGrid components on the documentation home page.

## Changes

- Adds four LinkCard entries linking to Configuration, Networking, Operations, and Assistant pages
- Includes icons (pencil, server, laptop, rocket) and descriptions for each section
- Adds CSS overrides in custom.css including:
  - Responsive grid layout (1/2/3 columns)
  - Border styling and border-radius
  - Box-shadow transitions on hover
  - Red accent outline on hover for visual feedback
  - `:focus-visible` support for keyboard accessibility
  - `outline-offset` for proper outline positioning

## Frontend Review Improvements Applied

- Removed dead code (unused `.card*` styles from old implementation)
- Added `:focus-visible` state for keyboard navigation
- Added `outline-offset: 2px` for proper outline rendering with rounded corners
