### PR TITLE
feat(docs-site): form validation & defaults

### DIFF
--- a/docs-site/public/config-assistant.js
+++ b/docs-site/public/config-assistant.js
@@ -1,3 +1,57 @@
+const ENV_DEFAULTS = {
+  SSID: 'raspberry',
+  WPA_PASSPHRASE: 'passw0rd',
+  WPA_VERSION: '2',
+  HW_MODE: 'g',
+  CHANNEL: 'acs',
+  COUNTRY_CODE: '',
+  SUBNET: '192.168.254.0',
+  AP_ADDR: '192.168.254.1',
+  PRI_DNS: '8.8.8.8',
+  SEC_DNS: '8.8.4.4',
+  DHCP_LEASE: '12h',
+  INTERFACE: 'wlan0',
+}
+
+const COMPONENT_DEFAULTS = {
+  hwMode: 'g',
+  countryCode: '',
+  channel: 'acs',
+  wpaVersion: '2',
+  wpaPassphrase: 'passw0rd',
+  showPassphrase: false,
+  pmfAuto: true,
+  pmf: '0',
+  subnet: '192.168.254.0',
+  apAddr: '192.168.254.1',
+  dhcpRangeAuto: true,
+  dhcpRangeStart: '192.168.254.100',
+  dhcpRangeEnd: '192.168.254.200',
+  dhcpLease: '12h',
+  priDns: '8.8.8.8',
+  secDns: '8.8.4.4',
+  ipv6: false,
+  ssid: 'raspberry',
+  hideSsid: false,
+  maxStations: '0',
+  apIsolation: false,
+  macFilter: '0',
+  macAclFile: '',
+  txPower: '',
+  interface: 'wlan0',
+  driver: '',
+  htEnabled: false,
+  htCapab: '',
+  vhtEnabled: false,
+  vhtCapab: '',
+  heEnabled: false,
+  heCapab: '',
+  showAllVars: false,
+  copied: false,
+  containerName: 'rpi-hostap',
+  copiedDocker: false,
+}
+
 const channels2G = {
   US: [1,2,3,4,5,6,7,8,9,10,11],
   CA: [1,2,3,4,5,6,7,8,9,10,11],
@@ -27,60 +81,10 @@ const _countryGroup = {
 
 function configAssistant() {
   return {
-    hwMode: 'g',
-    countryCode: '',
-    channel: '11',
-    wpaVersion: '2',
-    wpaPassphrase: 'passw0rd',
-    showPassphrase: false,
-    pmfAuto: true,
-    pmf: '0',
-    subnet: '192.168.254.0',
-    apAddr: '192.168.254.1',
-    dhcpRangeAuto: true,
-    dhcpRangeStart: '192.168.254.100',
-    dhcpRangeEnd: '192.168.254.200',
-    dhcpLease: '12h',
-    priDns: '8.8.8.8',
-    secDns: '8.8.4.4',
-    ipv6: false,
-    ssid: 'raspberry',
-    hideSsid: false,
-    maxStations: '0',
-    apIsolation: false,
-    macFilter: '0',
-    macAclFile: '',
-    txPower: '',
-    interface: 'wlan0',
-    driver: '',
-    htEnabled: false,
-    htCapab: '',
-    vhtEnabled: false,
-    vhtCapab: '',
-    heEnabled: false,
-    heCapab: '',
-    showAllVars: false,
-    copied: false,
-    containerName: 'rpi-hostap',
-    copiedDocker: false,
+    ...COMPONENT_DEFAULTS,
 
-    get envFileOutput() {
-      const defaults = {
-        SSID: 'raspberry',
-        WPA_PASSPHRASE: 'passw0rd',
-        WPA_VERSION: '2',
-        HW_MODE: 'g',
-        CHANNEL: 'acs',
-        COUNTRY_CODE: '',
-        SUBNET: '192.168.254.0',
-        AP_ADDR: '192.168.254.1',
-        PRI_DNS: '8.8.8.8',
-        SEC_DNS: '8.8.4.4',
-        DHCP_LEASE: '12h',
-        INTERFACE: 'wlan0',
-      }
-
-      const allVars = {
+    _buildAllVars() {
+      const v = {
         SSID: this.ssid,
         WPA_PASSPHRASE: this.wpaPassphrase,
         WPA_VERSION: this.wpaVersion,
@@ -96,32 +100,38 @@ function configAssistant() {
         INTERFACE: this.interface,
       }
 
-      if (this.hideSsid) allVars.HIDE_SSID = '1'
-      if (this.apIsolation) allVars.AP_ISOLATION = '1'
-      if (this.maxStations && this.maxStations !== '0') allVars.MAX_STATIONS = this.maxStations
+      if (this.hideSsid) v.HIDE_SSID = '1'
+      if (this.apIsolation) v.AP_ISOLATION = '1'
+      if (this.maxStations && this.maxStations !== '0') v.MAX_STATIONS = this.maxStations
       if (this.macFilter !== '0') {
-        allVars.MAC_FILTER = this.macFilter
-        allVars.MAC_ACL_FILE = this.macAclFile
+        v.MAC_FILTER = this.macFilter
+        v.MAC_ACL_FILE = this.macAclFile
       }
-      if (this.txPower) allVars.TX_POWER = this.txPower
-      if (this.driver) allVars.DRIVER = this.driver
+      if (this.txPower) v.TX_POWER = this.txPower
+      if (this.driver) v.DRIVER = this.driver
       if (this.htEnabled) {
-        allVars.HT_ENABLED = '1'
-        if (this.htCapab) allVars.HT_CAPAB = this.htCapab
+        v.HT_ENABLED = '1'
+        if (this.htCapab) v.HT_CAPAB = this.htCapab
       }
       if (this.vhtEnabled) {
-        allVars.VHT_ENABLED = '1'
-        if (this.vhtCapab) allVars.VHT_CAPAB = this.vhtCapab
+        v.VHT_ENABLED = '1'
+        if (this.vhtCapab) v.VHT_CAPAB = this.vhtCapab
       }
       if (this.heEnabled) {
-        allVars.HE_ENABLED = '1'
-        if (this.heCapab) allVars.HE_CAPAB = this.heCapab
+        v.HE_ENABLED = '1'
+        if (this.heCapab) v.HE_CAPAB = this.heCapab
       }
-      if (this.ipv6) allVars.IPV6 = '1'
+      if (this.ipv6) v.IPV6 = '1'
+
+      return v
+    },
+
+    get envFileOutput() {
+      const allVars = this._buildAllVars()
 
       const vars = this.showAllVars
         ? Object.entries(allVars)
-        : Object.entries(allVars).filter(([k, v]) => defaults[k] !== v)
+        : Object.entries(allVars).filter(([k, v]) => ENV_DEFAULTS[k] !== v)
 
       if (vars.length === 0 && !this.showAllVars) return '# No non-default values'
 
@@ -187,65 +197,13 @@ function configAssistant() {
     },
 
     get dockerRunCommand() {
-      const defaults = {
-        SSID: 'raspberry',
-        WPA_PASSPHRASE: 'passw0rd',
-        WPA_VERSION: '2',
-        HW_MODE: 'g',
-        CHANNEL: 'acs',
-        COUNTRY_CODE: '',
-        SUBNET: '192.168.254.0',
-        AP_ADDR: '192.168.254.1',
-        PRI_DNS: '8.8.8.8',
-        SEC_DNS: '8.8.4.4',
-        DHCP_LEASE: '12h',
-        INTERFACE: 'wlan0',
-      }
+      const allVars = this._buildAllVars()
 
-      const allVars = {
-        SSID: this.ssid,
-        WPA_PASSPHRASE: this.wpaPassphrase,
-        WPA_VERSION: this.wpaVersion,
-        PMF: this.pmf,
-        HW_MODE: this.hwMode,
-        CHANNEL: this.channel === 'acs' ? 'acs' : this.channel,
-        COUNTRY_CODE: this.countryCode,
-        SUBNET: this.subnet,
-        AP_ADDR: this.apAddr,
-        PRI_DNS: this.priDns,
-        SEC_DNS: this.secDns,
-        DHCP_LEASE: this.dhcpLease,
-        INTERFACE: this.interface,
-      }
+      const nonDefault = Object.entries(allVars).filter(([k, v]) => ENV_DEFAULTS[k] !== v)
 
-      if (this.hideSsid) allVars.HIDE_SSID = '1'
-      if (this.apIsolation) allVars.AP_ISOLATION = '1'
-      if (this.maxStations && this.maxStations !== '0') allVars.MAX_STATIONS = this.maxStations
-      if (this.macFilter !== '0') {
-        allVars.MAC_FILTER = this.macFilter
-        allVars.MAC_ACL_FILE = this.macAclFile
-      }
-      if (this.txPower) allVars.TX_POWER = this.txPower
-      if (this.driver) allVars.DRIVER = this.driver
-      if (this.htEnabled) {
-        allVars.HT_ENABLED = '1'
-        if (this.htCapab) allVars.HT_CAPAB = this.htCapab
-      }
-      if (this.vhtEnabled) {
-        allVars.VHT_ENABLED = '1'
-        if (this.vhtCapab) allVars.VHT_CAPAB = this.vhtCapab
-      }
-      if (this.heEnabled) {
-        allVars.HE_ENABLED = '1'
-        if (this.heCapab) allVars.HE_CAPAB = this.heCapab
-      }
-      if (this.ipv6) allVars.IPV6 = '1'
+      const envFlags = nonDefault.map(([k, v]) => `-e ${k}="${v}"`).join(' \\\n  ')
 
-      const nonDefault = Object.entries(allVars).filter(([k, v]) => defaults[k] !== v)
-
-      const envFlags = nonDefault.map(([k, v]) => `-e ${k}=${v}`).join(' \\\n  ')
-
-      let cmd = `docker run -d \\\n  --privileged \\\n  --net host \\\n  --name ${this.containerName} \\`
+      let cmd = `docker run -d \\\n  --privileged \\\n  --net host \\\n  --name "${this.containerName}" \\`
 
       if (envFlags) {
         cmd += `\n  ${envFlags} \\`
@@ -277,6 +235,79 @@ function configAssistant() {
 
     toggleShowAll() {
       this.showAllVars = !this.showAllVars
+    },
+
+    validateSsid() {
+      if (this.ssid.length < 1 || this.ssid.length > 32) return 'SSID must be 1-32 characters'
+      if (/[#=]/.test(this.ssid)) return 'SSID cannot contain # or ='
+      if (/^\s|\s$/.test(this.ssid)) return 'SSID cannot have leading/trailing whitespace'
+      if (/\n/.test(this.ssid)) return 'SSID cannot contain newlines'
+      return null
+    },
+
+    validatePassphrase() {
+      if (this.wpaPassphrase.length < 8) return 'Passphrase must be at least 8 characters'
+      if (this.wpaPassphrase.length > 63) return 'Passphrase must be 63 characters or fewer'
+      if (/[\x00-\x1f\x7f]/.test(this.wpaPassphrase)) return 'Passphrase cannot contain control characters'
+      return null
+    },
+
+    validateSubnet() {
+      const ipPattern = /^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/
+      const match = this.subnet.match(ipPattern)
+      if (!match) return 'Subnet must be a valid IPv4 address (e.g. 192.168.254.0)'
+      const octets = match.slice(1).map(Number)
+      if (octets.some(o => o < 0 || o > 255)) return 'Subnet octets must be 0-255'
+      return null
+    },
+
+    validateChannel() {
+      if (this.channel === 'acs') return null
+      if (this.countryCode && !this.availableChannels.includes(parseInt(this.channel, 10))) {
+        return `Channel ${this.channel} is not available for ${this.countryCode}`
+      }
+      return null
+    },
+
+    validateMaxStations() {
+      const val = parseInt(this.maxStations, 10)
+      if (isNaN(val) || val < 0) return 'Max stations must be a non-negative integer'
+      return null
+    },
+
+    validateTxPower() {
+      if (!this.txPower) return null
+      if (this.txPower.toLowerCase() === 'auto') return null
+      const val = parseInt(this.txPower, 10)
+      if (isNaN(val) || val <= 0) return 'TX power must be a positive integer or "auto"'
+      return null
+    },
+
+    get validationErrors() {
+      const errors = {}
+      const ssidErr = this.validateSsid()
+      if (ssidErr) errors.ssid = ssidErr
+      const passErr = this.validatePassphrase()
+      if (passErr) errors.passphrase = passErr
+      const subnetErr = this.validateSubnet()
+      if (subnetErr) errors.subnet = subnetErr
+      const channelErr = this.validateChannel()
+      if (channelErr) errors.channel = channelErr
+      const maxErr = this.validateMaxStations()
+      if (maxErr) errors.maxStations = maxErr
+      const txErr = this.validateTxPower()
+      if (txErr) errors.txPower = txErr
+      return errors
+    },
+
+    get isValid() {
+      return Object.keys(this.validationErrors).length === 0
+    },
+
+    resetToDefaults() {
+      if (!confirm('Reset all settings to defaults?')) return
+      Object.assign(this, COMPONENT_DEFAULTS)
+      this._syncChannel()
     }
   }
 }

--- a/docs-site/src/content/docs/configuration-assistant.mdx
+++ b/docs-site/src/content/docs/configuration-assistant.mdx
@@ -9,6 +9,10 @@ title: "Configuration Assistant"
 
 This interactive tool helps you compose the Docker environment variables needed to run rpi-hostap. Select your options below and the tool will generate the corresponding `docker run` command with all the correct flags.
 
+<div style="margin-bottom: 1.5rem;">
+  <button type="button" class="btn btn-reset" x-on:click="resetToDefaults()">Reset to Defaults</button>
+</div>
+
 ### Radio Settings
 
 Configure the basic wireless radio parameters.
@@ -36,10 +40,11 @@ Configure the basic wireless radio parameters.
 
 <div class="config-section">
   <label for="channel">Channel</label>
-  <select id="channel" x-model="channel">
+  <select id="channel" x-model="channel" x-bind:class="{ 'invalid': validationErrors.channel }">
     <option value="acs">Auto (ACS)</option>
   </select>
 </div>
+<div class="validation-error" x-show="validationErrors.channel" x-text="validationErrors.channel"></div>
 
 ### Security Settings
 
@@ -57,10 +62,11 @@ Configure WPA authentication and passphrase.
 <div class="config-section">
   <label for="wpa-passphrase">Passphrase</label>
   <div class="passphrase-input">
-    <input id="wpa-passphrase" x-bind:type="showPassphrase ? 'text' : 'password'" x-model="wpaPassphrase" minlength="8" required />
+    <input id="wpa-passphrase" x-bind:type="showPassphrase ? 'text' : 'password'" x-model="wpaPassphrase" minlength="8" required x-bind:class="{ 'invalid': validationErrors.passphrase }" />
     <button type="button" class="passphrase-toggle" x-on:click="showPassphrase = !showPassphrase" x-text="showPassphrase ? 'Hide' : 'Show'"></button>
   </div>
 </div>
+<div class="validation-error" x-show="validationErrors.passphrase" x-text="validationErrors.passphrase"></div>
 
 <div class="config-section">
   <label for="pmf-auto">
@@ -128,9 +134,10 @@ Configure the LAN subnet, access point address, DHCP pool, and DNS servers.
 
 <div class="config-section">
   <label for="subnet">Subnet</label>
-  <input id="subnet" type="text" x-model="subnet" placeholder="192.168.254.0" />
+  <input id="subnet" type="text" x-model="subnet" placeholder="192.168.254.0" x-bind:class="{ 'invalid': validationErrors.subnet }" />
   <div class="help-text">Network address for the access point LAN (e.g. 192.168.254.0).</div>
 </div>
+<div class="validation-error" x-show="validationErrors.subnet" x-text="validationErrors.subnet"></div>
 
 <div class="config-section">
   <label for="ap-addr">AP Address</label>
@@ -184,9 +191,10 @@ Configure SSID, station limits, MAC filtering, and other advanced access point s
 
 <div class="config-section">
   <label for="ssid">SSID</label>
-  <input id="ssid" type="text" x-model="ssid" placeholder="raspberry" />
+  <input id="ssid" type="text" x-model="ssid" placeholder="raspberry" x-bind:class="{ 'invalid': validationErrors.ssid }" />
   <div class="help-text">Network name broadcast by the access point.</div>
 </div>
+<div class="validation-error" x-show="validationErrors.ssid" x-text="validationErrors.ssid"></div>
 
 <div class="config-section">
   <label for="hide-ssid">
@@ -198,9 +206,10 @@ Configure SSID, station limits, MAC filtering, and other advanced access point s
 
 <div class="config-section">
   <label for="max-stations">Max Stations</label>
-  <input id="max-stations" type="number" x-model="maxStations" min="0" placeholder="0" />
+  <input id="max-stations" type="number" x-model="maxStations" min="0" placeholder="0" x-bind:class="{ 'invalid': validationErrors.maxStations }" />
   <div class="help-text">Maximum number of associated stations. Set to 0 for unlimited (hostapd default).</div>
 </div>
+<div class="validation-error" x-show="validationErrors.maxStations" x-text="validationErrors.maxStations"></div>
 
 <div class="config-section">
   <label for="ap-isolation">
@@ -228,9 +237,10 @@ Configure SSID, station limits, MAC filtering, and other advanced access point s
 
 <div class="config-section">
   <label for="tx-power">TX Power</label>
-  <input id="tx-power" type="text" x-model="txPower" placeholder="auto" />
+  <input id="tx-power" type="text" x-model="txPower" placeholder="auto" x-bind:class="{ 'invalid': validationErrors.txPower }" />
   <div class="help-text">Transmit power in dBm or "auto" to use the driver default. Leave empty to skip setting.</div>
 </div>
+<div class="validation-error" x-show="validationErrors.txPower" x-text="validationErrors.txPower"></div>
 
 <div class="config-section">
   <label for="interface">Interface</label>

--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -164,6 +164,41 @@
   overflow-x: auto;
 }
 
+.config-section input.invalid,
+.config-section select.invalid {
+  border-color: hsl(0, 60%, 50%);
+  box-shadow: 0 0 0 1px hsl(0, 60%, 50%);
+}
+
+.config-section input.invalid:focus,
+.config-section select.invalid:focus {
+  border-color: hsl(0, 60%, 50%);
+  box-shadow: 0 0 0 2px hsl(0, 60%, 50%);
+  outline: none;
+}
+
+[data-theme='dark'] .config-section input.invalid,
+[data-theme='dark'] .config-section select.invalid {
+  border-color: hsl(0, 60%, 60%);
+  box-shadow: 0 0 0 1px hsl(0, 60%, 60%);
+}
+
+[data-theme='dark'] .config-section input.invalid:focus,
+[data-theme='dark'] .config-section select.invalid:focus {
+  border-color: hsl(0, 60%, 60%);
+  box-shadow: 0 0 0 2px hsl(0, 60%, 60%);
+}
+
+.validation-error {
+  color: hsl(0, 60%, 45%);
+  font-size: 0.8rem;
+  margin-top: 0.25rem;
+}
+
+[data-theme='dark'] .validation-error {
+  color: hsl(0, 60%, 65%);
+}
+
 @layer starlight.core {
   .hero {
     background: var(--sl-color-bg, hsl(0 0% 100%));
@@ -257,6 +292,30 @@
     --sl-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.06);
     --sl-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.08);
     --sl-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.1);
+  }
+
+  .btn-reset {
+    background: var(--sl-color-gray-6);
+    border: 1px solid var(--sl-color-border);
+  }
+
+  .btn-reset:hover {
+    background: var(--sl-color-gray-5);
+  }
+
+  .btn-primary {
+    background: var(--sl-color-accent);
+    color: var(--sl-color-white);
+    border: none;
+  }
+
+  .btn-primary:hover {
+    opacity: 0.9;
+  }
+
+  .btn-primary:disabled {
+    opacity: 0.5;
+    cursor: not-allowed;
   }
 }
 


### PR DESCRIPTION
## Problem

Form inputs need validation to prevent invalid configurations. Users also need a way to reset to defaults.

## Solution

Add form validation and a reset button to the configuration assistant.

### Validation rules implemented
- **SSID**: 1-32 characters, no `#`, `=`, newlines, no leading/trailing whitespace
- **Passphrase**: 8-63 characters, no control characters
- **Subnet**: valid IPv4 format
- **Channel**: validates against allowed list for current band/country
- **Max Stations**: non-negative integer
- **TX Power**: positive integer or "auto" or empty

### Validation UI
- Inline error messages below invalid fields
- Red border on invalid inputs
- Real-time validation updates as user types

### Reset button
- "Reset to Defaults" button at top of form
- Resets all form fields to `lib/core/env.sh` defaults
- Confirmation dialog before reset

### Files changed
- `docs-site/public/config-assistant.js` - added validation methods and resetToDefaults()
- `docs-site/src/content/docs/configuration-assistant.mdx` - added validation error displays and reset button
- `docs-site/src/styles/custom.css` - added validation error CSS styles

## Acceptance criteria

- [x] SSID validation shows error for invalid input
- [x] Passphrase validation shows error for <8 chars
- [x] Invalid fields highlighted with red border
- [x] "Reset to Defaults" button resets all fields
- [x] Reset requires confirmation
- [x] Validation updates in real-time
