### PR TITLE
style(docs-site): theme & responsive layout

### DIFF
--- a/docs-site/src/content/docs/configuration-assistant.mdx
+++ b/docs-site/src/content/docs/configuration-assistant.mdx
@@ -43,6 +43,9 @@ For detailed parameter documentation, see [Configuration](/rpi-hostap/configurat
   <button type="button" class="btn btn-reset" x-on:click="resetToDefaults()">Reset to Defaults</button>
 </div>
 
+<div class="config-assistant-layout">
+<div class="config-form-panel">
+
 ### Radio Settings
 
 Configure the basic wireless radio parameters.
@@ -74,7 +77,7 @@ Configure the basic wireless radio parameters.
     <option value="acs">Auto (ACS)</option>
   </select>
 </div>
-<div class="validation-error" x-show="validationErrors.channel" x-text="validationErrors.channel"></div>
+<div class="validation-error" role="alert" x-show="validationErrors.channel" x-text="validationErrors.channel"></div>
 
 ### Security Settings
 
@@ -93,10 +96,10 @@ Configure WPA authentication and passphrase.
   <label for="wpa-passphrase">Passphrase</label>
   <div class="passphrase-input">
     <input id="wpa-passphrase" x-bind:type="showPassphrase ? 'text' : 'password'" x-model="wpaPassphrase" minlength="8" required x-bind:class="{ 'invalid': validationErrors.passphrase }" />
-    <button type="button" class="passphrase-toggle" x-on:click="showPassphrase = !showPassphrase" x-text="showPassphrase ? 'Hide' : 'Show'"></button>
+    <button type="button" class="passphrase-toggle" x-on:click="showPassphrase = !showPassphrase" x-bind:aria-pressed="showPassphrase" aria-label="Toggle passphrase visibility" x-text="showPassphrase ? 'Hide' : 'Show'"></button>
   </div>
 </div>
-<div class="validation-error" x-show="validationErrors.passphrase" x-text="validationErrors.passphrase"></div>
+<div class="validation-error" role="alert" x-show="validationErrors.passphrase" x-text="validationErrors.passphrase"></div>
 
 <div class="config-section">
   <label for="pmf-auto">
@@ -167,7 +170,7 @@ Configure the LAN subnet, access point address, DHCP pool, and DNS servers.
   <input id="subnet" type="text" x-model="subnet" placeholder="192.168.254.0" x-bind:class="{ 'invalid': validationErrors.subnet }" />
   <div class="help-text">Network address for the access point LAN (e.g. 192.168.254.0).</div>
 </div>
-<div class="validation-error" x-show="validationErrors.subnet" x-text="validationErrors.subnet"></div>
+<div class="validation-error" role="alert" x-show="validationErrors.subnet" x-text="validationErrors.subnet"></div>
 
 <div class="config-section">
   <label for="ap-addr">AP Address</label>
@@ -224,7 +227,7 @@ Configure SSID, station limits, MAC filtering, and other advanced access point s
   <input id="ssid" type="text" x-model="ssid" placeholder="raspberry" x-bind:class="{ 'invalid': validationErrors.ssid }" />
   <div class="help-text">Network name broadcast by the access point.</div>
 </div>
-<div class="validation-error" x-show="validationErrors.ssid" x-text="validationErrors.ssid"></div>
+<div class="validation-error" role="alert" x-show="validationErrors.ssid" x-text="validationErrors.ssid"></div>
 
 <div class="config-section">
   <label for="hide-ssid">
@@ -239,7 +242,7 @@ Configure SSID, station limits, MAC filtering, and other advanced access point s
   <input id="max-stations" type="number" x-model="maxStations" min="0" placeholder="0" x-bind:class="{ 'invalid': validationErrors.maxStations }" />
   <div class="help-text">Maximum number of associated stations. Set to 0 for unlimited (hostapd default).</div>
 </div>
-<div class="validation-error" x-show="validationErrors.maxStations" x-text="validationErrors.maxStations"></div>
+<div class="validation-error" role="alert" x-show="validationErrors.maxStations" x-text="validationErrors.maxStations"></div>
 
 <div class="config-section">
   <label for="ap-isolation">
@@ -270,7 +273,7 @@ Configure SSID, station limits, MAC filtering, and other advanced access point s
   <input id="tx-power" type="text" x-model="txPower" placeholder="auto" x-bind:class="{ 'invalid': validationErrors.txPower }" />
   <div class="help-text">Transmit power in dBm or "auto" to use the driver default. Leave empty to skip setting.</div>
 </div>
-<div class="validation-error" x-show="validationErrors.txPower" x-text="validationErrors.txPower"></div>
+<div class="validation-error" role="alert" x-show="validationErrors.txPower" x-text="validationErrors.txPower"></div>
 
 <div class="config-section">
   <label for="interface">Interface</label>
@@ -284,9 +287,12 @@ Configure SSID, station limits, MAC filtering, and other advanced access point s
   <div class="help-text">hostapd driver override. Leave empty for the default nl80211 driver.</div>
 </div>
 
+</div>
+<div class="config-output-panel">
+
 ### Generated Env File
 
-The generated environment file content for use with `--env-file` flag. Only non-default values are shown by default.
+Environment file content for use with `--env-file`. Only non-default values are shown.
 
 <div class="config-section">
   <div class="env-file-header">
@@ -317,6 +323,9 @@ The complete `docker run` command with all required flags and non-default enviro
     </button>
   </div>
   <textarea class="env-file-output" readonly x-text="dockerRunCommand" rows="8" style="font-family: monospace;"></textarea>
+</div>
+
+</div>
 </div>
 
 </div>

--- a/docs-site/src/styles/custom.css
+++ b/docs-site/src/styles/custom.css
@@ -83,123 +83,152 @@
   font-size: 0.875em;
 }
 
-.config-section {
-  display: flex;
-  align-items: baseline;
-  flex-wrap: wrap;
-  gap: 0.75rem;
-  margin-bottom: 1rem;
+:root, [data-theme='light'] {
+  --sl-color-error: hsl(0, 60%, 50%);
+  --sl-color-error-text: hsl(0, 60%, 45%);
 }
 
-.config-section label {
-  display: inline;
-  font-weight: 600;
-  margin-bottom: 0;
-  white-space: nowrap;
-}
-
-.config-section label:has(input) {
-  display: flex;
-  align-items: center;
-  gap: 0.45rem;
-  white-space: normal;
-}
-
-.config-section select,
-.config-section input {
-  flex: 1;
-  min-width: 2.5em;
-  max-width: 12em;
-  padding: 0.25rem;
-  border-radius: var(--sl-border-radius-sm);
-  border: 1px solid var(--sl-color-border);
-}
-
-.passphrase-input {
-  display: inline-flex;
-  gap: 0.5rem;
-  max-width: 20rem;
-}
-
-.passphrase-input input {
-  flex: 1;
-}
-
-.passphrase-toggle {
-  padding: 0.5rem 1rem;
-  cursor: pointer;
-}
-
-.btn {
-  padding: 0.5rem 1rem;
-  border-radius: var(--sl-border-radius-sm);
-  border: 1px solid var(--sl-color-border);
-  background: var(--sl-color-bg);
-  cursor: pointer;
-  font-weight: 500;
-}
-
-.btn:hover {
-  background: var(--sl-color-gray-6);
-}
-
-.env-file-header {
-  display: flex;
-  gap: 0.5rem;
-  margin-bottom: 0.5rem;
-}
-
-.env-file-output {
-  width: 100%;
-  min-height: 10rem;
-  padding: 1rem;
-  border-radius: var(--sl-border-radius-md);
-  border: 1px solid var(--sl-color-border);
-  background: var(--sl-color-gray-7);
-  font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', 'Courier New', monospace;
-  font-size: 0.875rem;
-  line-height: 1.5;
-  resize: vertical;
-  white-space: pre;
-  overflow-x: auto;
-}
-
-.config-section input.invalid,
-.config-section select.invalid {
-  border-color: hsl(0, 60%, 50%);
-  box-shadow: 0 0 0 1px hsl(0, 60%, 50%);
-}
-
-.config-section input.invalid:focus,
-.config-section select.invalid:focus {
-  border-color: hsl(0, 60%, 50%);
-  box-shadow: 0 0 0 2px hsl(0, 60%, 50%);
-  outline: none;
-}
-
-[data-theme='dark'] .config-section input.invalid,
-[data-theme='dark'] .config-section select.invalid {
-  border-color: hsl(0, 60%, 60%);
-  box-shadow: 0 0 0 1px hsl(0, 60%, 60%);
-}
-
-[data-theme='dark'] .config-section input.invalid:focus,
-[data-theme='dark'] .config-section select.invalid:focus {
-  border-color: hsl(0, 60%, 60%);
-  box-shadow: 0 0 0 2px hsl(0, 60%, 60%);
-}
-
-.validation-error {
-  color: hsl(0, 60%, 45%);
-  font-size: 0.8rem;
-  margin-top: 0.25rem;
-}
-
-[data-theme='dark'] .validation-error {
-  color: hsl(0, 60%, 65%);
+[data-theme='dark'] {
+  --sl-color-error: hsl(0, 60%, 60%);
+  --sl-color-error-text: hsl(0, 60%, 65%);
 }
 
 @layer starlight.core {
+  /* Configuration Assistant Layout */
+  .config-assistant-layout {
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 2rem;
+    margin-top: 1.5rem;
+  }
+
+  @media (min-width: 64rem) {
+    .config-assistant-layout {
+      grid-template-columns: 1fr 1fr;
+    }
+  }
+
+  .config-form-panel,
+  .config-output-panel {
+    min-width: 0;
+  }
+
+  .config-section {
+    display: flex;
+    align-items: baseline;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+  }
+
+  .config-section label {
+    display: inline;
+    font-weight: 600;
+    margin-bottom: 0;
+    white-space: nowrap;
+  }
+
+  .config-section label:has(input) {
+    display: flex;
+    align-items: center;
+    gap: 0.45rem;
+    white-space: normal;
+  }
+
+  .config-section select,
+  .config-section input {
+    flex: 1;
+    min-width: 2.5em;
+    max-width: 12em;
+    padding: 0.25rem;
+    border-radius: var(--sl-border-radius-sm);
+    border: 1px solid var(--sl-color-border);
+  }
+
+  .config-section select:focus,
+  .config-section input:focus {
+    outline: 2px solid var(--sl-color-accent);
+    outline-offset: 1px;
+  }
+
+  .passphrase-input {
+    display: inline-flex;
+    gap: 0.5rem;
+    max-width: 20rem;
+  }
+
+  .passphrase-input input {
+    flex: 1;
+  }
+
+  .passphrase-toggle {
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+  }
+
+  .passphrase-toggle:focus-visible {
+    outline: 2px solid var(--sl-color-accent);
+    outline-offset: 1px;
+  }
+
+  .btn {
+    padding: 0.5rem 1rem;
+    border-radius: var(--sl-border-radius-sm);
+    border: 1px solid var(--sl-color-border);
+    background: var(--sl-color-bg);
+    cursor: pointer;
+    font-weight: 500;
+  }
+
+  .btn:hover {
+    background: var(--sl-color-gray-6);
+  }
+
+  .btn:focus-visible {
+    outline: 2px solid var(--sl-color-accent);
+    outline-offset: 1px;
+  }
+
+  .env-file-header {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 0.5rem;
+  }
+
+  .env-file-output {
+    width: 100%;
+    min-height: 10rem;
+    padding: 1rem;
+    border-radius: var(--sl-border-radius-md);
+    border: 1px solid var(--sl-color-border);
+    background: var(--sl-color-gray-7);
+    font-family: 'SF Mono', 'Fira Code', 'Fira Mono', 'Roboto Mono', 'Courier New', monospace;
+    font-size: 0.875rem;
+    line-height: 1.5;
+    resize: vertical;
+    white-space: pre;
+    overflow-x: auto;
+  }
+
+  .config-section input.invalid,
+  .config-section select.invalid {
+    border-color: var(--sl-color-error);
+    box-shadow: 0 0 0 1px var(--sl-color-error);
+  }
+
+  .config-section input.invalid:focus,
+  .config-section select.invalid:focus {
+    border-color: var(--sl-color-error);
+    box-shadow: 0 0 0 2px var(--sl-color-error);
+    outline: none;
+  }
+
+  .validation-error {
+    color: var(--sl-color-error-text);
+    font-size: 0.8rem;
+    margin-top: 0.25rem;
+  }
   .hero {
     background: var(--sl-color-bg, hsl(0 0% 100%));
     text-align: center;


### PR DESCRIPTION
## Problem

The form needs to match the docs-site's visual theme and work well on mobile devices.

## Solution

Add theme integration and responsive layout to the configuration assistant.

### Changes
- Two-column layout on desktop (form left, output right) using CSS Grid
- Single column on mobile (form above, output below)
- Moved all config assistant styles into `@layer starlight.core` for proper cascade
- Added `flex-wrap` to env-file-header for 320px support
- Added CSS variables for error/validation colors
- Added focus-visible outlines for accessibility
- Added `role="alert"` to validation error messages
- Added `aria-pressed` and `aria-label` to passphrase toggle button

### Files changed
- `docs-site/src/styles/custom.css` - added responsive layout and improved styles
- `docs-site/src/content/docs/configuration-assistant.mdx` - applied layout classes and accessibility

## Acceptance criteria

- [x] Form uses docs-site CSS variables for colors
- [x] Two-column layout on desktop, single on mobile
- [x] Form inputs are consistently styled
- [x] Copy buttons have visual feedback
- [x] Dark mode works correctly
- [x] Responsive down to 320px width
